### PR TITLE
Implemented control + enter functionality to add a newline

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -1098,6 +1098,19 @@
                 event.preventDefault();
                 return this.$('.bottom-bar form').submit();
             }
+            if (keyCode === 13 && event.ctrlKey) {
+                // we add a new line character
+                var txt = this.$('.bottom-bar textarea').val();
+                var start = this.$('.bottom-bar textarea')[0].selectionStart;
+                var end = this.$('.bottom-bar textarea')[0].selectionEnd;
+                txt = txt.substring(0, start) + "\r" + txt.substring(end, txt.length);
+                this.$('.bottom-bar textarea').val(txt);
+                // we reposition the cursor, prevent event default and return
+                this.$('.bottom-bar textarea')[0].selectionStart = start + 1;
+                this.$('.bottom-bar textarea')[0].selectionEnd = start + 1;
+                event.preventDefault();
+                return;
+            }
             this.toggleMicrophone();
             this.toggleLengthWarning();
 


### PR DESCRIPTION
### First time contributor checklist:
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)


### Contributor checklist:
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
- [x] My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
- [x] My changes are ready to be shipped to users


### Description

This is a small modification to allow to insert a newline in the textarea that sends message in conversations using control + enter.

There are no new tests and all the tests run by yarn test were successful.

I've tested in Ubuntu Linux 17.10 (desktop).