### PR TITLE
Strip Image Metadata

### DIFF
--- a/js/modules/types/attachment.js
+++ b/js/modules/types/attachment.js
@@ -47,6 +47,8 @@ exports.isValid = rawAttachment => {
 };
 
 // Upgrade steps
+// NOTE: This step strips all EXIF metadata from JPEG images as
+// part of re-encoding the image:
 exports.autoOrientJPEG = async attachment => {
   if (!MIME.isJPEG(attachment.contentType)) {
     return attachment;

--- a/js/modules/types/message.js
+++ b/js/modules/types/message.js
@@ -16,6 +16,8 @@ const PRIVATE = 'private';
 //   - Schema initialized
 // Version 1
 //   - Attachments: Auto-orient JPEG attachments using EXIF `Orientation` data.
+//     N.B. The process of auto-orient for JPEGs strips (loses) all existing
+//     EXIF metadata improving privacy, e.g. geolocation, camera make, etc.
 // Version 2
 //   - Attachments: Sanitize Unicode order override characters.
 // Version 3


### PR DESCRIPTION
Turns out that our JPEG auto-orient code already strips all image metadata.

- [x] Document that JPEG auto-orient strips EXIF metadata.