### PR TITLE
Increase attachment migration conversion speed by a factor of 3x

### DIFF
--- a/js/modules/idle_detector.js
+++ b/js/modules/idle_detector.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events');
 
 
-const POLL_INTERVAL_MS = 15 * 1000;
+const POLL_INTERVAL_MS = 5 * 1000;
 const IDLE_THRESHOLD_MS = 20;
 
 class IdleDetector extends EventEmitter {


### PR DESCRIPTION
This will speed up the attachment migration for existing users. Tested it locally and didn’t notice any negative impact as we still require 20ms time remaining from browser. We can tune this value based on beta user feedback.