### PR TITLE
Improve messaging duration database migration

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -39,6 +39,10 @@
       "message": "Loading...",
       "description": "Message shown on the loading screen before we've loaded any messages"
     },
+    "optimizingApplication": {
+      "message": "Optimizing application...",
+      "description": "Message shown on the loading screen while we are doing application optimizations"
+    },
     "chooseDirectory": {
       "message": "Choose folder",
       "description": "Button to allow the user to find a folder on disk"

--- a/background.html
+++ b/background.html
@@ -961,7 +961,7 @@
         <span class='dot'></span>
         <span class='dot'></span>
       </div>
-      <div class='message'>Loading...</div>
+      <div class='message'></div>
     </div>
   </div>
 

--- a/background.html
+++ b/background.html
@@ -951,7 +951,6 @@
   <script type='text/javascript' src='js/wall_clock_listener.js'></script>
   <script type='text/javascript' src='js/rotate_signed_prekey_listener.js'></script>
   <script type='text/javascript' src='js/keychange_listener.js'></script>
-  <script type='text/javascript' src='js/background.js'></script>
 </head>
 <body>
   <div class='app-loading-screen'>
@@ -965,5 +964,7 @@
       <div class='message'>Loading...</div>
     </div>
   </div>
+
+  <script type='text/javascript' src='js/background.js'></script>
 </body>
 </html>

--- a/js/background.js
+++ b/js/background.js
@@ -16,6 +16,7 @@
 
     const { Errors, Message } = window.Signal.Types;
     const { context: migrationsContext } = window.Signal.Migrations;
+    const { Views } = window.Signal;
 
     // Implicitly used in `indexeddb-backbonejs-adapter`:
     // https://github.com/signalapp/Signal-Desktop/blob/4033a9f8137e62ed286170ed5d4941982b1d3a64/components/indexeddb-backbonejs-adapter/backbone-indexeddb.js#L569
@@ -73,6 +74,8 @@
         return accountManager;
     };
 
+    const cancelInitializationMessage = Views.Initialization.setMessage();
+    console.log('Start IndexedDB migrations');
     storage.fetch();
 
     // We need this 'first' check because we don't want to start the app up any other time
@@ -137,6 +140,7 @@
             connect(true);
         });
 
+        cancelInitializationMessage();
         var appView = window.owsDesktopApp.appView = new Whisper.AppView({el: $('body')});
 
         Whisper.WallClockListener.init(Whisper.events);

--- a/js/modules/views/initialization.js
+++ b/js/modules/views/initialization.js
@@ -1,0 +1,33 @@
+/* eslint-env browser */
+
+/* global i18n: false */
+
+
+const OPTIMIZATION_MESSAGE_DISPLAY_THRESHOLD = 2000; // milliseconds
+
+// type Canceler = () => Eff Unit
+//
+//    setMessage :: Unit -> Eff (dom :: DOM) Canceler
+const setMessage = () => {
+  const message = document.querySelector('.app-loading-screen .message');
+  if (!message) {
+    return () => {};
+  }
+  message.innerText = i18n('loading');
+
+  const optimizingMessageTimeoutId = setTimeout(() => {
+    const innerMessage = document.querySelector('.app-loading-screen .message');
+    if (!innerMessage) {
+      return;
+    }
+    innerMessage.innerText = i18n('optimizingApplication');
+  }, OPTIMIZATION_MESSAGE_DISPLAY_THRESHOLD);
+
+  return () => {
+    clearTimeout(optimizingMessageTimeoutId);
+  };
+};
+
+module.exports = {
+  setMessage,
+};

--- a/preload.js
+++ b/preload.js
@@ -134,6 +134,8 @@
   window.Signal.Types.Message = require('./js/modules/types/message');
   window.Signal.Types.MIME = require('./js/modules/types/mime');
   window.Signal.Types.Settings = require('./js/modules/types/settings');
+  window.Signal.Views = {};
+  window.Signal.Views.Initialization = require('./js/modules/views/initialization');
 
   // We pull this in last, because the native module involved appears to be sensitive to
   //   /tmp mounted as noexec on Linux.

--- a/preload.js
+++ b/preload.js
@@ -113,13 +113,13 @@
   const readAttachmentData = Attachments.readData(attachmentsPath);
   const writeAttachmentData = Attachments.writeData(attachmentsPath);
 
-  window.Signal = window.Signal || {};
+  window.Signal = {};
   window.Signal.Logs = require('./js/modules/logs');
   window.Signal.OS = require('./js/modules/os');
   window.Signal.Backup = require('./js/modules/backup');
   window.Signal.Crypto = require('./js/modules/crypto');
 
-  window.Signal.Migrations = window.Signal.Migrations || {};
+  window.Signal.Migrations = {};
   // Injected context functions to keep `Message` agnostic from Electron:
   window.Signal.Migrations.context = {
     deleteAttachmentData,
@@ -128,7 +128,7 @@
   };
   window.Signal.Migrations.V17 = require('./js/modules/migrations/17');
 
-  window.Signal.Types = window.Signal.Types || {};
+  window.Signal.Types = {};
   window.Signal.Types.Attachment = require('./js/modules/types/attachment');
   window.Signal.Types.Errors = require('./js/modules/types/errors');
   window.Signal.Types.Message = require('./js/modules/types/message');


### PR DESCRIPTION
If database migration takes a long time, user should get better messaging. I picked ‘Optimizing application…’ based on other apps I’ve seen but I’m open to other suggestions.

**Implementation notes**
- Run `background.js` after DOM is ready. This simplifies various pieces of code and I don’t see any downside to it, but let me know if you do.