### PR TITLE
Don't lock the Node version so strictly

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "spectron": "^3.8.0"
   },
   "engines": {
-    "node": "8.2.1"
+    "node": "^8.2.1"
   },
   "build": {
     "appId": "org.whispersystems.signal-desktop",


### PR DESCRIPTION
### First time contributor checklist:
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)


### Contributor checklist:
- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/liliakai/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
- [x] ~~~My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)~~~ skipped for obvious reasons
- [x] My changes are ready to be shipped to users


### Description

What the title says. This is particularly problematic because Yarn apparently errors (not warns) if the engine doesn't match; I just had a friend complain about this in a group chat.