### PR TITLE
Make 'submit debug log'/'try again' clickable on error screen

### DIFF
--- a/background.html
+++ b/background.html
@@ -733,10 +733,10 @@ sudo apt update && sudo apt install signal-desktop
         </div>
         <div class='nav'>
           <div>
-            <a class='button export'>{{ tryAgain }}</a>
+            <a class='button choose'>{{ tryAgain }}</a>
           </div>
           <div>
-            <a class='link debug-log'>{{ debugLogButton }}</a>
+            <a class='link submit-debug-log'>{{ debugLogButton }}</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
https://github.com/signalapp/Signal-Desktop/issues/2127 reported that after an export error happened, neither of the two buttons could be clicked. With this change, they are now clickable.