### PR TITLE
On hold: WIP: Ensure that previous messages are sent fully before new send

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -417,6 +417,9 @@
     "resend": {
       "message": "Resend"
     },
+    "send": {
+      "message": "Send"
+    },
     "messageDetail": {
         "message": "Message Detail"
     },

--- a/background.html
+++ b/background.html
@@ -261,6 +261,9 @@
   <script type='text/x-tmpl-mustache' id='some-failed'>
     {{ someFailed }}
   </script>
+  <script type='text/x-tmpl-mustache' id='send'>
+    {{ send }}
+  </script>
   <script type='text/x-tmpl-mustache' id='keychange'>
       <span class='content' dir='auto'><span class='shield icon'></span> {{ content }}</span>
   </script>

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -39830,6 +39830,8 @@ MessageSender.prototype = {
                 delete this.pendingMessages[number];
             }
         }.bind(this));
+
+        return runCurrent;
     },
 
     uploadMedia: function(message) {
@@ -39875,9 +39877,7 @@ MessageSender.prototype = {
         var outgoing = new OutgoingMessage(this.server, timestamp, numbers, message, silent, callback);
 
         numbers.forEach(function(number) {
-            this.queueJobForNumber(number, function() {
-                return outgoing.sendToNumber(number);
-            });
+            return outgoing.sendToNumber(number);
         }.bind(this));
     },
 
@@ -40084,15 +40084,17 @@ MessageSender.prototype = {
     },
 
     sendMessageToNumber: function(number, messageText, attachments, timestamp, expireTimer, profileKey) {
-        return this.sendMessage({
-            recipients  : [number],
-            body        : messageText,
-            timestamp   : timestamp,
-            attachments : attachments,
-            needsSync   : true,
-            expireTimer : expireTimer,
-            profileKey  : profileKey
-        });
+        return this.queueJobForNumber(number, function() {
+            return this.sendMessage({
+                recipients  : [number],
+                body        : messageText,
+                timestamp   : timestamp,
+                attachments : attachments,
+                needsSync   : true,
+                expireTimer : expireTimer,
+                profileKey  : profileKey
+            });
+        }.bind(this));
     },
 
     closeSession: function(number, timestamp) {

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -204,7 +204,10 @@
         },
 
         send: function(promise) {
+            this.sendPromise = promise;
+
             this.trigger('pending');
+
             return promise.then(function(result) {
                 var now = Date.now();
                 this.trigger('done');
@@ -213,9 +216,9 @@
                 }
                 var sent_to = this.get('sent_to') || [];
                 this.save({
-                  sent_to: _.union(sent_to, result.successfulNumbers),
-                  sent: true,
-                  expirationStartTimestamp: now
+                    sent_to: _.union(sent_to, result.successfulNumbers),
+                    sent: true,
+                    expirationStartTimestamp: now
                 });
                 this.sendSyncMessage();
             }.bind(this)).catch(function(result) {

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -975,7 +975,7 @@
                 this.fileInput.getFiles().then(function(attachments) {
                     var sendDelta = Date.now() - this.sendStart;
                     console.log('Send pre-checks took', sendDelta, 'milliseconds');
-                    this.model.sendMessage(message, attachments);
+                    this.model.sendNewMessage(message, attachments);
                     input.val("");
                     this.focusMessageField();
                     this.forceUpdateMessageFieldSize(e);

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -210,6 +210,8 @@ MessageSender.prototype = {
                 delete this.pendingMessages[number];
             }
         }.bind(this));
+
+        return runCurrent;
     },
 
     uploadMedia: function(message) {
@@ -255,9 +257,7 @@ MessageSender.prototype = {
         var outgoing = new OutgoingMessage(this.server, timestamp, numbers, message, silent, callback);
 
         numbers.forEach(function(number) {
-            this.queueJobForNumber(number, function() {
-                return outgoing.sendToNumber(number);
-            });
+            return outgoing.sendToNumber(number);
         }.bind(this));
     },
 
@@ -464,15 +464,17 @@ MessageSender.prototype = {
     },
 
     sendMessageToNumber: function(number, messageText, attachments, timestamp, expireTimer, profileKey) {
-        return this.sendMessage({
-            recipients  : [number],
-            body        : messageText,
-            timestamp   : timestamp,
-            attachments : attachments,
-            needsSync   : true,
-            expireTimer : expireTimer,
-            profileKey  : profileKey
-        });
+        return this.queueJobForNumber(number, function() {
+            return this.sendMessage({
+                recipients  : [number],
+                body        : messageText,
+                timestamp   : timestamp,
+                attachments : attachments,
+                needsSync   : true,
+                expireTimer : expireTimer,
+                profileKey  : profileKey
+            });
+        }.bind(this));
     },
 
     closeSession: function(number, timestamp) {

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -422,8 +422,7 @@ span.status {
     max-width: 800px;
     margin: 0 auto 10px;
     padding-left: 1em;
-    // we need more padding on right side because scroll bar overlaps
-    padding-right: 1.5em;
+    padding-right: 1em;
 
     &::after {
       visibility: hidden;
@@ -481,6 +480,13 @@ span.status {
 
     .retry {
       text-decoration: underline;
+      cursor: pointer;
+    }
+
+    .send {
+      float: left;
+      margin-left: 6px;
+      margin-right: 6px;
       cursor: pointer;
     }
 

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1429,7 +1429,7 @@ span.status {
     max-width: 800px;
     margin: 0 auto 10px;
     padding-left: 1em;
-    padding-right: 1.5em; }
+    padding-right: 1em; }
     .message-container li::after,
     .message-list li::after {
       visibility: hidden;
@@ -1478,6 +1478,12 @@ span.status {
     .message-container .meta .retry,
     .message-list .meta .retry {
       text-decoration: underline;
+      cursor: pointer; }
+    .message-container .meta .send,
+    .message-list .meta .send {
+      float: left;
+      margin-left: 6px;
+      margin-right: 6px;
       cursor: pointer; }
     .message-container .meta .some-failed,
     .message-list .meta .some-failed {


### PR DESCRIPTION
Without this change, sometimes messages would be sent out of order if we ran into errors. When we retried one of the first messages, it would end up being sent afterwards, different from how the messages were rendered in the conversation.

Now, we wait for the previous message to be completely sent or error'd before sending the next message. This is particularly impactful for long attachment uploads.

Still to do:
- Finish the work to move `queueJobForNumber` in `sendmessage.js` - need to cover all entrypoints.
- Maybe add a `queueJob` call to `Conversation.prepareNewMessage()`
- Add 'Message not sent' notification to an unsent message in addition to the 'Send' link.