### PR TITLE
Remove "Sending a keepalive message" message

### DIFF
--- a/libtextsecure/websocket-resources.js
+++ b/libtextsecure/websocket-resources.js
@@ -224,7 +224,6 @@
                 } else {
                     this.reset();
                 }
-                console.log('Sending a keepalive message');
                 this.wsr.sendRequest({
                     verb: 'GET',
                     path: this.path,


### PR DESCRIPTION
I left Signal open for weeks and now I’ve got more than 23 062 copies of this debug message in my system journal logs.

Removing debug message that is triggered every 55 second.

