### PR TITLE
app.quit() -> app.exit(), immediate app close on second instance

### DIFF
--- a/main.js
+++ b/main.js
@@ -83,7 +83,7 @@ if (!process.mas) {
 
   if (shouldQuit) {
     console.log('quitting; we are the second instance');
-    app.quit();
+    app.exit();
   }
 }
 


### PR DESCRIPTION
In the case where we've detected we're the second instance, we activate the primary instance then exit. On Windows this scenario was causing an error dialog to pop up, because we were using `app.quit()`, which doesn't close the app immediately. `app.exit()` does.

Fixes #2016