### PR TITLE
Disable all webviews, since we never intend to create them

### DIFF
--- a/main.js
+++ b/main.js
@@ -494,6 +494,13 @@ app.on('activate', () => {
   }
 });
 
+// Defense in depth. We never intend to open webviews, so this prevents it completely.
+app.on('web-contents-created', (createEvent, win) => {
+  win.on('will-attach-webview', (attachEvent) => {
+    attachEvent.preventDefault();
+  });
+});
+
 ipc.on('set-badge-count', (event, count) => {
   app.setBadgeCount(count);
 });


### PR DESCRIPTION
Simple change to ensure that a webview is never created. Since we don't run third-party javascript and have a strong CSP, this will never happen - we're adding it for future-proofing.