### PR TITLE
Chrome: Move Debug Logs From GitHub Gists to debuglogs.org 

### DIFF
--- a/background.html
+++ b/background.html
@@ -698,7 +698,7 @@ sudo apt update && sudo apt install signal-desktop
         </div>
         <div class='nav'>
           <div>
-            <a class='link debug-log'>{{ debugLogButton }}</a>
+            <a class='link submit-debug-log'>{{ debugLogButton }}</a>
           </div>
         </div>
       </div>
@@ -717,7 +717,7 @@ sudo apt update && sudo apt install signal-desktop
         </div>
         <div class='nav'>
           <div>
-            <a class='link debug-log'>{{ debugLogButton }}</a>
+            <a class='link submit-debug-log'>{{ debugLogButton }}</a>
           </div>
         </div>
       </div>

--- a/js/debugLog.js
+++ b/js/debugLog.js
@@ -63,25 +63,7 @@
             }
 
             return new Promise(function(resolve, reject) {
-                // NOTE: Fetching the signed form requires CORS headers
-                // on debuglogs.org:
-
-                // $.get(DEBUGLOGS_BASE_URL).then(function (signedForm) {
-
-                    var signedForm = {
-                      "url": "https://s3.amazonaws.com/signal-debug-logs",
-                      "fields": {
-                        "bucket": "signal-debug-logs",
-                        "X-Amz-Algorithm": "...",
-                        "X-Amz-Credential": "...",
-                        "X-Amz-Date": "...",
-                        "X-Amz-Security-Token": "...",
-                        "Policy": "...",
-                        "X-Amz-Signature": "...",
-                        "key": "..."
-                      }
-                    };
-
+                $.get(DEBUGLOGS_BASE_URL).then(function (signedForm) {
                     var url = signedForm.url;
                     var fields = signedForm.fields;
 
@@ -110,22 +92,20 @@
                             return;
                         }
 
-                        // NOTE: `request.status` is `0` and Chrome reports it
-                        // as CORS error because S3 bucket response does not
-                        // include CORS headers but the upload succeeds:
+                        if (request.status !== 204) {
+                            return reject(
+                                new Error('Failed to publish debug log. Status: ' +
+                                    request.statusText + ' (' + request.status + ')'
+                                )
+                            );
+                        }
 
-                        // if (request.status === 204) {
-                            return resolve(publishedLogURL);
-                        // }
-
-                        // return reject(
-                        //     new Error('Failed to publish debug log. Status: ' +
-                        //         request.statusText + ' (' + request.status + ')'
-                        //     )
-                        // );
+                        return resolve(publishedLogURL);
                     };
                     request.send(formData);
-                // });
+                }).fail(function () {
+                    reject(new Error('Failed to publish logs'));
+                });
             });
         };
 

--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -145,7 +145,7 @@
       'click .start': 'onClickStart',
       'click .installed': 'onClickInstalled',
       'click .choose': 'onClickChoose',
-      'click .debug-log': 'onClickDebugLog',
+      'click .submit-debug-log': 'onClickDebugLog',
       'click .cancel': 'onClickCancel',
     },
     initialize: function() {

--- a/manifest.json
+++ b/manifest.json
@@ -15,8 +15,7 @@
       {"fileSystem": ["write", "directory"]},
       "alarms",
       "fullscreen",
-      "audioCapture",
-      "https://s3.amazonaws.com/signal-debug-logs"
+      "audioCapture"
     ],
 
     "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,9 @@
       {"fileSystem": ["write", "directory"]},
       "alarms",
       "fullscreen",
-      "audioCapture"
+      "audioCapture",
+      "https://debuglogs.org/",
+      "https://s3.amazonaws.com/signal-debug-logs"
     ],
 
     "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,6 @@
       "alarms",
       "fullscreen",
       "audioCapture",
-      "https://debuglogs.org/",
       "https://s3.amazonaws.com/signal-debug-logs"
     ],
 


### PR DESCRIPTION
In anticipation of GitHub’s deprecation of anonymous gists, we are moving our debug logs to https://debuglogs.org.

- [x] Publish debug logs to debuglogs.org:
  - ~~Using jQuery v2.1.1-pre results in S3 error about invalid form data indicating our jQuery version (added in 2014) doesn’t serialize `FormData` correctly.~~
  - [x] Using vanilla XHR ~~results in CORS error indicating our S3 bucket doesn’t CORS headers but upload succeeds nonetheless.~~
- [x] Add CORS headers to https://debuglogs.org
- [x] Add CORS headers to S3 bucket (incl. `POST` requests): https://s3.amazonaws.com/signal-debug-logs

**Sample log:** https://debuglogs.org/76bf1d7fd9b88ad061d91f79914230e45dc123bc8d169e073f10adb5c1999d4e