### PR TITLE
Two fixes for tricky import/register scenarios

### DIFF
--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -54,7 +54,7 @@
         },
         finishLightImport: function() {
           var options = {
-            postImport: true
+            hasExistingData: true
           };
           this.openInstaller(options);
         },
@@ -71,7 +71,7 @@
           //   allowing the user to switch to other ways to set up the app. If they
           //   switched back and forth in the middle of a light import, they'd lose all
           //   that imported data.
-          if (!options.postImport) {
+          if (!options.hasExistingData) {
             window.addSetupMenuItems();
           }
 

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -65,7 +65,16 @@
           }
         },
         openInstaller: function(options) {
-          window.addSetupMenuItems();
+          options = options || {};
+
+          // If we're in the middle of import, we don't want to show the menu options
+          //   allowing the user to switch to other ways to set up the app. If they
+          //   switched back and forth in the middle of a light import, they'd lose all
+          //   that imported data.
+          if (!options.postImport) {
+            window.addSetupMenuItems();
+          }
+
           this.resetViews();
           var installView = this.installView = new Whisper.InstallView(options);
           this.openView(this.installView);

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -54,7 +54,7 @@
         },
         finishLightImport: function() {
           var options = {
-            startStep: Whisper.InstallView.Steps.SCAN_QR_CODE,
+            postImport: true
           };
           this.openInstaller(options);
         },

--- a/js/views/install_view.js
+++ b/js/views/install_view.js
@@ -33,9 +33,7 @@
             this.on('disconnected', this.reconnect);
 
             // Keep data around if it's a re-link, or the middle of a light import
-            if (Whisper.Registration.everDone() || options.postImport) {
-                this.retainData = true;
-            }
+            this.shouldRetainData = Whisper.Registration.everDone() || options.hasExistingData;
         },
         render_attributes: function() {
             var errorMessage;
@@ -173,7 +171,7 @@
                     //   app restarts at certain times can cause weird things to happen,
                     //   like data from a previous incomplete light import showing up
                     //   after a new install.
-                    if (this.retainData) {
+                    if (this.shouldRetainData) {
                         return finish();
                     }
 

--- a/js/views/install_view.js
+++ b/js/views/install_view.js
@@ -32,8 +32,9 @@
             this.connect();
             this.on('disconnected', this.reconnect);
 
-            if (Whisper.Registration.everDone() || options.startStep) {
-                this.selectStep(options.startStep || Steps.SCAN_QR_CODE);
+            // Keep data around if it's a re-link, or the middle of a light import
+            if (Whisper.Registration.everDone() || options.postImport) {
+                this.retainData = true;
             }
         },
         render_attributes: function() {
@@ -162,11 +163,29 @@
                     }
 
                     this.selectStep(Steps.PROGRESS_BAR);
-                    resolve(name);
+
+                    var finish = function() {
+                        resolve(name);
+                    };
+
+                    // Delete all data from database unless we're in the middle
+                    //   of a re-link, or we are finishing a light import. Without this,
+                    //   app restarts at certain times can cause weird things to happen,
+                    //   like data from a previous incomplete light import showing up
+                    //   after a new install.
+                    if (this.retainData) {
+                        return finish();
+                    }
+
+                    Whisper.Backup.clearDatabase().then(finish, function(error) {
+                        console.log(
+                          'confirmNumber: error clearing database',
+                          error && error.stack ? error.stack : error
+                        );
+                        finish();
+                    });
                 }.bind(this));
             }.bind(this));
         },
     });
-
-    Whisper.InstallView.Steps = Steps;
 })();


### PR DESCRIPTION

First, we now clear data on finish of new install, unless it's a re-link/light import.

Why? From the comments:

> Delete all data from database unless we're in the middle
> of a re-link, or we are finishing a light import. Without this,
> app restarts at certain times can cause weird things to happen,
> like data from a previous incomplete light import showing up
> after a new install.

Second, we no longer show setup options in file menu in middle of a light import.

More justification from the comments:

> If we're in the middle of import, we don't want to show the menu options
> allowing the user to switch to other ways to set up the app. If they
> switched back and forth in the middle of a light import, they'd lose all
> that imported data.


