### PR TITLE
Remove ‘Ctrl+,’ keyboard shortcut on Windows & Linux

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -26,7 +26,6 @@ exports.createTemplate = (options, messages) => {
     submenu: [
       {
         label: messages.mainMenuSettings.message,
-        accelerator: 'CommandOrControl+,',
         click: showSettings,
       },
       {

--- a/test/app/fixtures/menu-windows-linux-setup.json
+++ b/test/app/fixtures/menu-windows-linux-setup.json
@@ -15,7 +15,6 @@
       },
       {
         "label": "Preferences…",
-        "accelerator": "CommandOrControl+,",
         "click": null
       },
       {

--- a/test/app/fixtures/menu-windows-linux.json
+++ b/test/app/fixtures/menu-windows-linux.json
@@ -4,7 +4,6 @@
     "submenu": [
       {
         "label": "Preferences…",
-        "accelerator": "CommandOrControl+,",
         "click": null
       },
       {


### PR DESCRIPTION
As discussed, `Ctrl+,` is not idiomatic on Windows & Linux.