### PR TITLE
Enable conversation open when app started offline

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -888,6 +888,10 @@
     },
 
     getProfile: function(id) {
+        if (!textsecure.messaging) {
+            return Promise.reject(new Error('textsecure.messaging is not available'));
+        }
+
         return textsecure.messaging.getProfile(id).then(function(profile) {
             var identityKey = dcodeIO.ByteBuffer.wrap(profile.identityKey, 'base64').toArrayBuffer();
 

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -889,7 +889,8 @@
 
     getProfile: function(id) {
         if (!textsecure.messaging) {
-            return Promise.reject(new Error('textsecure.messaging is not available'));
+            var message = 'Conversation.getProfile: textsecure.messaging not available';
+            return Promise.reject(new Error(message));
         }
 
         return textsecure.messaging.getProfile(id).then(function(profile) {


### PR DESCRIPTION
Turns out `textsecure.messaging` is only set up on first connection to the server. When we start up offline, we never do that. And it prevents the user from opening every conversation.

There's a whole lot more to do to bulletproof ourselves against a missing textsecure.messaging (and then beyond that, queuing outgoing messages so they don't get dropped completely when offline).

Hence, this is just a band-aid.