### PR TITLE
iOS Theme: Ensure first message is not cut off

### DIFF
--- a/stylesheets/_ios.scss
+++ b/stylesheets/_ios.scss
@@ -81,7 +81,10 @@ $ios-border-color: rgba(0,0,0,0.1);
   }
 
   .conversation .panel {
-    height: 100%;
+    position: absolute;
+    top: $header-height;
+    bottom: 0;
+    width: 100%;
   }
 
   .settings h3,


### PR DESCRIPTION
@scottnonnenberg Your previous observation was correct and my original attempt to fix this cut off the first message in a thread. This change seems more robust and handles that correctly.

Follow up to #2144.
Fixes #2149.