### PR TITLE
Hide “It’s Installed” until user installs standalone version

### DIFF
--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -139,6 +139,7 @@
     templateName: 'migration-flow-template',
     className: 'migration-flow',
     events: {
+      'click .install': 'onInstallClick',
       'click .install-mac': 'onClickMac',
       'click .install-windows': 'onClickWindows',
       'click .install-linux': 'onClickLinux',
@@ -242,6 +243,9 @@
     },
     onClickWindows: function() {
       console.log('Windows install link clicked');
+    },
+    onInstallClick: function() {
+      this.$el.find('.installed').css('visibility', 'visible');
     },
     onClickLinux: function() {
       var dialog = this.linuxInstructionsView = new LinuxInstructionsView({});

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -818,6 +818,7 @@ input[type=text], input[type=search], textarea {
       font-size: 20pt;
     }
   }
+
   a.link {
     display: block;
     cursor: pointer;
@@ -899,6 +900,10 @@ input[type=text], input[type=search], textarea {
     padding-bottom: 1em;
     padding-left: 20px;
     padding-right: 20px;
+  }
+
+  .installed {
+    visibility: hidden;
   }
 }
 

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -752,6 +752,8 @@ input[type=text]:active, input[type=text]:focus, input[type=search]:active, inpu
     padding-bottom: 1em;
     padding-left: 20px;
     padding-right: 20px; }
+  .migration-flow .installed {
+    visibility: hidden; }
 
 .inbox:focus {
   outline: none; }


### PR DESCRIPTION
Some of our users skipped over the installation screen as it wasn’t clear installation was a required action before proceeding.