### PR TITLE
Issue#512: Navigate through conversations with hotkeys

### DIFF
--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -305,7 +305,7 @@
             });
 
             // down key
-            if (keyCode === 40 && currentConversationIndex < conversations.length) {
+            if (keyCode === 40 && currentConversationIndex + 1 < conversations.length) {
                 this.openConversation(e, conversations[currentConversationIndex + 1]);
             // up key
             } else if (keyCode === 38 && currentConversationIndex > 0) { // up key

--- a/test/index.html
+++ b/test/index.html
@@ -635,6 +635,7 @@
   <script type="text/javascript" src="views/attachment_view_test.js"></script>
   <script type="text/javascript" src="views/timestamp_view_test.js"></script>
   <script type="text/javascript" src="views/list_view_test.js"></script>
+  <script type="text/javascript" src="views/inbox_view_test.js"></script>
   <script type="text/javascript" src="views/conversation_search_view_test.js"></script>
   <script type="text/javascript" src="views/network_status_view_test.js"></script>
   <script type="text/javascript" src="views/last_seen_indicator_view_test.js"></script>

--- a/test/views/inbox_view_test.js
+++ b/test/views/inbox_view_test.js
@@ -1,0 +1,124 @@
+describe('InboxView', function() {
+    var inboxView = new Whisper.InboxView({
+        model: {},
+        window: window,
+        initialLoadComplete: function() {}
+    }).render();
+
+    var conversation = new Whisper.Conversation({ id: '1234', type: 'private'});
+
+    describe('switching conversations with key events', function() {
+        var openConversationCalls;
+        var conversations = [new Whisper.Conversation({
+            name: '1',
+            id: '+1',
+        }), new Whisper.Conversation({
+            name: '2',
+            id: '+2',
+        }),
+        new Whisper.Conversation({
+            name: '3',
+            id: '+3',
+        })];
+
+        beforeEach(function() {
+            var collection = window.getInboxCollection();
+            collection.reset([]);
+
+            collection.add(conversations[0]);
+            collection.add(conversations[1]);
+            collection.add(conversations[2]);
+
+            openConversationCalls = [];
+            inboxView.openConversation = function() {
+                openConversationCalls.push(arguments);
+            };
+        });
+
+        it('should do nothing if the alt or ctrl keys are not pressed', function() {
+            var event = {
+                keyCode: 40
+            };
+            inboxView.conversation_stack.stack = [conversations[1]];
+            inboxView.switchConversation(event);
+
+            assert(openConversationCalls.length === 0);
+        });
+
+        describe('with the ctrl key down', function() {
+            var event = {
+                ctrlKey: true
+            };
+
+            testKeyDownEvents(event);
+        });
+
+        describe('with the alt key down', function() {
+            var event = {
+                altKey: true
+            };
+
+            testKeyDownEvents(event);
+        });
+
+        function testKeyDownEvents(event) {
+            describe('and the down key is pressed', function() {
+                before(function() {
+                    event.keyCode = 40;
+                });
+
+                it ('should select the first conversation if none were selected', function() {
+                    inboxView.conversation_stack.stack = [];
+                    inboxView.switchConversation(event);
+
+                    assert(openConversationCalls.length === 1);
+                    assert.deepEqual(openConversationCalls[0][1], conversations[0]);
+                });
+
+                it ('should select the next conversation down when there is one', function() {
+                    inboxView.conversation_stack.stack = [conversations[1]];
+                    inboxView.switchConversation(event);
+
+                    assert(openConversationCalls.length === 1);
+                    assert.deepEqual(openConversationCalls[0][1], conversations[2]);
+                });
+
+                it ('should do nothing when there are no more conversations', function() {
+                    inboxView.conversation_stack.stack = [conversations[2]];
+                    inboxView.switchConversation(event);
+
+                    assert(openConversationCalls.length === 0);
+                });
+            });
+
+            describe('and the up key is pressed', function() {
+                before(function() {
+                    event.keyCode = 38;
+                });
+
+                it ('should select the first conversation if none were selected', function() {
+                    inboxView.conversation_stack.stack = [];
+                    inboxView.switchConversation(event);
+
+                    assert(openConversationCalls.length === 1);
+                    assert.deepEqual(openConversationCalls[0][1], conversations[0]);
+                });
+
+                it ('should select the next conversation up when there is one', function() {
+                    inboxView.conversation_stack.stack = [conversations[1]];
+                    inboxView.switchConversation(event);
+
+                    assert(openConversationCalls.length === 1);
+                    assert.deepEqual(openConversationCalls[0][1], conversations[0]);
+                });
+
+                it ('should do nothing when there are no more conversations', function() {
+                    inboxView.conversation_stack.stack = [conversations[0]];
+                    inboxView.switchConversation(event);
+
+                    assert(openConversationCalls.length === 0);
+                });
+            });
+        }
+    });
+});


### PR DESCRIPTION
### Contributor checklist:
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
- [X] My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
- [X] My changes are ready to be shipped to users


### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/WhisperSystems/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
#512 #752 
This was initially to be for issue 752 and noticed this as one of the priority fixes addressed in the issue and it didn't make sense for me to do all of the issues on one PR. This fix includes the following functionality:
* You can now switch between conversations using the ctrl/alt keys and up/down in unison.
* If you do not have a conversation selected it will select the first conversation

Tested on:
* Windows 10 64-bit.
* Ubuntu 17.10 64-bit Virtual Machine 

New unit tests were also added to fully cover the feature.
Testing N/A to iOS or Android.
Manually testing included cycling through many conversations while modals were open or not and while focus was elsewhere. No issues.