### PR TITLE
Add border-radius to iOS quoted-message to fix MacOS render bug

### DIFF
--- a/stylesheets/_ios.scss
+++ b/stylesheets/_ios.scss
@@ -118,7 +118,10 @@ $ios-border-color: rgba(0,0,0,0.1);
     //   classes used in conversations.scss
     background-color: white !important;
     border: none !important;
-    border-radius: 0;
+    border-top-left-radius: 15px;
+    border-top-right-radius: 15px;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
 
     margin-top: 0px !important;
     margin-bottom: 0px;


### PR DESCRIPTION
We discovered that iOS quote bubbles rendered incorrectly only on some machines. But this change should fix it, either way.