### PR TITLE
Update links to community forum

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@ both logs and a detailed description of what you encountered. Please do your bes
 Please note that this tracker is only for bugs and feature requests. Please try these
 locations if you have a question or comment:
 
-  https://whispersystems.discoursehosting.net/
+  https://community.signalusers.org/
   http://support.signal.org/
   support@whispersystems.org
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ You can install it on a computer which already has the production version instal
 
 ## Got a question?
 
-You can find a number of frequently asked questions here https://support.signal.org/.
-The discussion groups are another good place for questions: https://whispersystems.discoursehosting.net/.
+You can find answers to a number of frequently asked questions on our support site: https://support.signal.org/.
+The community forum is another good place for questions: https://community.signalusers.org/.
 
 
 ## Found a Bug? Have a feature request?

--- a/main.js
+++ b/main.js
@@ -338,7 +338,7 @@ function openSupportPage() {
 }
 
 function openForums() {
-  shell.openExternal('https://whispersystems.discoursehosting.net/');
+  shell.openExternal('https://community.signalusers.org/');
 }
 
 function setupWithImport() {


### PR DESCRIPTION
We recently changed our forum URL from https://whispersystems.discoursehosting.net/ to https://community.signalusers.org/. This change updates all our references in the app.