### PR TITLE
Show 'You' in Android theme quotes instead of contact name

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -468,6 +468,10 @@
       "message": "Replying to You",
       "description": "Shown in iOS theme when someone else quotes a message from you"
     },
+    "you": {
+      "message": "You",
+      "description": "In Android theme, shown in quote if you or someone else replies to you"
+    },
     "replyingTo": {
       "message": "Replying to $name$",
       "description": "Shown in iOS theme when you or someone quotes to a message which is not from you",

--- a/ts/components/conversation/Quote.tsx
+++ b/ts/components/conversation/Quote.tsx
@@ -176,10 +176,32 @@ export class Quote extends React.Component<Props, {}> {
     );
   }
 
+  public renderAuthor() {
+    const {
+      authorColor,
+      authorProfileName,
+      authorTitle,
+      i18n,
+      isFromMe,
+    } = this.props;
+
+
+    const authorProfileElement = authorProfileName
+      ? <span className="profile-name">~{authorProfileName}</span>
+      : null;
+
+    return (
+      <div className={classnames(authorColor, 'author')}>
+        { isFromMe
+          ? i18n('you')
+          : <span>{authorTitle}{' '}{authorProfileElement}</span>
+        }
+      </div>
+    );
+  }
+
   public render() {
     const {
-      authorTitle,
-      authorProfileName,
       authorColor,
       onClick,
       isFromMe,
@@ -189,9 +211,6 @@ export class Quote extends React.Component<Props, {}> {
       return null;
     }
 
-    const authorProfileElement = authorProfileName
-      ? <span className="profile-name">~{authorProfileName}</span>
-      : null;
     const classes = classnames(
       authorColor,
       'quoted-message',
@@ -203,9 +222,7 @@ export class Quote extends React.Component<Props, {}> {
       <div onClick={onClick} className={classes}>
         <div className="primary">
           {this.renderIOSLabel()}
-          <div className={classnames(authorColor, 'author')}>
-            {authorTitle}{' '}{authorProfileElement}
-           </div>
+          {this.renderAuthor()}
           {this.renderText()}
         </div>
         {this.renderIconContainer()}


### PR DESCRIPTION
Instead of pulling information from the user's contacts (which doesn't always have their own contact set), we now show 'You' for quotes referencing the current user in the android theme. This mirrors 'Replying to Yourself' or 'Replying to You' shown in the iOS theme already.

Before:
![screen shot 2018-04-30 at 12 40 29 pm](https://user-images.githubusercontent.com/36971246/39446581-dcb77d1c-4c73-11e8-91b7-7f40e17e50ba.png)

After:
![screen shot 2018-04-30 at 12 39 26 pm](https://user-images.githubusercontent.com/36971246/39446580-dca25e50-4c73-11e8-82e5-738381d721f0.png)

