### PR TITLE
Enable sending quoted replies, two fixes

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -373,6 +373,7 @@
         if (firstRun === true && deviceId != '1') {
             if (!storage.get('theme-setting') && textsecure.storage.get('userAgent') === 'OWI') {
                 storage.put('theme-setting', 'ios');
+                onChangeTheme();
             }
             var syncRequest = new textsecure.SyncRequest(textsecure.messaging, messageReceiver);
             Whisper.events.trigger('contactsync:begin');
@@ -394,6 +395,12 @@
         }
     }
 
+    function onChangeTheme() {
+        var view = window.owsDesktopApp.appView;
+        if (view) {
+            view.applyTheme();
+        }
+    }
     function onEmpty() {
         initialLoadComplete = true;
 

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1250,7 +1250,7 @@
         // If we already have a quoted message, then we exit early. If we don't have it,
         //   then we'll continue to look again for an in-memory message to use. Why? This
         //   will enable us to scroll to it when the user clicks.
-        if (messages.quotedMessage) {
+        if (message.quotedMessage) {
           return;
         }
 

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -456,8 +456,8 @@
       const contact = this.model.isIncoming() ? this.model.getContact() : null;
       const attachments = this.model.get('attachments');
 
-      // TODO: used for the feature flag below
-      // const hasErrors = errors && errors.length > 0;
+      const errors = this.model.get('errors');
+      const hasErrors = errors && errors.length > 0;
       const hasAttachments = attachments && attachments.length > 0;
       const hasBody = this.hasTextContents();
 
@@ -469,8 +469,7 @@
         avatar: (contact && contact.getAvatar()),
         profileName: (contact && contact.getProfileName()),
         innerBubbleClasses: this.isImageWithoutCaption() ? '' : 'with-tail',
-        // TODO: Turn this on when we're ready to enable sending quoted replies
-        hoverIcon: false, // !hasErrors,
+        hoverIcon: !hasErrors,
         hasAttachments,
         reply: i18n('replyToMessage'),
       }, this.render_partials()));


### PR DESCRIPTION
This removes the bit of code for `v1.8.0` that prevents the ability to quote messages.

It also fixes two other bugs:
1. When you sent a quote, you'd see a flicker in the thumbnails of the other quotes in the conversation. This is because we were re-fetching and re-rendering those thumbnails.
2. When you linked a new iOS device, the iOS theme would not show until restarting the app.
