### PR TITLE
Autofix: Move Debug Logs From GitHub Gists to debuglogs.org

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,6 +16,7 @@ test/views/*.js
 
 # ES2015+ files
 !js/background.js
+!js/logging.js
 !js/models/conversations.js
 !js/views/attachment_view.js
 !js/views/conversation_search_view.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -20,6 +20,7 @@ test/views/*.js
 !js/models/conversations.js
 !js/views/attachment_view.js
 !js/views/conversation_search_view.js
+!js/views/debug_log_view.js
 !js/views/file_input_view.js
 !js/views/inbox_view.js
 !main.js

--- a/js/background.js
+++ b/js/background.js
@@ -1,7 +1,5 @@
 /* eslint-disable */
 
-/* eslint-env browser */
-
 /* global Backbone: false */
 /* global $: false */
 

--- a/js/logging.js
+++ b/js/logging.js
@@ -1,5 +1,7 @@
 /* eslint-env node */
 
+/* eslint strict: ['error', 'never'] */
+
 const electron = require('electron');
 const bunyan = require('bunyan');
 const _ = require('lodash');

--- a/js/logging.js
+++ b/js/logging.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 const electron = require('electron');
 const bunyan = require('bunyan');
 const _ = require('lodash');

--- a/js/logging.js
+++ b/js/logging.js
@@ -100,20 +100,20 @@ function format(entries) {
 }
 
 function fetch() {
-  return new Promise(((resolve) => {
+  return new Promise((resolve) => {
     ipc.send('fetch-log');
 
     ipc.on('fetched-log', (event, text) => {
       const result = `${getHeader()}\n${format(text)}`;
       resolve(result);
     });
-  }));
+  });
 }
 
 function publish(rawContent) {
   const content = rawContent || fetch();
 
-  return new Promise(((resolve) => {
+  return new Promise((resolve) => {
     const payload = textsecure.utils.jsonThing({
       files: {
         'debugLog.txt': {
@@ -129,7 +129,7 @@ function publish(rawContent) {
         resolve(response.html_url);
       })
       .fail(resolve);
-  }));
+  });
 }
 
 

--- a/js/logging.js
+++ b/js/logging.js
@@ -2,6 +2,9 @@
 
 /* eslint strict: ['error', 'never'] */
 
+/* global $: false */
+/* global textsecure: false */
+
 const electron = require('electron');
 const bunyan = require('bunyan');
 const _ = require('lodash');

--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -1,5 +1,3 @@
-/* eslint-env browser */
-
 /* global $: false */
 /* global _: false */
 /* global Backbone: false */

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -1,6 +1,3 @@
-/*
- * vim: ts=4:sw=4:expandtab
- */
 (function () {
   'use strict';
 

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -1,5 +1,3 @@
-/* eslint-env browser */
-
 /* global i18n: false */
 /* global Whisper: false */
 

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -1,3 +1,9 @@
+/* eslint-env browser */
+
+/* global i18n: false */
+/* global Whisper: false */
+
+// eslint-disable-next-line func-names
 (function () {
   'use strict';
 
@@ -22,6 +28,7 @@
       this.render();
       this.$('textarea').val(i18n('loading'));
 
+      // eslint-disable-next-line more/no-then
       window.log.fetch().then((text) => {
         this.$('textarea').val(text);
       });
@@ -47,7 +54,8 @@
       if (text.length === 0) {
         return;
       }
-      log.publish(text).then((url) => {
+      // eslint-disable-next-line more/no-then
+      window.log.publish(text).then((url) => {
         const view = new Whisper.DebugLogLinkView({
           url,
           el: this.$('.result'),

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -2,65 +2,65 @@
  * vim: ts=4:sw=4:expandtab
  */
 (function () {
-    'use strict';
-    window.Whisper = window.Whisper || {};
+  'use strict';
 
-    Whisper.DebugLogLinkView = Whisper.View.extend({
-        templateName: 'debug-log-link',
-        initialize: function(options) {
-            this.url = options.url;
-        },
-        render_attributes: function() {
-            return {
-                url: this.url,
-                reportIssue: i18n('reportIssue')
-            };
-        }
-    });
-    Whisper.DebugLogView = Whisper.View.extend({
-        templateName: 'debug-log',
-        className: 'debug-log modal',
-        initialize: function() {
-            this.render();
-            this.$('textarea').val(i18n('loading'));
+  window.Whisper = window.Whisper || {};
 
-            window.log.fetch().then(function(text) {
-                this.$('textarea').val(text);
-            }.bind(this));
-        },
-        events: {
-            'click .submit': 'submit',
-            'click .close': 'close'
-        },
-        render_attributes: {
-            title: i18n('submitDebugLog'),
-            cancel: i18n('cancel'),
-            submit: i18n('submit'),
-            close: i18n('gotIt'),
-            debugLogExplanation: i18n('debugLogExplanation')
-        },
-        close: function(e) {
-            e.preventDefault();
-            this.remove();
-        },
-        submit: function(e) {
-            e.preventDefault();
-            var text = this.$('textarea').val();
-            if (text.length === 0) {
-                return;
-            }
-            log.publish(text).then(function(url) {
-                var view = new Whisper.DebugLogLinkView({
-                    url: url,
-                    el: this.$('.result')
-                });
-                this.$('.loading').removeClass('loading');
-                view.render();
-                this.$('.link').focus().select();
-            }.bind(this));
-            this.$('.buttons, textarea').remove();
-            this.$('.result').addClass('loading');
-        }
-    });
+  Whisper.DebugLogLinkView = Whisper.View.extend({
+    templateName: 'debug-log-link',
+    initialize(options) {
+      this.url = options.url;
+    },
+    render_attributes() {
+      return {
+        url: this.url,
+        reportIssue: i18n('reportIssue'),
+      };
+    },
+  });
+  Whisper.DebugLogView = Whisper.View.extend({
+    templateName: 'debug-log',
+    className: 'debug-log modal',
+    initialize() {
+      this.render();
+      this.$('textarea').val(i18n('loading'));
 
-})();
+      window.log.fetch().then((text) => {
+        this.$('textarea').val(text);
+      });
+    },
+    events: {
+      'click .submit': 'submit',
+      'click .close': 'close',
+    },
+    render_attributes: {
+      title: i18n('submitDebugLog'),
+      cancel: i18n('cancel'),
+      submit: i18n('submit'),
+      close: i18n('gotIt'),
+      debugLogExplanation: i18n('debugLogExplanation'),
+    },
+    close(e) {
+      e.preventDefault();
+      this.remove();
+    },
+    submit(e) {
+      e.preventDefault();
+      const text = this.$('textarea').val();
+      if (text.length === 0) {
+        return;
+      }
+      log.publish(text).then((url) => {
+        const view = new Whisper.DebugLogLinkView({
+          url,
+          el: this.$('.result'),
+        });
+        this.$('.loading').removeClass('loading');
+        view.render();
+        this.$('.link').focus().select();
+      });
+      this.$('.buttons, textarea').remove();
+      this.$('.result').addClass('loading');
+    },
+  });
+}());


### PR DESCRIPTION
- [x] Apply ESLint autofixes in preparation of changes to debug log publish change.
- [x] Remove now unnecessary `/* eslint-env browser */` directives from some files. This is now part of our per-folder ESLint configuration.

Manual changes: https://github.com/signalapp/Signal-Desktop/pull/2111/files/77cc9b61c9e0ec4a4091e6e65e1096da3b6ee314..0cf64f5083263b44e12e6625fe14bef7a72e070c