### PR TITLE
Don't pop conversations with timer change to top

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -675,7 +675,8 @@
         return collection.fetchConversation(this.id, 1).then(function() {
             var lastMessage = collection.at(0);
             if (lastMessage) {
-                if (lastMessage.get('type') === 'verified-change') {
+                var type = lastMessage.get('type');
+                if (type === 'verified-change' || lastMessage.get('expirationTimerUpdate')) {
                     return;
                 }
                 this.set({

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -676,7 +676,8 @@
             var lastMessage = collection.at(0);
             if (lastMessage) {
                 var type = lastMessage.get('type');
-                if (type === 'verified-change' || lastMessage.get('expirationTimerUpdate')) {
+                var shouldSkipUpdate = type === 'verified-change' || lastMessage.get('expirationTimerUpdate');
+                if (shouldSkipUpdate) {
                     return;
                 }
                 this.set({


### PR DESCRIPTION
When you link a new device, as of `v1.5.0` we get the disappearing messages status along with the initial contact/group sync. But this currently pops all conversations with a timer change to the top of the left pane. This change prevents that.