### PR TITLE
missing space

### DIFF
--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -420,7 +420,7 @@
         }
     },
     "joinedTheGroup": {
-        "message": "$name$a rejoint le groupe.",
+        "message": "$name$ a rejoint le groupe.",
         "description": "Shown in the conversation history when a single person joins the group",
         "placeholders": {
             "name": {
@@ -798,7 +798,7 @@
         "description": "Item under the Help menu, takes you to the support page"
     },
     "multipleJoinedTheGroup": {
-        "message": "$names$a rejoint le groupe.",
+        "message": "$names$ a rejoint le groupe.",
         "description": "Shown in the conversation history when more than one person joins the group",
         "placeholders": {
             "names": {


### PR DESCRIPTION
### First time contributor checklist:
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)


### Contributor checklist:
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
- [x] My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
- [x] My changes are ready to be shipped to users


### Description

When someone is added to a group, in french, the message to annnounce to everyone finishes by this : "Django Jannya rejoint le groupe." A space is missing : "Django Janny a rejoint le groupe."