### PR TITLE
Move Debug Logs From GitHub Gists to debuglogs.org

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,7 +103,9 @@ module.exports = function(grunt) {
         '!js/Mp3LameEncoder.min.js',
         '!js/libsignal-protocol-worker.js',
         '!js/components.js',
+        '!js/logging.js',
         '!js/modules/**/*.js',
+        '!js/views/debug_log_view.js',
         '!js/signal_protocol_store.js',
         '_locales/**/*'
       ],

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -367,8 +367,8 @@
       }
     },
     "submitDebugLog": {
-      "message": "Submit debug log",
-      "description": "Menu item and header text for debug log modal, title case."
+      "message": "Debug log",
+      "description": "Menu item and header text for debug log modal (sentence case)"
     },
     "debugLog": {
       "message": "Debug Log",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -386,9 +386,9 @@
       "message": "Go to Support Page",
       "description": "Item under the Help menu, takes you to the support page"
     },
-    "fileABug": {
-      "message": "File a Bug",
-      "description": "Item under the Help menu, takes you to GitHub new issue form"
+    "menuReportIssue": {
+      "message": "Report an Issue",
+      "description": "Item under the Help menu, takes you to GitHub new issue form (title case)"
     },
     "aboutSignalDesktop": {
       "message": "About Signal Desktop",

--- a/app/menu.js
+++ b/app/menu.js
@@ -130,7 +130,7 @@ exports.createTemplate = (options, messages) => {
         click: openSupportPage,
       },
       {
-        label: messages.fileABug.message,
+        label: messages.menuReportIssue.message,
         click: openNewBugForm,
       },
       {

--- a/js/focus_listener.js
+++ b/js/focus_listener.js
@@ -1,7 +1,7 @@
 (function () {
   'use strict';
 
-  var windowFocused;
+  var windowFocused = false;
   window.addEventListener('blur', function() {
     windowFocused = false;
   });
@@ -12,5 +12,4 @@
   window.isFocused = function() {
     return windowFocused;
   };
-
 })();

--- a/js/logging.js
+++ b/js/logging.js
@@ -5,7 +5,8 @@
 const electron = require('electron');
 const bunyan = require('bunyan');
 const _ = require('lodash');
-const superagent = require('superagent');
+
+const debuglogs = require('./modules/debuglogs');
 
 
 const ipc = electron.ipcRenderer;
@@ -108,26 +109,7 @@ function fetch() {
   });
 }
 
-const DEBUGLOGS_API_URL = 'https://debuglogs.org';
-const publish = async (content) => {
-  const credentialsResponse = await superagent.get(DEBUGLOGS_API_URL);
-  const { fields, url } = credentialsResponse.body;
-  const uploadRequest = superagent.post(url);
-  Object.entries(fields).forEach(([key, value]) => {
-    uploadRequest.field(key, value);
-  });
-
-  const contentBuffer = Buffer.from(content, 'utf8');
-  uploadRequest.attach('file', contentBuffer, {
-    contentType: 'text/plain',
-    filename: 'signal-desktop-debug-log.txt',
-  });
-
-  await uploadRequest;
-
-  return `${DEBUGLOGS_API_URL}/${fields.key}`;
-};
-
+const publish = debuglogs.upload;
 
 // A modern logging interface for the browser
 

--- a/js/logging.js
+++ b/js/logging.js
@@ -2,12 +2,10 @@
 
 /* eslint strict: ['error', 'never'] */
 
-/* global $: false */
-/* global textsecure: false */
-
 const electron = require('electron');
 const bunyan = require('bunyan');
 const _ = require('lodash');
+const superagent = require('superagent');
 
 
 const ipc = electron.ipcRenderer;
@@ -110,27 +108,25 @@ function fetch() {
   });
 }
 
-function publish(rawContent) {
-  const content = rawContent || fetch();
-
-  return new Promise((resolve) => {
-    const payload = textsecure.utils.jsonThing({
-      files: {
-        'debugLog.txt': {
-          content,
-        },
-      },
-    });
-
-    // eslint-disable-next-line more/no-then
-    $.post('https://api.github.com/gists', payload)
-      .then((response) => {
-        console._log('Posted debug log to ', response.html_url);
-        resolve(response.html_url);
-      })
-      .fail(resolve);
+const DEBUGLOGS_API_URL = 'https://debuglogs.org';
+const publish = async (content) => {
+  const credentialsResponse = await superagent.get(DEBUGLOGS_API_URL);
+  const { fields, url } = credentialsResponse.body;
+  const uploadRequest = superagent.post(url);
+  Object.entries(fields).forEach(([key, value]) => {
+    uploadRequest.field(key, value);
   });
-}
+
+  const contentBuffer = Buffer.from(content, 'utf8');
+  uploadRequest.attach('file', contentBuffer, {
+    contentType: 'text/plain',
+    filename: 'signal-desktop-debug-log.txt',
+  });
+
+  await uploadRequest;
+
+  return `${DEBUGLOGS_API_URL}/${fields.key}`;
+};
 
 
 // A modern logging interface for the browser

--- a/js/modules/debuglogs.js
+++ b/js/modules/debuglogs.js
@@ -26,8 +26,8 @@ exports.upload = async (content) => {
   const { fields, url } = signedForm.body;
 
   const form = new FormData();
+  // The API expects `key` to be the first field:
   form.append('key', fields.key);
-
   Object.entries(fields)
     .filter(([key]) => key !== 'key')
     .forEach(([key, value]) => {

--- a/js/modules/debuglogs.js
+++ b/js/modules/debuglogs.js
@@ -1,0 +1,48 @@
+/* eslint-env node */
+
+const FormData = require('form-data');
+const got = require('got');
+
+
+const BASE_URL = 'https://debuglogs.org';
+
+// Workaround: Submitting `FormData` using native `FormData::submit` procedure
+// as integration with `got` results in S3 error saying we haven’t set the
+// `Content-Length` header:
+const submitFormData = (form, url) =>
+  new Promise((resolve, reject) => {
+    form.submit(url, (error) => {
+      if (error) {
+        return reject(error);
+      }
+
+      return resolve();
+    });
+  });
+
+//      upload :: String -> Promise URL
+exports.upload = async (content) => {
+  const signedForm = await got.get(BASE_URL, { json: true });
+  const { fields, url } = signedForm.body;
+
+  const form = new FormData();
+  form.append('key', fields.key);
+
+  Object.entries(fields)
+    .filter(([key]) => key !== 'key')
+    .forEach(([key, value]) => {
+      form.append(key, value);
+    });
+
+  const contentBuffer = Buffer.from(content, 'utf8');
+  const contentType = 'text/plain';
+  form.append('Content-Type', contentType);
+  form.append('file', contentBuffer, {
+    contentType,
+    filename: 'signal-desktop-debug-log.txt',
+  });
+
+  await submitFormData(form, url);
+
+  return `${BASE_URL}/${fields.key}`;
+};

--- a/js/modules/debuglogs.js
+++ b/js/modules/debuglogs.js
@@ -9,6 +9,7 @@ const BASE_URL = 'https://debuglogs.org';
 // Workaround: Submitting `FormData` using native `FormData::submit` procedure
 // as integration with `got` results in S3 error saying we haven’t set the
 // `Content-Length` header:
+// https://github.com/sindresorhus/got/pull/466
 const submitFormData = (form, url) =>
   new Promise((resolve, reject) => {
     form.submit(url, (error) => {
@@ -42,6 +43,8 @@ exports.upload = async (content) => {
     filename: 'signal-desktop-debug-log.txt',
   });
 
+  // WORKAROUND: See comment on `submitFormData`:
+  // await got.post(url, { body: form });
   await submitFormData(form, url);
 
   return `${BASE_URL}/${fields.key}`;

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -46,24 +46,24 @@
       e.preventDefault();
       this.remove();
     },
-    submit(e) {
+    async submit(e) {
       e.preventDefault();
       const text = this.$('textarea').val();
       if (text.length === 0) {
         return;
       }
-      // eslint-disable-next-line more/no-then
-      window.log.publish(text).then((url) => {
-        const view = new Whisper.DebugLogLinkView({
-          url,
-          el: this.$('.result'),
-        });
-        this.$('.loading').removeClass('loading');
-        view.render();
-        this.$('.link').focus().select();
-      });
+
       this.$('.buttons, textarea').remove();
       this.$('.result').addClass('loading');
+
+      const publishedLogURL = await window.log.publish(text);
+      const view = new Whisper.DebugLogLinkView({
+        url: publishedLogURL,
+        el: this.$('.result'),
+      });
+      this.$('.loading').removeClass('loading');
+      view.render();
+      this.$('.link').focus().select();
     },
   });
 }());

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "emoji-panel": "https://github.com/scottnonnenberg/emoji-panel.git#v0.5.5",
     "firstline": "^1.2.1",
     "google-libphonenumber": "^3.0.7",
+    "got": "^8.2.0",
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "node-fetch": "https://github.com/scottnonnenberg/node-fetch.git#3e5f51e08c647ee5f20c43b15cf2d352d61c36b4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "rimraf": "^2.6.2",
     "semver": "^5.4.1",
     "spellchecker": "^3.4.4",
-    "superagent": "^3.8.2",
     "testcheck": "^1.0.0-rc.2",
     "websocket": "^1.0.25"
   },

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "rimraf": "^2.6.2",
     "semver": "^5.4.1",
     "spellchecker": "^3.4.4",
+    "superagent": "^3.8.2",
     "testcheck": "^1.0.0-rc.2",
     "websocket": "^1.0.25"
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "emoji-js": "^3.4.0",
     "emoji-panel": "https://github.com/scottnonnenberg/emoji-panel.git#v0.5.5",
     "firstline": "^1.2.1",
+    "form-data": "^2.3.2",
     "google-libphonenumber": "^3.0.7",
     "got": "^8.2.0",
     "lodash": "^4.17.4",

--- a/stylesheets/_debugLog.scss
+++ b/stylesheets/_debugLog.scss
@@ -15,6 +15,9 @@
         width: 100%;
         resize: none;
         min-height: 100px;
+
+        font-family: Monaco, Consolas, 'Courier New', Courier, monospace;
+        font-size: 12px;
       }
     }
   }

--- a/test/app/fixtures/menu-mac-os-setup.json
+++ b/test/app/fixtures/menu-mac-os-setup.json
@@ -172,7 +172,7 @@
         "click": null
       },
       {
-        "label": "File a Bug",
+        "label": "Report an Issue",
         "click": null
       }
     ]

--- a/test/app/fixtures/menu-mac-os.json
+++ b/test/app/fixtures/menu-mac-os.json
@@ -159,7 +159,7 @@
         "click": null
       },
       {
-        "label": "File a Bug",
+        "label": "Report an Issue",
         "click": null
       }
     ]

--- a/test/app/fixtures/menu-windows-linux-setup.json
+++ b/test/app/fixtures/menu-windows-linux-setup.json
@@ -119,7 +119,7 @@
         "click": null
       },
       {
-        "label": "File a Bug",
+        "label": "Report an Issue",
         "click": null
       },
       {

--- a/test/app/fixtures/menu-windows-linux.json
+++ b/test/app/fixtures/menu-windows-linux.json
@@ -108,7 +108,7 @@
         "click": null
       },
       {
-        "label": "File a Bug",
+        "label": "Report an Issue",
         "click": null
       },
       {

--- a/test/modules/debuglogs_test.js
+++ b/test/modules/debuglogs_test.js
@@ -1,0 +1,17 @@
+const { assert } = require('chai');
+const got = require('got');
+
+const debuglogs = require('../../js/modules/debuglogs');
+
+
+describe('debuglogs', () => {
+  describe('upload', () => {
+    it('should upload log content', async () => {
+      const nonce = Math.random().toString().slice(2);
+      const url = await debuglogs.upload(nonce);
+
+      const { body } = await got.get(url);
+      assert.equal(nonce, body);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,10 +916,6 @@ compare-version@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
 
-component-emitter@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
-
 compress-commons@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-1.2.2.tgz#524a9f10903f3a813389b0225d27c48bb751890f"
@@ -997,10 +993,6 @@ content-type@~1.0.1:
 convert-source-map@^1.3.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
-
-cookiejar@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
 core-js@^2.4.0:
   version "2.4.1"
@@ -1827,7 +1819,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-extend@3, extend@^3.0.0, extend@~3.0.1:
+extend@3, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -2039,9 +2031,6 @@ from2@^2.1.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
-formidable@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
 
 fs-extra-p@^4.5.0:
   version "4.5.0"
@@ -3496,10 +3485,6 @@ merge-source-map@^1.0.2:
   dependencies:
     source-map "^0.6.1"
 
-methods@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
-
 micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -3541,10 +3526,6 @@ mime-types@~2.1.17:
 mime@^1.3.4:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.0.tgz#69e9e0db51d44f2a3b56e48b7817d7d137f1a343"
-
-mime@^1.4.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mime@^2.2.0:
   version "2.2.0"
@@ -4309,10 +4290,6 @@ qs@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-5.2.0.tgz#a9f31142af468cb72b25b30136ba2456834916be"
 
-qs@^6.5.1, qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-
 qs@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-5.1.0.tgz#4d932e5c7ea411cca76a312d39a606200fd50cd9"
@@ -4320,6 +4297,10 @@ qs@~5.1.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 query-string@^5.0.1:
   version "5.1.0"
@@ -5106,21 +5087,6 @@ sumchecker@^2.0.1, sumchecker@^2.0.2:
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-2.0.2.tgz#0f42c10e5d05da5d42eea3e56c3399a37d6c5b3e"
   dependencies:
     debug "^2.2.0"
-
-superagent@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
-  dependencies:
-    component-emitter "^1.2.0"
-    cookiejar "^2.1.0"
-    debug "^3.1.0"
-    extend "^3.0.0"
-    form-data "^2.3.1"
-    formidable "^1.1.1"
-    methods "^1.1.1"
-    mime "^1.4.1"
-    qs "^6.5.1"
-    readable-stream "^2.0.5"
 
 supports-color@4.4.0, supports-color@^4.0.0:
   version "4.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,7 +2009,7 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@^2.3.1:
+form-data@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,10 @@
     "7zip-bin-mac" "~1.0.1"
     "7zip-bin-win" "~2.2.0"
 
+"@sindresorhus/is@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
@@ -650,6 +654,18 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
+cacheable-request@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
+  dependencies:
+    clone-response "1.0.2"
+    get-stream "3.0.0"
+    http-cache-semantics "3.8.1"
+    keyv "3.0.0"
+    lowercase-keys "1.0.0"
+    normalize-url "2.0.1"
+    responselike "1.0.2"
+
 caching-transform@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-1.0.1.tgz#6dbdb2f20f8d8fbce79f3e94e9d1742dcdf5c0a1"
@@ -819,6 +835,12 @@ cliui@^4.0.0:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
+
+clone-response@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  dependencies:
+    mimic-response "^1.0.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -1146,6 +1168,16 @@ debug@~2.2.0:
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  dependencies:
+    mimic-response "^1.0.0"
 
 decompress-zip@0.3.0:
   version "0.3.0"
@@ -2001,6 +2033,12 @@ form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+from2@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
 formidable@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
@@ -2138,7 +2176,7 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
-get-stream@^3.0.0:
+get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
@@ -2298,6 +2336,28 @@ got@^6.7.1:
     timed-out "^4.0.0"
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
+
+got@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-8.2.0.tgz#0d11a071d05046348a2f5c0a5fa047fb687fdfc6"
+  dependencies:
+    "@sindresorhus/is" "^0.7.0"
+    cacheable-request "^2.1.1"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    into-stream "^3.1.0"
+    is-retry-allowed "^1.1.0"
+    isurl "^1.0.0-alpha5"
+    lowercase-keys "^1.0.0"
+    mimic-response "^1.0.0"
+    p-cancelable "^0.3.0"
+    p-timeout "^2.0.1"
+    pify "^3.0.0"
+    safe-buffer "^5.1.1"
+    timed-out "^4.0.1"
+    url-parse-lax "^3.0.0"
+    url-to-options "^1.0.1"
 
 graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -2492,6 +2552,16 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-symbol-support-x@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
+
+has-to-string-tag-x@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz#a045ab383d7b4b2012a00148ab0aa5f290044d4d"
+  dependencies:
+    has-symbol-support-x "^1.4.1"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2560,6 +2630,10 @@ htmlparser2@3.8.3, htmlparser2@3.8.x:
     domutils "1.5"
     entities "1.0"
     readable-stream "1.1"
+
+http-cache-semantics@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
 
 http-errors@1.6.2:
   version "1.6.2"
@@ -2699,6 +2773,13 @@ inquirer@^3.0.6, inquirer@~3.3.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+into-stream@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
+  dependencies:
+    from2 "^2.1.1"
+    p-is-promise "^1.1.0"
+
 invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
@@ -2808,6 +2889,10 @@ is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
@@ -2823,6 +2908,10 @@ is-path-inside@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
   dependencies:
     path-is-inside "^1.0.1"
+
+is-plain-obj@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -2844,7 +2933,7 @@ is-resolvable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.1.tgz#acca1cd36dbe44b974b924321555a70ba03b1cf4"
 
-is-retry-allowed@^1.0.0:
+is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
@@ -2932,6 +3021,13 @@ istanbul-reports@^1.1.3:
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
   dependencies:
     handlebars "^4.0.3"
+
+isurl@^1.0.0-alpha5:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
+  dependencies:
+    has-to-string-tag-x "^1.2.0"
+    is-object "^1.0.1"
 
 jimp@^0.2.27:
   version "0.2.27"
@@ -3066,6 +3162,10 @@ jshint@~2.9.4:
     shelljs "0.3.x"
     strip-json-comments "1.0.x"
 
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
+
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
@@ -3135,6 +3235,12 @@ just-extend@^1.1.27:
 kew@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
+
+keyv@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
+  dependencies:
+    json-buffer "3.0.0"
 
 kind-of@^3.0.2:
   version "3.2.2"
@@ -3324,7 +3430,7 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lowercase-keys@^1.0.0:
+lowercase-keys@1.0.0, lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
@@ -3447,6 +3553,10 @@ mime@^2.2.0:
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -3688,6 +3798,14 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize-url@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
+  dependencies:
+    prepend-http "^2.0.0"
+    query-string "^5.0.1"
+    sort-keys "^2.0.0"
+
 npm-install-package@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/npm-install-package/-/npm-install-package-2.1.0.tgz#d7efe3cfcd7ab00614b896ea53119dc9ab259125"
@@ -3843,9 +3961,17 @@ osenv@0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-cancelable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
 
 p-limit@^1.1.0:
   version "1.1.0"
@@ -3860,6 +3986,12 @@ p-locate@^2.0.0:
 p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+
+p-timeout@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
+  dependencies:
+    p-finally "^1.0.0"
 
 pac-proxy-agent@^2.0.0:
   version "2.0.0"
@@ -4096,6 +4228,10 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -4184,6 +4320,14 @@ qs@~5.1.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+query-string@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.0.tgz#9583b15fd1307f899e973ed418886426a9976469"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 querystring@0.2.0:
   version "0.2.0"
@@ -4475,6 +4619,12 @@ resolve@^1.2.0:
   dependencies:
     path-parse "^1.0.5"
 
+responselike@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  dependencies:
+    lowercase-keys "^1.0.0"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -4696,6 +4846,12 @@ socks@^1.1.10, socks@~1.1.5:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
 
+sort-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 source-map-resolve@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.3.1.tgz#610f6122a445b8dd51535a2a71b783dfc1248761"
@@ -4847,6 +5003,10 @@ stream-to-buffer@^0.1.0:
 stream-to@~0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/stream-to/-/stream-to-0.2.2.tgz#84306098d85fdb990b9fa300b1b3ccf55e8ef01d"
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
 string-similarity@1.1.0:
   version "1.1.0"
@@ -5099,7 +5259,7 @@ thunkify@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
-timed-out@^4.0.0:
+timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
@@ -5286,11 +5446,21 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  dependencies:
+    prepend-http "^2.0.0"
+
 url-regex@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-3.2.0.tgz#dbad1e0c9e29e105dd0b1f09f6862f7fdb482724"
   dependencies:
     ip-regex "^1.0.1"
+
+url-to-options@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
 
 url@0.10.3:
   version "0.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,6 +858,12 @@ colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
+combined-stream@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -887,6 +893,10 @@ commondir@^1.0.1:
 compare-version@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
+
+component-emitter@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
 compress-commons@^1.2.0:
   version "1.2.2"
@@ -965,6 +975,10 @@ content-type@~1.0.1:
 convert-source-map@^1.3.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
+
+cookiejar@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
 core-js@^2.4.0:
   version "2.4.1"
@@ -1781,7 +1795,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-extend@3, extend@~3.0.1:
+extend@3, extend@^3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -1963,6 +1977,14 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
+form-data@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
@@ -1978,6 +2000,10 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formidable@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
 
 fs-extra-p@^4.5.0:
   version "4.5.0"
@@ -3364,6 +3390,10 @@ merge-source-map@^1.0.2:
   dependencies:
     source-map "^0.6.1"
 
+methods@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+
 micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -3405,6 +3435,10 @@ mime-types@~2.1.17:
 mime@^1.3.4:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.0.tgz#69e9e0db51d44f2a3b56e48b7817d7d137f1a343"
+
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mime@^2.2.0:
   version "2.2.0"
@@ -4139,6 +4173,10 @@ qs@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-5.2.0.tgz#a9f31142af468cb72b25b30136ba2456834916be"
 
+qs@^6.5.1, qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
 qs@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-5.1.0.tgz#4d932e5c7ea411cca76a312d39a606200fd50cd9"
@@ -4146,10 +4184,6 @@ qs@~5.1.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
-qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 querystring@0.2.0:
   version "0.2.0"
@@ -4912,6 +4946,21 @@ sumchecker@^2.0.1, sumchecker@^2.0.2:
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-2.0.2.tgz#0f42c10e5d05da5d42eea3e56c3399a37d6c5b3e"
   dependencies:
     debug "^2.2.0"
+
+superagent@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.1.1"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.0.5"
 
 supports-color@4.4.0, supports-color@^4.0.0:
   version "4.4.0"


### PR DESCRIPTION
In anticipation of GitHub’s deprecation of anonymous gists, we are moving our debug logs to https://debuglogs.org.

- [x] Publish debug logs to debuglogs.org.
- [x] Rename **Help > File a Bug** to **Report an Issue** for consistency with our debug log view as well as other apps such as Google Chrome.
- [x] Quickfix: Ensure `window.isFocused` always returns a boolean.

**Sample log:** https://debuglogs.org/0272bdd35288ed839ede88938a5290011150d42b56599efb5dd93ac80a2ac915