### PR TITLE
Use system UI font as default font before falling back to Roboto

### DIFF
--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -11,7 +11,7 @@ body {
   height: 100%;
   width: 100%;
   margin: 0;
-  font-family: $roboto;
+  font-family: $font;
   font-size: 14px;
   color: $grey_d;
 }

--- a/stylesheets/_variables.scss
+++ b/stylesheets/_variables.scss
@@ -28,8 +28,8 @@ $red: #EF8989;
   src: url('../fonts/Roboto-Bold.ttf') format('truetype');
   font-weight: bold;
 }
-$roboto: Roboto, 'Helvetica Neue', Arial, Helvetica, sans-serif;
-$roboto-light: Roboto-Light, 'Helvetica Neue', Arial, Helvetica, sans-serif;
+$font: system-ui, Roboto, 'Helvetica Neue', Arial, Helvetica, sans-serif;
+$font-light: system-ui, Roboto-Light, 'Helvetica Neue', Arial, Helvetica, sans-serif;
 
 $header-height: 64px;
 $button-height: 24px;


### PR DESCRIPTION
### First time contributor checklist:
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)


### Contributor checklist:
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
- [x] My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
- [x] My changes are ready to be shipped to users


### Description

This is an incredibly minor PR and changes the SCSS to use the `system-ui` meta font family for all UI elements. This font option was introduced in the [CSS Fonts Module Level 4](https://www.w3.org/TR/css-fonts-4/#system-ui-def) specification draft, and is [supported in Chromium 56+](https://www.chromestatus.com/feature/5640395337760768) (and thus Electron).

This was first raised and discussed in issue #1363. My main rationale for the change is to provide a more consistent experience for users. Since the Electron app generally behaves like a native program, I believe it should probably also use the system UI fonts, as native programs tend to do, and honor the users font preferences (If they have configured any).

I have not written any tests for this since I don't see how one could reasonably test this, but I'm open to suggestions.

I also considered moving the `sans-serif` font entry up in front of Roboto, but decided against it, as I'm not 100% sure how it would affect rendering for glyphs that are not included in the system font.

#### Examples
* [MacOS High Sierra (San Francisco Text)](https://user-images.githubusercontent.com/179393/37523923-a16de4a8-2928-11e8-9be9-3b9ea37bcb03.png)
* [Linux with custom font config (Fira Sans)](https://user-images.githubusercontent.com/179393/37523924-a18b4e12-2928-11e8-84da-e002a22abf7e.png)
* [Windows 10 (Segoe UI)](https://user-images.githubusercontent.com/179393/37523777-3bd25908-2928-11e8-8614-ae6747c5deff.png)