### PR TITLE
styleguide: Make filesize and Signal.Util.GoogleChrome available

### DIFF
--- a/ts/styleguide/StyleGuideUtil.ts
+++ b/ts/styleguide/StyleGuideUtil.ts
@@ -107,6 +107,8 @@ import localeMessages from '../../_locales/en/messages.json';
 
 // @ts-ignore
 import { setup } from '../../js/modules/i18n';
+import * as Util from '../util';
+import filesize from 'filesize';
 
 const i18n = setup(locale, localeMessages);
 
@@ -137,6 +139,8 @@ parent.Signal.Types.MIME = MIME;
 parent.Signal.Components = {
   Quote,
 };
+parent.Signal.Util = Util;
+parent.filesize = filesize;
 
 parent.ConversationController._initialFetchComplete = true;
 parent.ConversationController._initialPromise = Promise.resolve();


### PR DESCRIPTION
Some recent refactors left the styleguide in the dust! This makes everything work once more.