### PR TITLE
2043 expiry message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ Please write tests! Our testing framework is
 
 The easiest way to run all tests at once is `yarn test`.
 
-You can browser tests from the command line with `grunt unit-tests` or in an
+You can browse tests from the command line with `grunt unit-tests` or in an
 interactive session with `NODE_ENV=test yarn run start`. The `libtextsecure` tests are run
 similarly: `grunt lib-unit-tests` and `NODE_ENV=test-lib yarn run start`. You can tweak
 the appropriate `test.html` for both of these runs to get code coverage numbers via

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ So you wanna make a pull request? Please observe the following guidelines.
    automatically based on that file and then periodically uploaded to Transifex for
    translation.
  * [Rebase](https://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/) your
-   changes on the latest `master` branch, resolving any conflicts.
+   changes on the latest `development` branch, resolving any conflicts.
    This ensures that your changes will merge cleanly when you open your PR.
  * Be sure to add and run tests!
  * Make sure the diff between our master and your branch contains only the

--- a/background.html
+++ b/background.html
@@ -108,7 +108,7 @@
     </div>
   </script>
   <script type='text/x-tmpl-mustache' id='expired_alert'>
-    <a target='_blank' href='https://chrome.google.com/webstore/detail/bikioccmkafdpakkkcpdbppfkghcmihk'>
+    <a target='_blank' href='https://signal.org/download/'>
       <button class='upgrade'>{{ upgrade }}</button>
     </a>
     {{ expiredWarning }}

--- a/test/index.html
+++ b/test/index.html
@@ -78,7 +78,7 @@
     </div>
   </script>
   <script type='text/x-tmpl-mustache' id='expired_alert'>
-    <a target='_blank' href='https://chrome.google.com/webstore/detail/bikioccmkafdpakkkcpdbppfkghcmihk'>
+    <a target='_blank' href='https://signal.org/download/'>
       <button class='upgrade'>{{ upgrade }}</button>
     </a>
     {{ expiredWarning }}


### PR DESCRIPTION
### First time contributor checklist:
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)


### Contributor checklist:
- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/liliakai/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
- [x] My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
- [x] My changes are ready to be shipped to users


### Description

Fixes #2043. The notification that is shown when an installation is expired referred to the Chrome web store - it now refers to Signal.org/download. I tested this manually by setting changing the expiry check to `if(true)` and then clicking the update button. Note that I wasn't quite clear on what `index.html` did, so while I did change it I wasn't able to test that. I tested this on:

```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.4 LTS
Release:	16.04
Codename:	xenial
```

I also fixed a typo in the contribution guide, and specified that one has to rebase off of `development` instead of `master - because that is what is specified in the PR template.

Note that I'm aware that you usually first have to specify your intention to contribute in an issue and such, but I just thought it'd be fun to get to know the codebase a bit. Therefore feel free to reject this or tell me to do it in a completely different way or something.