### PR TITLE
UX Improvements: Global Menu & Copy Changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,5 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{js/modules/**/*.js, test/modules/**/*.js}]
+[{js/modules/**/*.js, test/app/**/*.js, test/modules/**/*.js}]
 indent_size = 2

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -411,7 +411,7 @@
       "description": "Tooltip for the tray icon"
     },
     "searchForPeopleOrGroups": {
-      "message": "Search...",
+      "message": "Enter name or number",
       "description": "Placeholder text in the search input"
     },
     "welcomeToSignal": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -24,15 +24,15 @@
       "description": "The label that is used for the Preferences menu in the program main menu. This should be consistent with the standard naming for ‘Preferences’ on the operating system."
     },
     "menuSetupWithImport": {
-      "message": "Set up with import",
+      "message": "Set Up with Import",
       "description": "When the application is not yet set up, menu option to start up the import sequence"
     },
     "menuSetupAsNewDevice": {
-      "message": "Set up as new device",
+      "message": "Set Up as New Device",
       "description": "When the application is not yet set up, menu option to start up the set up as fresh device"
     },
     "menuSetupAsStandalone": {
-      "message": "Set up as standalone device",
+      "message": "Set Up as Standalone Device",
       "description": "Only available on development modes, menu option to open up the standalone device setup sequence"
     },
     "loading": {
@@ -372,22 +372,22 @@
     },
     "debugLog": {
       "message": "Debug Log",
-      "description": "View menu item to open the debug log, capitalized"
+      "description": "View menu item to open the debug log (title case)"
     },
     "goToReleaseNotes": {
-      "message": "Go to release notes",
+      "message": "Go to Release Notes",
       "description": ""
     },
     "goToForums": {
-      "message": "Go to forums",
+      "message": "Go to Forums",
       "description": "Item under the Help menu, takes you to the forums"
     },
     "goToSupportPage": {
-      "message": "Go to support page",
+      "message": "Go to Support Page",
       "description": "Item under the Help menu, takes you to the support page"
     },
     "fileABug": {
-      "message": "File a bug",
+      "message": "File a Bug",
       "description": "Item under the Help menu, takes you to GitHub new issue form"
     },
     "aboutSignalDesktop": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -835,9 +835,9 @@
       "message": "Hide menu bar",
       "description": "Label text for menu bar visibility setting"
     },
-    "newContact": {
-      "message": "Click to create new contact",
-      "description": ""
+    "startConversation": {
+      "message": "Start conversation…",
+      "description": "Label underneath number a user enters that is not an existing contact"
     },
     "newPhoneNumber": {
       "message": "Enter a phone number to add a contact.",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -19,6 +19,10 @@
       "message": "&Help",
       "description": "The label that is used for the Help menu in the program main menu. The '&' indicates that the following letter will be used as the keyboard 'shortcut letter' for accessing the menu with the Alt-<letter> combination."
     },
+    "mainMenuSettings": {
+      "message": "Preferences…",
+      "description": "The label that is used for the Preferences menu in the program main menu. This should be consistent with the standard naming for ‘Preferences’ on the operating system."
+    },
     "menuSetupWithImport": {
       "message": "Set up with import",
       "description": "When the application is not yet set up, menu option to start up the import sequence"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -595,10 +595,6 @@
         "message": "New Messages",
         "description": "Displayed in notifications for multiple messages"
     },
-    "restartSignal": {
-        "message": "Restart Signal",
-        "description": "Menu item for restarting the program."
-    },
     "messageNotSent": {
         "message": "Message not sent.",
         "description": "Informational label, appears on messages that failed to send"

--- a/app/locale.js
+++ b/app/locale.js
@@ -1,9 +1,7 @@
 const path = require('path');
 const fs = require('fs');
-const { app } = require('electron');
 const _ = require('lodash');
 
-const logging = require('./logging');
 
 function normalizeLocaleName(locale) {
   if (/^en-/.test(locale)) {
@@ -27,14 +25,16 @@ function getLocaleMessages(locale) {
   return JSON.parse(fs.readFileSync(targetFile, 'utf-8'));
 }
 
-function load() {
-  const logger = logging.getLogger();
-  const english = getLocaleMessages('en');
-  let appLocale = app.getLocale();
-
-  if (process.env.NODE_ENV === 'test') {
-    appLocale = 'en';
+function load({ appLocale, logger } = {}) {
+  if (!appLocale) {
+    throw new TypeError('`appLocale` is required');
   }
+
+  if (!logger || !logger.error) {
+    throw new TypeError('`logger.error` is required');
+  }
+
+  const english = getLocaleMessages('en');
 
   // Load locale - if we can't load messages for the current locale, we
   // default to 'en'

--- a/app/menu.js
+++ b/app/menu.js
@@ -7,6 +7,7 @@ exports.createTemplate = (options, messages) => {
   }
 
   const {
+    includeSetup,
     openForums,
     openNewBugForm,
     openReleaseNotes,
@@ -134,7 +135,7 @@ exports.createTemplate = (options, messages) => {
     ],
   }];
 
-  if (options.includeSetup) {
+  if (includeSetup) {
     const fileMenu = template[0];
 
     // These are in reverse order, since we're prepending them one at a time
@@ -164,6 +165,7 @@ exports.createTemplate = (options, messages) => {
 
 function updateForMac(template, messages, options) {
   const {
+    includeSetup,
     setupAsNewDevice,
     setupAsStandalone,
     setupWithImport,
@@ -179,7 +181,7 @@ function updateForMac(template, messages, options) {
   // Remove File menu
   template.shift();
 
-  if (options.includeSetup) {
+  if (includeSetup) {
     // Add a File menu just for these setup options. Because we're using unshift(), we add
     //   the file menu first, though it ends up to the right of the Signal Desktop menu.
     const fileMenu = {
@@ -235,7 +237,7 @@ function updateForMac(template, messages, options) {
   });
 
   // Add to Edit menu
-  const editIndex = options.includeSetup ? 2 : 1;
+  const editIndex = includeSetup ? 2 : 1;
   template[editIndex].submenu.push(
     {
       type: 'separator',

--- a/app/menu.js
+++ b/app/menu.js
@@ -156,6 +156,9 @@ exports.createTemplate = (options, messages) => {
     }
 
     fileMenu.submenu.unshift({
+      type: 'separator',
+    });
+    fileMenu.submenu.unshift({
       label: messages.menuSetupAsNewDevice.message,
       click: setupAsNewDevice,
     });

--- a/app/menu.js
+++ b/app/menu.js
@@ -168,6 +168,7 @@ function updateForMac(template, messages, options) {
     setupAsStandalone,
     setupWithImport,
     showAbout,
+    showSettings,
     showWindow,
   } = options;
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,9 +1,17 @@
+const isString = require('lodash/isString');
+
+
 exports.createTemplate = (options, messages) => {
+  if (!isString(options.platform)) {
+    throw new TypeError('`options.platform` must be a string');
+  }
+
   const {
     openForums,
     openNewBugForm,
     openReleaseNotes,
     openSupportPage,
+    platform,
     setupAsNewDevice,
     setupAsStandalone,
     setupWithImport,
@@ -147,7 +155,7 @@ exports.createTemplate = (options, messages) => {
     });
   }
 
-  if (process.platform === 'darwin') {
+  if (platform === 'darwin') {
     return updateForMac(template, messages, options);
   }
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -18,11 +18,20 @@ exports.createTemplate = (options, messages) => {
     setupWithImport,
     showAbout,
     showDebugLog,
+    showSettings,
   } = options;
 
   const template = [{
     label: messages.mainMenuFile.message,
     submenu: [
+      {
+        label: messages.mainMenuSettings.message,
+        accelerator: 'CommandOrControl+,',
+        click: showSettings,
+      },
+      {
+        type: 'separator',
+      },
       {
         role: 'quit',
       },
@@ -214,6 +223,14 @@ function updateForMac(template, messages, options) {
       {
         label: messages.aboutSignalDesktop.message,
         click: showAbout,
+      },
+      {
+        type: 'separator',
+      },
+      {
+        label: messages.mainMenuSettings.message,
+        accelerator: 'CommandOrControl+,',
+        click: showSettings,
       },
       {
         type: 'separator',

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,4 +1,4 @@
-function createTemplate(options, messages) {
+exports.createTemplate = (options, messages) => {
   const {
     openForums,
     openNewBugForm,
@@ -152,7 +152,7 @@ function createTemplate(options, messages) {
   }
 
   return template;
-}
+};
 
 function updateForMac(template, messages, options) {
   const {
@@ -273,5 +273,3 @@ function updateForMac(template, messages, options) {
 
   return template;
 }
-
-module.exports = createTemplate;

--- a/app/menu.js
+++ b/app/menu.js
@@ -276,9 +276,9 @@ function updateForMac(template, messages, options) {
   );
 
   // Replace Window menu
-  const windowIndex = options.includeSetup ? 4 : 3;
+  const windowMenuTemplateIndex = includeSetup ? 4 : 3;
   // eslint-disable-next-line no-param-reassign
-  template[windowIndex].submenu = [
+  template[windowMenuTemplateIndex].submenu = [
     {
       accelerator: 'CmdOrCtrl+W',
       role: 'close',

--- a/background.html
+++ b/background.html
@@ -69,16 +69,6 @@
     <div class='gutter'>
         <div class='network-status-container'></div>
         <div class='title-bar active' id='header'>
-          <div class='header-buttons right'>
-            <div class='vertical-align'>
-              <div class='global-menu menu'>
-                <button class='hamburger' alt='signal menu'></button>
-                <ul class='menu-list'>
-                    <li class='showSettings'>{{ settings }}</li>
-                </ul>
-              </div>
-            </div>
-          </div>
           <h1>Signal</h1>
           <div class='tool-bar clearfix'>
             <input type='search' class='search' placeholder='{{ searchForPeopleOrGroups }}' dir='auto'>

--- a/background.html
+++ b/background.html
@@ -75,7 +75,6 @@
                 <button class='hamburger' alt='signal menu'></button>
                 <ul class='menu-list'>
                     <li class='showSettings'>{{ settings }}</li>
-                    <li class='restart-signal'>{{ restartSignal }}</li>
                 </ul>
               </div>
             </div>

--- a/js/background.js
+++ b/js/background.js
@@ -170,6 +170,16 @@
         Whisper.events.on('showDebugLog', function() {
             appView.openDebugLog();
         });
+        Whisper.events.on('showSettings', () => {
+            if (!appView || !appView.inboxView) {
+                console.log(
+                    'background: Event: \'showSettings\':' +
+                    ' Expected `appView.inboxView` to exist.'
+                );
+                return;
+            }
+            appView.inboxView.showSettings();
+        });
         Whisper.events.on('unauthorized', function() {
             appView.inboxView.networkStatusView.update();
         });

--- a/js/views/conversation_search_view.js
+++ b/js/views/conversation_search_view.js
@@ -22,7 +22,7 @@
     },
     render_attributes() {
       return {
-        number: i18n('newContact'),
+        number: i18n('startConversation'),
         title: this.model.getNumber(),
         avatar: this.model.getAvatar(),
       };

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -170,8 +170,6 @@
       click: 'onClick',
       'click #header': 'focusHeader',
       'click .conversation': 'focusConversation',
-      'click .global-menu .hamburger': 'toggleMenu',
-      'click .showSettings': 'showSettings',
       'select .gutter .conversation-list-item': 'openConversation',
       'input input.search': 'filterContacts',
       'show .lightbox': 'showLightbox',
@@ -258,9 +256,6 @@
         this.focusConversation();
       }
     },
-    toggleMenu() {
-      this.$('.global-menu .menu-list').toggle();
-    },
     showLightbox(e) {
       this.$el.append(e.target);
     },
@@ -270,15 +265,7 @@
       }
       this.$('.conversation:first .recorder').trigger('close');
     },
-    closeMenu(e) {
-      if (e && this.$(e.target).parent('.global-menu').length > 0) {
-        return;
-      }
-
-      this.$('.global-menu .menu-list').hide();
-    },
     onClick(e) {
-      this.closeMenu(e);
       this.closeRecording(e);
     },
   });

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -165,7 +165,6 @@
       selectAContact: i18n('selectAContact'),
       searchForPeopleOrGroups: i18n('searchForPeopleOrGroups'),
       settings: i18n('settings'),
-      restartSignal: i18n('restartSignal'),
     },
     events: {
       click: 'onClick',
@@ -175,7 +174,6 @@
       'click .showSettings': 'showSettings',
       'select .gutter .conversation-list-item': 'openConversation',
       'input input.search': 'filterContacts',
-      'click .restart-signal': window.restart,
       'show .lightbox': 'showLightbox',
     },
     startConnectionListener() {

--- a/main.js
+++ b/main.js
@@ -435,6 +435,7 @@ app.on('ready', () => {
 });
 
 function setupMenu(options) {
+  const { platform } = process;
   const menuOptions = Object.assign({}, options, {
     development,
     showDebugLog,
@@ -444,6 +445,7 @@ function setupMenu(options) {
     openNewBugForm,
     openSupportPage,
     openForums,
+    platform,
     setupWithImport,
     setupAsNewDevice,
     setupAsStandalone,

--- a/main.js
+++ b/main.js
@@ -415,7 +415,8 @@ app.on('ready', () => {
     }
 
     if (!locale) {
-      locale = loadLocale();
+      const appLocale = process.env.NODE_ENV === 'test' ? 'en' : app.getLocale();
+      locale = loadLocale({ appLocale, logger });
     }
 
     ready = true;

--- a/main.js
+++ b/main.js
@@ -18,9 +18,9 @@ const packageJson = require('./package.json');
 
 const autoUpdate = require('./app/auto_update');
 const createTrayIcon = require('./app/tray_icon');
-const createTemplate = require('./app/menu.js');
 const logging = require('./app/logging');
 const windowState = require('./app/window_state');
+const { createTemplate } = require('./app/menu');
 
 const appUserModelId = `org.whispersystems.${packageJson.name}`;
 console.log('Set Windows Application User Model ID (AUMID)', { appUserModelId });

--- a/main.js
+++ b/main.js
@@ -324,6 +324,14 @@ function showDebugLog() {
   }
 }
 
+function showSettings() {
+  if (!mainWindow) {
+    return;
+  }
+
+  mainWindow.webContents.send('show-settings');
+}
+
 function openReleaseNotes() {
   shell.openExternal(`https://github.com/signalapp/Signal-Desktop/releases/tag/v${app.getVersion()}`);
 }
@@ -449,6 +457,7 @@ function setupMenu(options) {
     setupWithImport,
     setupAsNewDevice,
     setupAsStandalone,
+    showSettings,
   });
   const template = createTemplate(menuOptions, locale.messages);
   const menu = Menu.buildFromTemplate(template);

--- a/main.js
+++ b/main.js
@@ -16,10 +16,10 @@ const {
 
 const packageJson = require('./package.json');
 
+const autoUpdate = require('./app/auto_update');
 const createTrayIcon = require('./app/tray_icon');
 const createTemplate = require('./app/menu.js');
 const logging = require('./app/logging');
-const autoUpdate = require('./app/auto_update');
 const windowState = require('./app/window_state');
 
 const appUserModelId = `org.whispersystems.${packageJson.name}`;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "main.js",
   "scripts": {
     "postinstall": "electron-builder install-app-deps && rimraf node_modules/dtrace-provider",
-    "test": "npm run eslint && npm run test-server && grunt test && npm run test-modules",
+    "test": "npm run eslint && npm run test-server && grunt test && npm run test-app && npm run test-modules",
     "lint": "grunt jshint",
     "start": "electron .",
     "asarl": "asar l release/mac/Signal.app/Contents/Resources/app.asar",
@@ -36,6 +36,7 @@
     "release-win": "npm run build-release -- -w --prepackaged release/windows --publish=always",
     "release-lin": "npm run build-release -- -l --prepackaged release/linux && NAME=$npm_package_name VERSION=$npm_package_version ./aptly.sh",
     "release": "npm run release-mac && npm run release-win && npm run release-lin",
+    "test-app": "mocha --recursive test/app",
     "test-modules": "mocha --recursive test/modules",
     "test-server": "mocha --recursive test/server",
     "test-server-coverage": "nyc --reporter=lcov --reporter=text mocha --recursive test/server",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "release-win": "npm run build-release -- -w --prepackaged release/windows --publish=always",
     "release-lin": "npm run build-release -- -l --prepackaged release/linux && NAME=$npm_package_name VERSION=$npm_package_version ./aptly.sh",
     "release": "npm run release-mac && npm run release-win && npm run release-lin",
+    "test-modules": "mocha --recursive test/modules",
     "test-server": "mocha --recursive test/server",
     "test-server-coverage": "nyc --reporter=lcov --reporter=text mocha --recursive test/server",
-    "test-modules": "mocha --recursive test/modules",
     "eslint": "eslint .",
     "open-coverage": "open coverage/lcov-report/index.html"
   },

--- a/preload.js
+++ b/preload.js
@@ -54,6 +54,10 @@
     Whisper.events.trigger('setupAsStandalone');
   });
 
+  ipc.on('show-settings', function() {
+    Whisper.events.trigger('showSettings');
+  });
+
   window.addSetupMenuItems = function() {
     ipc.send('add-setup-menu-items');
   }

--- a/test/app/fixtures/menu-mac-os-setup.json
+++ b/test/app/fixtures/menu-mac-os-setup.json
@@ -1,0 +1,180 @@
+[
+  {
+    "submenu": [
+      {
+        "label": "About Signal Desktop",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Preferences…",
+        "accelerator": "CommandOrControl+,",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "hide"
+      },
+      {
+        "role": "hideothers"
+      },
+      {
+        "role": "unhide"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "quit"
+      }
+    ]
+  },
+  {
+    "label": "&File",
+    "submenu": [
+      {
+        "label": "Set up with import",
+        "click": null
+      },
+      {
+        "label": "Set up as new device",
+        "click": null
+      }
+    ]
+  },
+  {
+    "label": "&Edit",
+    "submenu": [
+      {
+        "role": "undo"
+      },
+      {
+        "role": "redo"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "cut"
+      },
+      {
+        "role": "copy"
+      },
+      {
+        "role": "paste"
+      },
+      {
+        "role": "pasteandmatchstyle"
+      },
+      {
+        "role": "delete"
+      },
+      {
+        "role": "selectall"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Speech",
+        "submenu": [
+          {
+            "role": "startspeaking"
+          },
+          {
+            "role": "stopspeaking"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "label": "&View",
+    "submenu": [
+      {
+        "role": "resetzoom"
+      },
+      {
+        "role": "zoomin"
+      },
+      {
+        "role": "zoomout"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "togglefullscreen"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Debug Log",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "toggledevtools"
+      }
+    ]
+  },
+  {
+    "label": "&Window",
+    "role": "window",
+    "submenu": [
+      {
+        "accelerator": "CmdOrCtrl+W",
+        "role": "close"
+      },
+      {
+        "accelerator": "CmdOrCtrl+M",
+        "role": "minimize"
+      },
+      {
+        "role": "zoom"
+      },
+      {
+        "label": "Show",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "front"
+      }
+    ]
+  },
+  {
+    "label": "&Help",
+    "role": "help",
+    "submenu": [
+      {
+        "label": "Go to release notes",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Go to forums",
+        "click": null
+      },
+      {
+        "label": "Go to support page",
+        "click": null
+      },
+      {
+        "label": "File a bug",
+        "click": null
+      }
+    ]
+  }
+]

--- a/test/app/fixtures/menu-mac-os-setup.json
+++ b/test/app/fixtures/menu-mac-os-setup.json
@@ -37,11 +37,11 @@
     "label": "&File",
     "submenu": [
       {
-        "label": "Set up with import",
+        "label": "Set Up with Import",
         "click": null
       },
       {
-        "label": "Set up as new device",
+        "label": "Set Up as New Device",
         "click": null
       }
     ]
@@ -157,22 +157,22 @@
     "role": "help",
     "submenu": [
       {
-        "label": "Go to release notes",
+        "label": "Go to Release Notes",
         "click": null
       },
       {
         "type": "separator"
       },
       {
-        "label": "Go to forums",
+        "label": "Go to Forums",
         "click": null
       },
       {
-        "label": "Go to support page",
+        "label": "Go to Support Page",
         "click": null
       },
       {
-        "label": "File a bug",
+        "label": "File a Bug",
         "click": null
       }
     ]

--- a/test/app/fixtures/menu-mac-os.json
+++ b/test/app/fixtures/menu-mac-os.json
@@ -1,0 +1,159 @@
+[
+  {
+    "submenu": [
+      {
+        "label": "About Signal Desktop",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "hide"
+      },
+      {
+        "role": "hideothers"
+      },
+      {
+        "role": "unhide"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "quit"
+      }
+    ]
+  },
+  {
+    "label": "&Edit",
+    "submenu": [
+      {
+        "role": "undo"
+      },
+      {
+        "role": "redo"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "cut"
+      },
+      {
+        "role": "copy"
+      },
+      {
+        "role": "paste"
+      },
+      {
+        "role": "pasteandmatchstyle"
+      },
+      {
+        "role": "delete"
+      },
+      {
+        "role": "selectall"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Speech",
+        "submenu": [
+          {
+            "role": "startspeaking"
+          },
+          {
+            "role": "stopspeaking"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "label": "&View",
+    "submenu": [
+      {
+        "role": "resetzoom"
+      },
+      {
+        "role": "zoomin"
+      },
+      {
+        "role": "zoomout"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "togglefullscreen"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Debug Log",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "toggledevtools"
+      }
+    ]
+  },
+  {
+    "label": "&Window",
+    "role": "window",
+    "submenu": [
+      {
+        "accelerator": "CmdOrCtrl+W",
+        "role": "close"
+      },
+      {
+        "accelerator": "CmdOrCtrl+M",
+        "role": "minimize"
+      },
+      {
+        "role": "zoom"
+      },
+      {
+        "label": "Show",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "front"
+      }
+    ]
+  },
+  {
+    "label": "&Help",
+    "role": "help",
+    "submenu": [
+      {
+        "label": "Go to release notes",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Go to forums",
+        "click": null
+      },
+      {
+        "label": "Go to support page",
+        "click": null
+      },
+      {
+        "label": "File a bug",
+        "click": null
+      }
+    ]
+  }
+]

--- a/test/app/fixtures/menu-mac-os.json
+++ b/test/app/fixtures/menu-mac-os.json
@@ -9,6 +9,14 @@
         "type": "separator"
       },
       {
+        "label": "Preferences…",
+        "accelerator": "CommandOrControl+,",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
         "role": "hide"
       },
       {

--- a/test/app/fixtures/menu-mac-os.json
+++ b/test/app/fixtures/menu-mac-os.json
@@ -144,22 +144,22 @@
     "role": "help",
     "submenu": [
       {
-        "label": "Go to release notes",
+        "label": "Go to Release Notes",
         "click": null
       },
       {
         "type": "separator"
       },
       {
-        "label": "Go to forums",
+        "label": "Go to Forums",
         "click": null
       },
       {
-        "label": "Go to support page",
+        "label": "Go to Support Page",
         "click": null
       },
       {
-        "label": "File a bug",
+        "label": "File a Bug",
         "click": null
       }
     ]

--- a/test/app/fixtures/menu-windows-linux-setup.json
+++ b/test/app/fixtures/menu-windows-linux-setup.json
@@ -3,11 +3,11 @@
     "label": "&File",
     "submenu": [
       {
-        "label": "Set up with import",
+        "label": "Set Up with Import",
         "click": null
       },
       {
-        "label": "Set up as new device",
+        "label": "Set Up as New Device",
         "click": null
       },
       {
@@ -105,22 +105,22 @@
     "role": "help",
     "submenu": [
       {
-        "label": "Go to release notes",
+        "label": "Go to Release Notes",
         "click": null
       },
       {
         "type": "separator"
       },
       {
-        "label": "Go to forums",
+        "label": "Go to Forums",
         "click": null
       },
       {
-        "label": "Go to support page",
+        "label": "Go to Support Page",
         "click": null
       },
       {
-        "label": "File a bug",
+        "label": "File a Bug",
         "click": null
       },
       {

--- a/test/app/fixtures/menu-windows-linux-setup.json
+++ b/test/app/fixtures/menu-windows-linux-setup.json
@@ -1,0 +1,135 @@
+[
+  {
+    "label": "&File",
+    "submenu": [
+      {
+        "label": "Set up with import",
+        "click": null
+      },
+      {
+        "label": "Set up as new device",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Preferences…",
+        "accelerator": "CommandOrControl+,",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "quit"
+      }
+    ]
+  },
+  {
+    "label": "&Edit",
+    "submenu": [
+      {
+        "role": "undo"
+      },
+      {
+        "role": "redo"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "cut"
+      },
+      {
+        "role": "copy"
+      },
+      {
+        "role": "paste"
+      },
+      {
+        "role": "pasteandmatchstyle"
+      },
+      {
+        "role": "delete"
+      },
+      {
+        "role": "selectall"
+      }
+    ]
+  },
+  {
+    "label": "&View",
+    "submenu": [
+      {
+        "role": "resetzoom"
+      },
+      {
+        "role": "zoomin"
+      },
+      {
+        "role": "zoomout"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "togglefullscreen"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Debug Log",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "toggledevtools"
+      }
+    ]
+  },
+  {
+    "label": "&Window",
+    "role": "window",
+    "submenu": [
+      {
+        "role": "minimize"
+      }
+    ]
+  },
+  {
+    "label": "&Help",
+    "role": "help",
+    "submenu": [
+      {
+        "label": "Go to release notes",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Go to forums",
+        "click": null
+      },
+      {
+        "label": "Go to support page",
+        "click": null
+      },
+      {
+        "label": "File a bug",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "About Signal Desktop",
+        "click": null
+      }
+    ]
+  }
+]

--- a/test/app/fixtures/menu-windows-linux.json
+++ b/test/app/fixtures/menu-windows-linux.json
@@ -3,6 +3,14 @@
     "label": "&File",
     "submenu": [
       {
+        "label": "Preferences…",
+        "accelerator": "CommandOrControl+,",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
         "role": "quit"
       }
     ]

--- a/test/app/fixtures/menu-windows-linux.json
+++ b/test/app/fixtures/menu-windows-linux.json
@@ -94,22 +94,22 @@
     "role": "help",
     "submenu": [
       {
-        "label": "Go to release notes",
+        "label": "Go to Release Notes",
         "click": null
       },
       {
         "type": "separator"
       },
       {
-        "label": "Go to forums",
+        "label": "Go to Forums",
         "click": null
       },
       {
-        "label": "Go to support page",
+        "label": "Go to Support Page",
         "click": null
       },
       {
-        "label": "File a bug",
+        "label": "File a Bug",
         "click": null
       },
       {

--- a/test/app/fixtures/menu-windows-linux.json
+++ b/test/app/fixtures/menu-windows-linux.json
@@ -1,0 +1,116 @@
+[
+  {
+    "label": "&File",
+    "submenu": [
+      {
+        "role": "quit"
+      }
+    ]
+  },
+  {
+    "label": "&Edit",
+    "submenu": [
+      {
+        "role": "undo"
+      },
+      {
+        "role": "redo"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "cut"
+      },
+      {
+        "role": "copy"
+      },
+      {
+        "role": "paste"
+      },
+      {
+        "role": "pasteandmatchstyle"
+      },
+      {
+        "role": "delete"
+      },
+      {
+        "role": "selectall"
+      }
+    ]
+  },
+  {
+    "label": "&View",
+    "submenu": [
+      {
+        "role": "resetzoom"
+      },
+      {
+        "role": "zoomin"
+      },
+      {
+        "role": "zoomout"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "togglefullscreen"
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Debug Log",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "role": "toggledevtools"
+      }
+    ]
+  },
+  {
+    "label": "&Window",
+    "role": "window",
+    "submenu": [
+      {
+        "role": "minimize"
+      }
+    ]
+  },
+  {
+    "label": "&Help",
+    "role": "help",
+    "submenu": [
+      {
+        "label": "Go to release notes",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "Go to forums",
+        "click": null
+      },
+      {
+        "label": "Go to support page",
+        "click": null
+      },
+      {
+        "label": "File a bug",
+        "click": null
+      },
+      {
+        "type": "separator"
+      },
+      {
+        "label": "About Signal Desktop",
+        "click": null
+      }
+    ]
+  }
+]

--- a/test/app/menu_test.js
+++ b/test/app/menu_test.js
@@ -3,36 +3,56 @@ const { assert } = require('chai');
 const SignalMenu = require('../../app/menu');
 const { load: loadLocale } = require('../../app/locale');
 
-const FIXTURE_MAC_OS_MENU = require('./fixtures/menu-mac-os');
+const FIXTURE_MENU_MAC_OS = require('./fixtures/menu-mac-os');
+const FIXTURE_MENU_WINDOWS_LINUX = require('./fixtures/menu-windows-linux');
 
+const PLATFORMS = [
+  {
+    label: 'macOS',
+    platform: 'darwin',
+    fixture: FIXTURE_MENU_MAC_OS,
+  },
+  {
+    label: 'Windows',
+    platform: 'win32',
+    fixture: FIXTURE_MENU_WINDOWS_LINUX,
+  },
+  {
+    label: 'Linux',
+    platform: 'linux',
+    fixture: FIXTURE_MENU_WINDOWS_LINUX,
+  },
+];
 
 describe('SignalMenu', () => {
   describe('createTemplate', () => {
-    context('on macOS', () => {
-      it('should return correct template', () => {
-        const logger = {
-          error(message) {
-            throw new Error(message);
-          },
-        };
-        const options = {
-          openForums: null,
-          openNewBugForm: null,
-          openReleaseNotes: null,
-          openSupportPage: null,
-          platform: 'darwin',
-          setupAsNewDevice: null,
-          setupAsStandalone: null,
-          setupWithImport: null,
-          showAbout: null,
-          showDebugLog: null,
-          showWindow: null,
-        };
-        const appLocale = 'en';
-        const { messages } = loadLocale({ appLocale, logger });
+    PLATFORMS.forEach(({ label, platform, fixture }) => {
+      context(`on ${label}`, () => {
+        it('should return correct template', () => {
+          const logger = {
+            error(message) {
+              throw new Error(message);
+            },
+          };
+          const options = {
+            openForums: null,
+            openNewBugForm: null,
+            openReleaseNotes: null,
+            openSupportPage: null,
+            platform,
+            setupAsNewDevice: null,
+            setupAsStandalone: null,
+            setupWithImport: null,
+            showAbout: null,
+            showDebugLog: null,
+            showWindow: null,
+          };
+          const appLocale = 'en';
+          const { messages } = loadLocale({ appLocale, logger });
 
-        const actual = SignalMenu.createTemplate(options, messages);
-        assert.deepEqual(actual, FIXTURE_MAC_OS_MENU);
+          const actual = SignalMenu.createTemplate(options, messages);
+          assert.deepEqual(actual, fixture);
+        });
       });
     });
   });

--- a/test/app/menu_test.js
+++ b/test/app/menu_test.js
@@ -1,0 +1,39 @@
+const { assert } = require('chai');
+
+const SignalMenu = require('../../app/menu');
+const { load: loadLocale } = require('../../app/locale');
+
+const FIXTURE_MAC_OS_MENU = require('./fixtures/menu-mac-os');
+
+
+describe('SignalMenu', () => {
+  describe('createTemplate', () => {
+    context('on macOS', () => {
+      it('should return correct template', () => {
+        const logger = {
+          error(message) {
+            throw new Error(message);
+          },
+        };
+        const options = {
+          openForums: null,
+          openNewBugForm: null,
+          openReleaseNotes: null,
+          openSupportPage: null,
+          platform: 'darwin',
+          setupAsNewDevice: null,
+          setupAsStandalone: null,
+          setupWithImport: null,
+          showAbout: null,
+          showDebugLog: null,
+          showWindow: null,
+        };
+        const appLocale = 'en';
+        const { messages } = loadLocale({ appLocale, logger });
+
+        const actual = SignalMenu.createTemplate(options, messages);
+        assert.deepEqual(actual, FIXTURE_MAC_OS_MENU);
+      });
+    });
+  });
+});

--- a/test/app/menu_test.js
+++ b/test/app/menu_test.js
@@ -3,36 +3,43 @@ const { assert } = require('chai');
 const SignalMenu = require('../../app/menu');
 const { load: loadLocale } = require('../../app/locale');
 
-const FIXTURE_MENU_MAC_OS = require('./fixtures/menu-mac-os');
-const FIXTURE_MENU_WINDOWS_LINUX = require('./fixtures/menu-windows-linux');
 
 const PLATFORMS = [
   {
     label: 'macOS',
     platform: 'darwin',
-    fixture: FIXTURE_MENU_MAC_OS,
+    fixtures: {
+      default: './fixtures/menu-mac-os',
+      setup: './fixtures/menu-mac-os-setup',
+    },
   },
   {
     label: 'Windows',
     platform: 'win32',
-    fixture: FIXTURE_MENU_WINDOWS_LINUX,
+    fixtures: {
+      default: './fixtures/menu-windows-linux',
+      setup: './fixtures/menu-windows-linux-setup',
+    },
   },
   {
     label: 'Linux',
     platform: 'linux',
-    fixture: FIXTURE_MENU_WINDOWS_LINUX,
+    fixtures: {
+      default: './fixtures/menu-windows-linux',
+      setup: './fixtures/menu-windows-linux-setup',
+    },
   },
 ];
 
-const INCLUDE_SETUP_OPTIONS = [false];
+const INCLUDE_SETUP_OPTIONS = [false, true];
 
 describe('SignalMenu', () => {
   describe('createTemplate', () => {
-    PLATFORMS.forEach(({ label, platform, fixture }) => {
+    PLATFORMS.forEach(({ label, platform, fixtures }) => {
       context(label, () => {
         INCLUDE_SETUP_OPTIONS.forEach((includeSetup) => {
           const prefix = includeSetup ? 'with' : 'without';
-          context(`${prefix} included setup`, () => {
+          context(`${prefix} setup options`, () => {
             it('should return correct template', () => {
               const logger = {
                 error(message) {
@@ -58,6 +65,9 @@ describe('SignalMenu', () => {
               const { messages } = loadLocale({ appLocale, logger });
 
               const actual = SignalMenu.createTemplate(options, messages);
+              const fixturePath = includeSetup ? fixtures.setup : fixtures.default;
+              // eslint-disable-next-line global-require, import/no-dynamic-require
+              const fixture = require(fixturePath);
               assert.deepEqual(actual, fixture);
             });
           });

--- a/test/app/menu_test.js
+++ b/test/app/menu_test.js
@@ -24,34 +24,43 @@ const PLATFORMS = [
   },
 ];
 
+const INCLUDE_SETUP_OPTIONS = [false];
+
 describe('SignalMenu', () => {
   describe('createTemplate', () => {
     PLATFORMS.forEach(({ label, platform, fixture }) => {
-      context(`on ${label}`, () => {
-        it('should return correct template', () => {
-          const logger = {
-            error(message) {
-              throw new Error(message);
-            },
-          };
-          const options = {
-            openForums: null,
-            openNewBugForm: null,
-            openReleaseNotes: null,
-            openSupportPage: null,
-            platform,
-            setupAsNewDevice: null,
-            setupAsStandalone: null,
-            setupWithImport: null,
-            showAbout: null,
-            showDebugLog: null,
-            showWindow: null,
-          };
-          const appLocale = 'en';
-          const { messages } = loadLocale({ appLocale, logger });
+      context(label, () => {
+        INCLUDE_SETUP_OPTIONS.forEach((includeSetup) => {
+          const prefix = includeSetup ? 'with' : 'without';
+          context(`${prefix} included setup`, () => {
+            it('should return correct template', () => {
+              const logger = {
+                error(message) {
+                  throw new Error(message);
+                },
+              };
+              const options = {
+                openForums: null,
+                openNewBugForm: null,
+                openReleaseNotes: null,
+                openSupportPage: null,
+                platform,
+                includeSetup,
+                setupAsNewDevice: null,
+                setupAsStandalone: null,
+                setupWithImport: null,
+                showAbout: null,
+                showDebugLog: null,
+                showSettings: null,
+                showWindow: null,
+              };
+              const appLocale = 'en';
+              const { messages } = loadLocale({ appLocale, logger });
 
-          const actual = SignalMenu.createTemplate(options, messages);
-          assert.deepEqual(actual, fixture);
+              const actual = SignalMenu.createTemplate(options, messages);
+              assert.deepEqual(actual, fixture);
+            });
+          });
         });
       });
     });

--- a/test/index.html
+++ b/test/index.html
@@ -41,16 +41,6 @@
     <div class='gutter'>
         <div class='network-status-container'></div>
         <div class='title-bar active' id='header'>
-          <div class='header-buttons right'>
-            <div class='vertical-align'>
-              <div class='global-menu menu'>
-                <button class='hamburger' alt='signal menu'></button>
-                <ul class='menu-list'>
-                    <li class='showSettings'>{{ settings }}</li>
-                </ul>
-              </div>
-            </div>
-          </div>
           <h1>Signal</h1>
           <div class='tool-bar clearfix'>
             <input type='search' class='search' placeholder='{{ searchForPeopleOrGroups }}' dir='auto'>

--- a/test/index.html
+++ b/test/index.html
@@ -47,7 +47,6 @@
                 <button class='hamburger' alt='signal menu'></button>
                 <ul class='menu-list'>
                     <li class='showSettings'>{{ settings }}</li>
-                    <li class='restart-signal'>{{ restartSignal }}</li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
- [x] Removed ‘Restart Signal’ global menu item
- [x] Change _Click to create contact…_ to _Start conversation…_
- [x] Move global menu (top-left kebab) into OS menu bar, i.e. **Settings** > **Preferences…**
- [x] Add tests for OS menu bar templates
- [x] Fix bug with **Window** menu on macOS when showing setup options
- [x] Use _Title Case_ for all OS menu bar menu items for consistency