### PR TITLE
Support Attachments On File System During Export + Import

### DIFF
--- a/app/attachments.js
+++ b/app/attachments.js
@@ -11,7 +11,7 @@ const PATH = 'attachments.noindex';
 //      getPath :: AbsolutePath -> AbsolutePath
 exports.getPath = (userDataPath) => {
   if (!isString(userDataPath)) {
-    throw new TypeError('`userDataPath` must be a string');
+    throw new TypeError('"userDataPath" must be a string');
   }
   return path.join(userDataPath, PATH);
 };
@@ -19,7 +19,7 @@ exports.getPath = (userDataPath) => {
 //      ensureDirectory :: AbsolutePath -> IO Unit
 exports.ensureDirectory = async (userDataPath) => {
   if (!isString(userDataPath)) {
-    throw new TypeError('`userDataPath` must be a string');
+    throw new TypeError('"userDataPath" must be a string');
   }
   await fse.ensureDir(exports.getPath(userDataPath));
 };
@@ -29,12 +29,12 @@ exports.ensureDirectory = async (userDataPath) => {
 //                      IO (Promise ArrayBuffer)
 exports.createReader = (root) => {
   if (!isString(root)) {
-    throw new TypeError('`root` must be a path');
+    throw new TypeError('"root" must be a path');
   }
 
   return async (relativePath) => {
     if (!isString(relativePath)) {
-      throw new TypeError('`relativePath` must be a string');
+      throw new TypeError('"relativePath" must be a string');
     }
 
     const absolutePath = path.join(root, relativePath);
@@ -48,12 +48,12 @@ exports.createReader = (root) => {
 //                      IO (Promise RelativePath)
 exports.createWriter = (root) => {
   if (!isString(root)) {
-    throw new TypeError('`root` must be a path');
+    throw new TypeError('"root" must be a path');
   }
 
   return async (arrayBuffer) => {
     if (!isArrayBuffer(arrayBuffer)) {
-      throw new TypeError('`arrayBuffer` must be an array buffer');
+      throw new TypeError('"arrayBuffer" must be an array buffer');
     }
 
     const buffer = Buffer.from(arrayBuffer);
@@ -71,12 +71,12 @@ exports.createWriter = (root) => {
 //                       IO Unit
 exports.createDeleter = (root) => {
   if (!isString(root)) {
-    throw new TypeError('`root` must be a path');
+    throw new TypeError('"root" must be a path');
   }
 
   return async (relativePath) => {
     if (!isString(relativePath)) {
-      throw new TypeError('`relativePath` must be a string');
+      throw new TypeError('"relativePath" must be a string');
     }
 
     const absolutePath = path.join(root, relativePath);
@@ -93,7 +93,7 @@ exports.createName = () => {
 //      getRelativePath :: String -> IO Path
 exports.getRelativePath = (name) => {
   if (!isString(name)) {
-    throw new TypeError('`name` must be a string');
+    throw new TypeError('"name" must be a string');
   }
 
   const prefix = name.slice(0, 2);

--- a/app/attachments.js
+++ b/app/attachments.js
@@ -43,10 +43,10 @@ exports.createReader = (root) => {
   };
 };
 
-//      createWriter :: AttachmentsPath ->
-//                      ArrayBuffer ->
-//                      IO (Promise RelativePath)
-exports.createWriter = (root) => {
+//      createWriterForNew :: AttachmentsPath ->
+//                            ArrayBuffer ->
+//                            IO (Promise RelativePath)
+exports.createWriterForNew = (root) => {
   if (!isString(root)) {
     throw new TypeError('"root" must be a path');
   }

--- a/app/attachments.js
+++ b/app/attachments.js
@@ -56,9 +56,33 @@ exports.createWriterForNew = (root) => {
       throw new TypeError('"arrayBuffer" must be an array buffer');
     }
 
-    const buffer = Buffer.from(arrayBuffer);
     const name = exports.createName();
     const relativePath = exports.getRelativePath(name);
+    return exports.createWriterForExisting(root)({
+      data: arrayBuffer,
+      path: relativePath,
+    });
+  };
+};
+
+//      createWriter :: AttachmentsPath ->
+//                      { data: ArrayBuffer, path: RelativePath } ->
+//                      IO (Promise RelativePath)
+exports.createWriterForExisting = (root) => {
+  if (!isString(root)) {
+    throw new TypeError('"root" must be a path');
+  }
+
+  return async ({ data: arrayBuffer, path: relativePath } = {}) => {
+    if (!isString(relativePath)) {
+      throw new TypeError('"relativePath" must be a path');
+    }
+
+    if (!isArrayBuffer(arrayBuffer)) {
+      throw new TypeError('"arrayBuffer" must be an array buffer');
+    }
+
+    const buffer = Buffer.from(arrayBuffer);
     const absolutePath = path.join(root, relativePath);
     await fse.ensureFile(absolutePath);
     await fse.writeFile(absolutePath, buffer);

--- a/js/modules/backup.js
+++ b/js/modules/backup.js
@@ -455,7 +455,7 @@ function _getAnonymousAttachmentFileName(message, index) {
 
 async function readAttachment(dir, attachment, name, options) {
   options = options || {};
-  const { key, encrypted } = options;
+  const { key } = options;
 
   const anonymousName = _sanitizeFileName(name);
   const targetPath = path.join(dir, anonymousName);
@@ -467,7 +467,8 @@ async function readAttachment(dir, attachment, name, options) {
 
   const data = await readFileAsArrayBuffer(targetPath);
 
-  if (encrypted && key) {
+  const isEncrypted = !_.isUndefined(key);
+  if (isEncrypted) {
     attachment.data = await crypto.decryptSymmetric(key, data);
   } else {
     attachment.data = data;
@@ -1208,9 +1209,7 @@ async function importFromDirectory(directory, options) {
           attachmentsDir,
         });
         const result = await importNonMessages(db, stagingDir, options);
-        await importConversations(db, stagingDir, Object.assign({}, options, {
-          encrypted: true,
-        }));
+        await importConversations(db, stagingDir, Object.assign({}, options));
 
         console.log('Done importing from backup!');
         return result;

--- a/js/modules/backup.js
+++ b/js/modules/backup.js
@@ -824,9 +824,9 @@ async function saveAllMessages(db, rawMessages) {
     return Promise.resolve();
   }
 
-  const { importMessage, upgradeMessageSchema } = Signal.Migrations;
+  const { writeMessageAttachments, upgradeMessageSchema } = Signal.Migrations;
   const importAndUpgrade = async message =>
-    upgradeMessageSchema(await importMessage(message));
+    upgradeMessageSchema(await writeMessageAttachments(message));
 
   const messages = await Promise.all(rawMessages.map(importAndUpgrade));
 

--- a/js/modules/backup.js
+++ b/js/modules/backup.js
@@ -499,11 +499,11 @@ async function writeAttachment(attachment, options) {
     throw new TypeError('"attachment.data" is required');
   }
 
-  const encrypted = await crypto.encryptSymmetric(key, attachment.data);
+  const ciphertext = await crypto.encryptSymmetric(key, attachment.data);
 
   const writer = await createFileAndWriter(dir, filename);
   const stream = createOutputStream(writer);
-  stream.write(Buffer.from(encrypted));
+  stream.write(Buffer.from(ciphertext));
   await stream.close();
 }
 
@@ -1092,8 +1092,8 @@ async function encryptFile(sourcePath, targetPath, options) {
   }
 
   const plaintext = await readFileAsArrayBuffer(sourcePath);
-  const encrypted = await crypto.encryptSymmetric(key, plaintext);
-  return writeFile(targetPath, encrypted);
+  const ciphertext = await crypto.encryptSymmetric(key, plaintext);
+  return writeFile(targetPath, ciphertext);
 }
 
 async function decryptFile(sourcePath, targetPath, options) {
@@ -1104,8 +1104,8 @@ async function decryptFile(sourcePath, targetPath, options) {
     throw new Error('Need key to do encryption!');
   }
 
-  const encrypted = await readFileAsArrayBuffer(sourcePath);
-  const plaintext = await crypto.decryptSymmetric(key, encrypted);
+  const ciphertext = await readFileAsArrayBuffer(sourcePath);
+  const plaintext = await crypto.decryptSymmetric(key, ciphertext);
   return writeFile(targetPath, Buffer.from(plaintext));
 }
 

--- a/js/modules/backup.js
+++ b/js/modules/backup.js
@@ -30,7 +30,7 @@ const {
 
 module.exports = {
   getDirectoryForExport,
-  backupToDirectory,
+  exportToDirectory,
   getDirectoryForImport,
   importFromDirectory,
   // for testing
@@ -1105,7 +1105,7 @@ function deleteAll(pattern) {
   return pify(rimraf)(pattern);
 }
 
-async function backupToDirectory(directory, options) {
+async function exportToDirectory(directory, options) {
   options = options || {};
 
   if (!options.key) {

--- a/js/modules/backup.js
+++ b/js/modules/backup.js
@@ -506,9 +506,11 @@ async function writeAttachment(attachment, options) {
   await stream.close();
 }
 
-async function writeAttachments(attachments, options) {
+async function writeAttachments(rawAttachments, options) {
   const { name } = options;
 
+  const { loadAttachmentData } = Signal.Migrations;
+  const attachments = await Promise.all(rawAttachments.map(loadAttachmentData));
   const promises = _.map(
     attachments,
     (attachment, index) => writeAttachment(attachment, Object.assign({}, options, {
@@ -626,7 +628,7 @@ async function exportConversation(db, conversation, options) {
         const jsonString = JSON.stringify(stringify(message));
         stream.write(jsonString);
 
-        if (attachments && attachments.length) {
+        if (attachments && attachments.length > 0) {
           const exportAttachments = () => writeAttachments(attachments, {
             dir: attachmentsDir,
             name,

--- a/js/modules/backup.js
+++ b/js/modules/backup.js
@@ -20,6 +20,7 @@ const archiver = require('archiver');
 const rimraf = require('rimraf');
 const electronRemote = require('electron').remote;
 
+const Attachment = require('./types/attachment');
 const crypto = require('./crypto');
 
 
@@ -491,6 +492,10 @@ async function writeAttachment(attachment, options) {
       console.log(`Skipping attachment ${filename}; already exists`);
       return;
     }
+  }
+
+  if (!Attachment.hasData(attachment)) {
+    throw new TypeError('"attachment.data" is required');
   }
 
   const encrypted = await crypto.encryptSymmetric(key, attachment.data);

--- a/js/modules/types/attachment/migrate_data_to_file_system.js
+++ b/js/modules/types/attachment/migrate_data_to_file_system.js
@@ -7,15 +7,15 @@ const {
 
 
 // type Context :: {
-//   writeAttachmentData :: ArrayBuffer -> Promise (IO Path)
+//   writeNewAttachmentData :: ArrayBuffer -> Promise (IO Path)
 // }
 //
 //      migrateDataToFileSystem :: Attachment ->
 //                                 Context ->
 //                                 Promise Attachment
-exports.migrateDataToFileSystem = async (attachment, { writeAttachmentData } = {}) => {
-  if (!isFunction(writeAttachmentData)) {
-    throw new TypeError('"writeAttachmentData" must be a function');
+exports.migrateDataToFileSystem = async (attachment, { writeNewAttachmentData } = {}) => {
+  if (!isFunction(writeNewAttachmentData)) {
+    throw new TypeError('"writeNewAttachmentData" must be a function');
   }
 
   const { data } = attachment;
@@ -32,7 +32,7 @@ exports.migrateDataToFileSystem = async (attachment, { writeAttachmentData } = {
       ` got: ${typeof attachment.data}`);
   }
 
-  const path = await writeAttachmentData(data);
+  const path = await writeNewAttachmentData(data);
 
   const attachmentWithoutData = omit(
     Object.assign({}, attachment, { path }),

--- a/js/modules/types/message.js
+++ b/js/modules/types/message.js
@@ -221,7 +221,7 @@ exports.createImporter = (writeExistingAttachmentData) => {
       }
 
       if (!isString(attachment.path)) {
-        throw new TypeError('"attachment.path" is required');
+        throw new TypeError('"attachment.path" is required during message import');
       }
     });
 

--- a/js/modules/types/message.js
+++ b/js/modules/types/message.js
@@ -187,10 +187,10 @@ exports.createAttachmentLoader = (loadAttachmentData) => {
   }));
 };
 
-//      createImporter :: (RelativePath -> IO Unit)
-//                        Message ->
-//                        IO (Promise Message)
-exports.createImporter = (writeExistingAttachmentData) => {
+//      createAttachmentDataWriter :: (RelativePath -> IO Unit)
+//                                    Message ->
+//                                    IO (Promise Message)
+exports.createAttachmentDataWriter = (writeExistingAttachmentData) => {
   if (!isFunction(writeExistingAttachmentData)) {
     throw new TypeError('"writeExistingAttachmentData" must be a function');
   }

--- a/js/modules/types/message.js
+++ b/js/modules/types/message.js
@@ -195,10 +195,12 @@ exports.createImporter = (writeExistingAttachmentData) => {
     throw new TypeError('"writeExistingAttachmentData" must be a function');
   }
 
-  return async (message) => {
-    if (!exports.isValid(message)) {
-      throw new TypeError('"message" is not valid');
+  return async (rawMessage) => {
+    if (!exports.isValid(rawMessage)) {
+      throw new TypeError('"rawMessage" is not valid');
     }
+
+    const message = exports.initializeSchemaVersion(rawMessage);
 
     const { attachments } = message;
     const hasAttachments = attachments && attachments.length > 0;

--- a/js/modules/types/message.js
+++ b/js/modules/types/message.js
@@ -209,9 +209,9 @@ exports.createAttachmentDataWriter = (writeExistingAttachmentData) => {
     }
 
     const lastVersionWithAttachmentDataInMemory = 2;
-    const willHaveAttachmentsSavedOnFileSystemDuringUpgrade =
+    const willAttachmentsGoToFileSystemOnUpgrade =
       message.schemaVersion <= lastVersionWithAttachmentDataInMemory;
-    if (willHaveAttachmentsSavedOnFileSystemDuringUpgrade) {
+    if (willAttachmentsGoToFileSystemOnUpgrade) {
       return message;
     }
 

--- a/js/modules/types/message.js
+++ b/js/modules/types/message.js
@@ -177,6 +177,16 @@ exports.upgradeSchema = async (message, { writeNewAttachmentData } = {}) => {
   );
 };
 
+exports.createAttachmentLoader = (loadAttachmentData) => {
+  if (!isFunction(loadAttachmentData)) {
+    throw new TypeError('`loadAttachmentData` is required');
+  }
+
+  return async message => (Object.assign({}, message, {
+    attachments: await Promise.all(message.attachments.map(loadAttachmentData)),
+  }));
+};
+
 //      createImporter :: (RelativePath -> IO Unit)
 //                        Message ->
 //                        IO (Promise Message)

--- a/js/modules/types/message.js
+++ b/js/modules/types/message.js
@@ -166,13 +166,13 @@ const toVersion3 = exports._withSchemaVersion(
 );
 
 // UpgradeStep
-exports.upgradeSchema = async (message, { writeAttachmentData } = {}) => {
-  if (!isFunction(writeAttachmentData)) {
-    throw new TypeError('`context.writeAttachmentData` is required');
+exports.upgradeSchema = async (message, { writeNewAttachmentData } = {}) => {
+  if (!isFunction(writeNewAttachmentData)) {
+    throw new TypeError('`context.writeNewAttachmentData` is required');
   }
 
   return toVersion3(
     await toVersion2(await toVersion1(await toVersion0(message))),
-    { writeAttachmentData }
+    { writeNewAttachmentData }
   );
 };

--- a/preload.js
+++ b/preload.js
@@ -113,11 +113,11 @@ window.ProxyAgent = require('proxy-agent');
 const attachmentsPath = Attachments.getPath(app.getPath('userData'));
 const deleteAttachmentData = Attachments.createDeleter(attachmentsPath);
 const readAttachmentData = Attachments.createReader(attachmentsPath);
-const writeAttachmentData = Attachments.createWriter(attachmentsPath);
+const writeNewAttachmentData = Attachments.createWriterForNew(attachmentsPath);
 
 // Injected context functions to keep `Message` agnostic from Electron:
 const upgradeSchemaContext = {
-  writeAttachmentData,
+  writeNewAttachmentData,
 };
 const upgradeMessageSchema = message =>
   Message.upgradeSchema(message, upgradeSchemaContext);

--- a/preload.js
+++ b/preload.js
@@ -114,6 +114,7 @@ const attachmentsPath = Attachments.getPath(app.getPath('userData'));
 const deleteAttachmentData = Attachments.createDeleter(attachmentsPath);
 const readAttachmentData = Attachments.createReader(attachmentsPath);
 const writeNewAttachmentData = Attachments.createWriterForNew(attachmentsPath);
+const writeExistingAttachmentData = Attachments.createWriterForExisting(attachmentsPath);
 
 // Injected context functions to keep `Message` agnostic from Electron:
 const upgradeSchemaContext = {
@@ -137,6 +138,8 @@ window.Signal.Migrations = {};
 window.Signal.Migrations.deleteAttachmentData =
   Attachment.deleteData(deleteAttachmentData);
 window.Signal.Migrations.getPlaceholderMigrations = getPlaceholderMigrations;
+window.Signal.Migrations.importMessage =
+  Message.createImporter(writeExistingAttachmentData);
 window.Signal.Migrations.loadAttachmentData = Attachment.loadData(readAttachmentData);
 window.Signal.Migrations.Migrations0DatabaseWithAttachmentData =
   require('./js/modules/migrations/migrations_0_database_with_attachment_data');

--- a/preload.js
+++ b/preload.js
@@ -116,6 +116,8 @@ const readAttachmentData = Attachments.createReader(attachmentsPath);
 const writeNewAttachmentData = Attachments.createWriterForNew(attachmentsPath);
 const writeExistingAttachmentData = Attachments.createWriterForExisting(attachmentsPath);
 
+const loadAttachmentData = Attachment.loadData(readAttachmentData);
+
 // Injected context functions to keep `Message` agnostic from Electron:
 const upgradeSchemaContext = {
   writeNewAttachmentData,
@@ -140,7 +142,7 @@ window.Signal.Migrations.deleteAttachmentData =
 window.Signal.Migrations.getPlaceholderMigrations = getPlaceholderMigrations;
 window.Signal.Migrations.importMessage =
   Message.createImporter(writeExistingAttachmentData);
-window.Signal.Migrations.loadAttachmentData = Attachment.loadData(readAttachmentData);
+window.Signal.Migrations.loadAttachmentData = loadAttachmentData;
 window.Signal.Migrations.Migrations0DatabaseWithAttachmentData =
   require('./js/modules/migrations/migrations_0_database_with_attachment_data');
 window.Signal.Migrations.Migrations1DatabaseWithoutAttachmentData =

--- a/preload.js
+++ b/preload.js
@@ -143,6 +143,7 @@ window.Signal.Migrations.getPlaceholderMigrations = getPlaceholderMigrations;
 window.Signal.Migrations.importMessage =
   Message.createImporter(writeExistingAttachmentData);
 window.Signal.Migrations.loadAttachmentData = loadAttachmentData;
+window.Signal.Migrations.loadMessage = Message.createAttachmentLoader(loadAttachmentData);
 window.Signal.Migrations.Migrations0DatabaseWithAttachmentData =
   require('./js/modules/migrations/migrations_0_database_with_attachment_data');
 window.Signal.Migrations.Migrations1DatabaseWithoutAttachmentData =

--- a/preload.js
+++ b/preload.js
@@ -140,8 +140,8 @@ window.Signal.Migrations = {};
 window.Signal.Migrations.deleteAttachmentData =
   Attachment.deleteData(deleteAttachmentData);
 window.Signal.Migrations.getPlaceholderMigrations = getPlaceholderMigrations;
-window.Signal.Migrations.importMessage =
-  Message.createImporter(writeExistingAttachmentData);
+window.Signal.Migrations.writeMessageAttachments =
+  Message.createAttachmentDataWriter(writeExistingAttachmentData);
 window.Signal.Migrations.loadAttachmentData = loadAttachmentData;
 window.Signal.Migrations.loadMessage = Message.createAttachmentLoader(loadAttachmentData);
 window.Signal.Migrations.Migrations0DatabaseWithAttachmentData =

--- a/scripts/start-backup
+++ b/scripts/start-backup
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [[ "$BACKUP" == "" ]]; then
+  echo "BACKUP environment variable is required"
+  exit 1
+fi
+
+if [[ "$PROFILE" == "" ]]; then
+  echo "PROFILE environment variable is required"
+  exit 1
+fi
+
+backupPath="$HOME/Library/Application Support/Signal-$BACKUP"
+profilePath="$HOME/Library/Application Support/Signal-$PROFILE"
+
+rm -rf "$profilePath" && \
+  cp -R "$backupPath" "$profilePath" && \
+  NODE_APP_INSTANCE="$PROFILE" yarn start

--- a/test/app/attachments_test.js
+++ b/test/app/attachments_test.js
@@ -13,7 +13,7 @@ const NAME_LENGTH = 64;
 const PATH_LENGTH = PREFIX_LENGTH + NUM_SEPARATORS + NAME_LENGTH;
 
 describe('Attachments', () => {
-  describe('createWriter', () => {
+  describe('createWriterForNew', () => {
     let tempRootDirectory = null;
     before(() => {
       tempRootDirectory = tmp.dirSync().name;
@@ -25,9 +25,12 @@ describe('Attachments', () => {
 
     it('should write file to disk and return path', async () => {
       const input = stringToArrayBuffer('test string');
-      const tempDirectory = path.join(tempRootDirectory, 'Attachments_createWriter');
+      const tempDirectory = path.join(
+        tempRootDirectory,
+        'Attachments_createWriterForNew'
+      );
 
-      const outputPath = await Attachments.createWriter(tempDirectory)(input);
+      const outputPath = await Attachments.createWriterForNew(tempDirectory)(input);
       const output = await fse.readFile(path.join(tempDirectory, outputPath));
 
       assert.lengthOf(outputPath, PATH_LENGTH);

--- a/test/app/attachments_test.js
+++ b/test/app/attachments_test.js
@@ -40,6 +40,39 @@ describe('Attachments', () => {
     });
   });
 
+  describe('createWriterForExisting', () => {
+    let tempRootDirectory = null;
+    before(() => {
+      tempRootDirectory = tmp.dirSync().name;
+    });
+
+    after(async () => {
+      await fse.remove(tempRootDirectory);
+    });
+
+    it('should write file to disk on given path and return path', async () => {
+      const input = stringToArrayBuffer('test string');
+      const tempDirectory = path.join(
+        tempRootDirectory,
+        'Attachments_createWriterForExisting'
+      );
+
+      const relativePath = Attachments.getRelativePath(Attachments.createName());
+      const attachment = {
+        path: relativePath,
+        data: input,
+      };
+      const outputPath =
+        await Attachments.createWriterForExisting(tempDirectory)(attachment);
+      const output = await fse.readFile(path.join(tempDirectory, outputPath));
+
+      assert.equal(outputPath, relativePath);
+
+      const inputBuffer = Buffer.from(input);
+      assert.deepEqual(inputBuffer, output);
+    });
+  });
+
   describe('createReader', () => {
     let tempRootDirectory = null;
     before(() => {

--- a/test/modules/types/attachment_test.js
+++ b/test/modules/types/attachment_test.js
@@ -120,14 +120,14 @@ describe('Attachment', () => {
       };
 
       const expectedAttachmentData = stringToArrayBuffer('Above us only sky');
-      const writeAttachmentData = async (attachmentData) => {
+      const writeNewAttachmentData = async (attachmentData) => {
         assert.deepEqual(attachmentData, expectedAttachmentData);
         return 'abc/abcdefgh123456789';
       };
 
       const actual = await Attachment.migrateDataToFileSystem(
         input,
-        { writeAttachmentData }
+        { writeNewAttachmentData }
       );
       assert.deepEqual(actual, expected);
     });
@@ -145,12 +145,12 @@ describe('Attachment', () => {
         size: 1111,
       };
 
-      const writeAttachmentData = async () =>
+      const writeNewAttachmentData = async () =>
         'abc/abcdefgh123456789';
 
       const actual = await Attachment.migrateDataToFileSystem(
         input,
-        { writeAttachmentData }
+        { writeNewAttachmentData }
       );
       assert.deepEqual(actual, expected);
     });
@@ -163,11 +163,11 @@ describe('Attachment', () => {
         size: 1111,
       };
 
-      const writeAttachmentData = async () =>
+      const writeNewAttachmentData = async () =>
         'abc/abcdefgh123456789';
 
       try {
-        await Attachment.migrateDataToFileSystem(input, { writeAttachmentData });
+        await Attachment.migrateDataToFileSystem(input, { writeNewAttachmentData });
       } catch (error) {
         assert.strictEqual(
           error.message,

--- a/test/modules/types/message_test.js
+++ b/test/modules/types/message_test.js
@@ -5,7 +5,7 @@ const { stringToArrayBuffer } = require('../../../js/modules/string_to_array_buf
 
 
 describe('Message', () => {
-  describe('createImporter', () => {
+  describe('createAttachmentDataWriter', () => {
     it('should ignore messages that didn’t go through attachment migration', async () => {
       const input = {
         body: 'Imagine there is no heaven…',
@@ -17,7 +17,8 @@ describe('Message', () => {
       };
       const writeExistingAttachmentData = () => {};
 
-      const actual = await Message.createImporter(writeExistingAttachmentData)(input);
+      const actual =
+        await Message.createAttachmentDataWriter(writeExistingAttachmentData)(input);
       assert.deepEqual(actual, expected);
     });
 
@@ -34,7 +35,8 @@ describe('Message', () => {
       };
       const writeExistingAttachmentData = () => {};
 
-      const actual = await Message.createImporter(writeExistingAttachmentData)(input);
+      const actual =
+        await Message.createAttachmentDataWriter(writeExistingAttachmentData)(input);
       assert.deepEqual(actual, expected);
     });
 
@@ -60,7 +62,8 @@ describe('Message', () => {
         assert.deepEqual(attachment.data, stringToArrayBuffer('It’s easy if you try'));
       };
 
-      const actual = await Message.createImporter(writeExistingAttachmentData)(input);
+      const actual =
+        await Message.createAttachmentDataWriter(writeExistingAttachmentData)(input);
       assert.deepEqual(actual, expected);
     });
   });

--- a/test/modules/types/message_test.js
+++ b/test/modules/types/message_test.js
@@ -5,6 +5,66 @@ const { stringToArrayBuffer } = require('../../../js/modules/string_to_array_buf
 
 
 describe('Message', () => {
+  describe('createImporter', () => {
+    it('should ignore messages that didn’t go through attachment migration', async () => {
+      const input = {
+        body: 'Imagine there is no heaven…',
+        schemaVersion: 2,
+      };
+      const expected = {
+        body: 'Imagine there is no heaven…',
+        schemaVersion: 2,
+      };
+      const writeExistingAttachmentData = () => {};
+
+      const actual = await Message.createImporter(writeExistingAttachmentData)(input);
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should ignore messages without attachments', async () => {
+      const input = {
+        body: 'Imagine there is no heaven…',
+        schemaVersion: 4,
+        attachments: [],
+      };
+      const expected = {
+        body: 'Imagine there is no heaven…',
+        schemaVersion: 4,
+        attachments: [],
+      };
+      const writeExistingAttachmentData = () => {};
+
+      const actual = await Message.createImporter(writeExistingAttachmentData)(input);
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should write attachments to file system on original path', async () => {
+      const input = {
+        body: 'Imagine there is no heaven…',
+        schemaVersion: 4,
+        attachments: [{
+          path: 'ab/abcdefghi',
+          data: stringToArrayBuffer('It’s easy if you try'),
+        }],
+      };
+      const expected = {
+        body: 'Imagine there is no heaven…',
+        schemaVersion: 4,
+        attachments: [{
+          path: 'ab/abcdefghi',
+        }],
+      };
+
+      const writeExistingAttachmentData = (attachment) => {
+        assert.equal(attachment.path, 'ab/abcdefghi');
+        assert.deepEqual(attachment.data, stringToArrayBuffer('It’s easy if you try'));
+      };
+
+      const actual = await Message.createImporter(writeExistingAttachmentData)(input);
+      assert.deepEqual(actual, expected);
+    });
+  });
+
   describe('initializeSchemaVersion', () => {
     it('should ignore messages with previously inherited schema', () => {
       const input = {

--- a/test/modules/types/message_test.js
+++ b/test/modules/types/message_test.js
@@ -85,7 +85,7 @@ describe('Message', () => {
 
       const expectedAttachmentData = stringToArrayBuffer('It’s easy if you try');
       const context = {
-        writeAttachmentData: async (attachmentData) => {
+        writeNewAttachmentData: async (attachmentData) => {
           assert.deepEqual(attachmentData, expectedAttachmentData);
           return 'abc/abcdefg';
         },


### PR DESCRIPTION
- [x] Load attachments into memory before export.
- [x] Save attachments to correct place in user profile upon import.
- [x] Upgrade message schema upon import.
- [x] Support both encrypted imports as well as unencrypted Chrome imports.

**Tests**

- [x] Export / import small database (25 messages) with some attachments already on disk (`schemaVersion >= 3`) and some not (`schemaVersion < 3`).
- [x] Import Chrome web app import (found and fixed issue with missing `schemaVersion`).
- [x] Export / import of real-world Signal Beta data (before: `IndexedDB` ~372MB / after: `IndexedDB` ~5.7MB / `attachments.noindex` ~234MB)
 
**Test commands:**

```javascript
// Export
let key = new Uint8Array([1, 3, 4, 5, 6, 7, 8, 11, 23, 34, 1, 34, 3, 5, 45, 45, 1, 3, 4, 5, 6, 7, 8, 11, 23, 34, 1, 34, 3, 5, 45, 45]);
Signal.Backup.exportToDirectory('/Users/<user>/Desktop/Signal-import-export-test', {key});

// Import
let key = new Uint8Array([1, 3, 4, 5, 6, 7, 8, 11, 23, 34, 1, 34, 3, 5, 45, 45, 1, 3, 4, 5, 6, 7, 8, 11, 23, 34, 1, 34, 3, 5, 45, 45]);
Signal.Backup.importFromDirectory('/Users/<user>/Desktop/Signal-import-export-test', {key});

// Import from Chrome
Signal.Backup.importFromDirectory('/Users/<user>/Desktop/Signal Export 2018 Apr 3 at 11.00.54 pm');
```