### PR TITLE
Ensure consistent builds using `yarn --frozen-lockfile`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - linux
 dist: trusty
 install:
-  - yarn install
+  - yarn install --frozen-lockfile
 script:
   - yarn run generate
   - yarn prepare-beta-build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,26 +48,25 @@ Now, run these commands in your preferred terminal in a good directory for devel
 ```
 git clone https://github.com/signalapp/Signal-Desktop.git
 cd Signal-Desktop
-npm install -g yarn      # (only if you don't already have yarn)
-npm install -g grunt-cli # (only if you don't already have grunt)
-yarn install             # Install and build dependencies (this will take a while)
-grunt                    # Generate final js/css assets
-yarn icon-gen            # Generate full set of icons for Electron
-yarn test                # A good idea to make sure tests run first
-yarn run start           # Run!
+npm install --global yarn      # (only if you don’t already have yarn)
+yarn install --frozen-lockfile # Install and build dependencies (this will take a while)
+yarn grunt                     # Generate final JS and CSS assets
+yarn icon-gen                  # Generate full set of icons for Electron
+yarn test                      # A good idea to make sure tests run first
+yarn start                     # Start Signal!
 ```
 
 You'll need to restart the application regularly to see your changes, as there is no
 automatic restart mechanism.
 
 Also, note that the assets loaded by the application are not necessarily the same files
-you're touching. You may not see your changes until you run `grunt` on the command-line
-like you did during setup. You can make it easier on yourself by generating the latest
-built assets when you change a file. Run this in its own terminal instance while you make
-changes:
+you're touching. You may not see your changes until you run `yarn grunt` on the
+command-line like you did during setup. You can make it easier on yourself by generating
+the latest built assets when you change a file. Run this in its own terminal instance
+while you make changes:
 
 ```
-grunt dev # runs until you stop it, re-generating built assets on file changes
+yarn grunt dev # runs until you stop it, re-generating built assets on file changes
 ```
 
 ## Setting up standalone

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - systeminfo | findstr /C:"OS"
   - set PATH=C:\Ruby23-x64\bin;%PATH%
   - ps: Install-Product node 8.2.1 x64
-  - yarn install
+  - yarn install --frozen-lockfile
 
 build_script:
   - yarn eslint


### PR DESCRIPTION
As recommended by documentation:
> If you need reproducible dependencies, which is usually the case with the
> continuous integration systems, you should pass `--frozen-lockfile` flag.
-- https://yarnpkg.com/lang/en/docs/cli/install/
