### PR TITLE
Hotfix: Ignore invalid expire timer sync resets

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -498,11 +498,17 @@
             }
 
             return wrapDeferred(conversation.save(updates)).then(function() {
-                if (typeof details.expireTimer !== 'undefined') {
+                const { expireTimer } = details;
+                const hasExpireTimer = typeof expireTimer !== 'undefined';
+                // TODO: Remove once
+                // https://github.com/signalapp/Signal-Desktop/issues/2079
+                // is resolved:
+                const isInvalidIOSExpireTimerReset = expireTimer === null;
+                if (hasExpireTimer && !isInvalidIOSExpireTimerReset) {
                     var source = textsecure.storage.user.getNumber();
                     var receivedAt = Date.now();
                     return conversation.updateExpirationTimer(
-                        details.expireTimer,
+                        expireTimer,
                         source,
                         receivedAt,
                         {fromSync: true}

--- a/js/background.js
+++ b/js/background.js
@@ -438,17 +438,24 @@
                     color: details.color,
                     active_at: activeAt,
                 })).then(function() {
-                    // this needs to be inline to get access to conversation model
-                    if (typeof details.expireTimer !== 'undefined') {
-                        var source = textsecure.storage.user.getNumber();
-                        var receivedAt = Date.now();
-                        return conversation.updateExpirationTimer(
-                            details.expireTimer,
-                            source,
-                            receivedAt,
-                            {fromSync: true}
+                    const { expireTimer } = details;
+                    const isValidExpireTimer = typeof expireTimer === 'number';
+                    if (!isValidExpireTimer) {
+                        console.log(
+                            'Ignore invalid expire timer.',
+                            'Expected numeric `expireTimer`, got:', expireTimer
                         );
+                        return;
                     }
+
+                    var source = textsecure.storage.user.getNumber();
+                    var receivedAt = Date.now();
+                    return conversation.updateExpirationTimer(
+                        expireTimer,
+                        source,
+                        receivedAt,
+                        {fromSync: true}
+                    );
                 });
             })
             .then(function() {
@@ -499,21 +506,23 @@
 
             return wrapDeferred(conversation.save(updates)).then(function() {
                 const { expireTimer } = details;
-                const hasExpireTimer = typeof expireTimer !== 'undefined';
-                // TODO: Remove once
-                // https://github.com/signalapp/Signal-Desktop/issues/2079
-                // is resolved:
-                const isInvalidIOSExpireTimerReset = expireTimer === null;
-                if (hasExpireTimer && !isInvalidIOSExpireTimerReset) {
-                    var source = textsecure.storage.user.getNumber();
-                    var receivedAt = Date.now();
-                    return conversation.updateExpirationTimer(
-                        expireTimer,
-                        source,
-                        receivedAt,
-                        {fromSync: true}
+                const isValidExpireTimer = typeof expireTimer === 'number';
+                if (!isValidExpireTimer) {
+                    console.log(
+                        'Ignore invalid expire timer.',
+                        'Expected numeric `expireTimer`, got:', expireTimer
                     );
+                    return;
                 }
+
+                var source = textsecure.storage.user.getNumber();
+                var receivedAt = Date.now();
+                return conversation.updateExpirationTimer(
+                    expireTimer,
+                    source,
+                    receivedAt,
+                    {fromSync: true}
+                );
             }).then(ev.confirm);
         });
     }

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -707,6 +707,8 @@
         console.log(
             'Updating expireTimer for conversation',
             this.idForLogging(),
+            'to',
+            expireTimer,
             'via',
             source
         );

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -457,6 +457,21 @@
                         message.set({expireTimer: dataMessage.expireTimer});
                     }
 
+                    // NOTE: Remove once the above uses
+                    // `Conversation::updateExpirationTimer`:
+                    const { expireTimer } = dataMessage;
+                    const shouldLogExpireTimerChange =
+                        message.isExpirationTimerUpdate() || expireTimer;
+                    if (shouldLogExpireTimerChange) {
+                        console.log(
+                            'Updating expireTimer for conversation',
+                            conversation.idForLogging(),
+                            'to',
+                            expireTimer,
+                            'via `handleDataMessage`'
+                        );
+                    }
+
                     if (!message.isEndSession() && !message.isGroupUpdate()) {
                         if (dataMessage.expireTimer) {
                             if (dataMessage.expireTimer !== conversation.get('expireTimer')) {


### PR DESCRIPTION
iOS omits `expireTimer` protobuf property to denote disappearing messages have been turned off. However, that doesn’t allow us to distinguish it from old clients that are not aware of this property. This change ignores these invalid values until we consistently use `0` to denote disabled disappearing messages.

- [x] Ignore non-numeric `expireTimer` values during contact sync. Long-term, we’ll use `0` to denote turning off expire timers.
- [x] Log what value `expireTimer` is set to.
- [x] Log changes to `expireTimer` in `handleDataMessage` until it uses `ConversationController::updateExpirationTimer`.