### PR TITLE
iOS Theme: Ensure conversation panel fills screen vertically

### DIFF
--- a/stylesheets/_ios.scss
+++ b/stylesheets/_ios.scss
@@ -79,6 +79,11 @@ $ios-border-color: rgba(0,0,0,0.1);
 
     .avatar { display: none; }
   }
+
+  .conversation .panel {
+    height: 100%;
+  }
+
   .settings h3,
   .menu-list li {
     text-transform: capitalize;


### PR DESCRIPTION
Fixes small regression from https://github.com/signalapp/Signal-Desktop/commit/ef041b29d0b1b1dc5e9ed3ede76d7ef48bdb71cb

**Before**

<img width="984" alt="signal_beta" src="https://user-images.githubusercontent.com/36971170/37543518-462dc350-2938-11e8-8153-2be753e2a5c7.png">

**After**

<img width="984" alt="signal_-_development" src="https://user-images.githubusercontent.com/36971170/37543559-5de6c50a-2938-11e8-9922-a5b270205e5f.png">


/ht @michaelkirk 