### PR TITLE
Move ESLint environment configuration into `.eslintrc`

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "browser": true,
+    "node": false
+  },
+}

--- a/js/modules/.eslintrc
+++ b/js/modules/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "browser": false,
+    "commonjs": true,
+    "node": false
+  },
+  "globals": {
+    "console": true
+  }
+}


### PR DESCRIPTION
This lets us omit manual per-file `eslint-env` directives. I tried the same for `globals` but the can only be turned on as `"Backbone": false` doesn’t mean turn off, but rather that it’s read-only. When we whitelist `Backbone` in `js/.eslintrc` it also becames a valid global in `js/modules` even though it’s not listed in `js/modules/.eslintrc`. As discussed, we want to discourage use of globals, so explicit opt-in will encourage us to whitelist the bare minimum and reduce our use of globals over time.