### PR TITLE
Use Native Notifications on Windows 7

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -36,6 +36,7 @@ ts/**/*.js
 !js/logging.js
 !js/models/conversations.js
 !js/models/messages.js
+!js/notifications.js
 !js/views/attachment_view.js
 !js/views/backbone_wrapper_view.js
 !js/views/conversation_search_view.js

--- a/js/database.js
+++ b/js/database.js
@@ -1,6 +1,7 @@
-/* global Whisper: false */
-/* global Backbone: false */
 /* global _: false */
+/* global Backbone: false */
+
+/* global Whisper: false */
 
 // eslint-disable-next-line func-names
 (function() {

--- a/js/modules/os.js
+++ b/js/modules/os.js
@@ -1,7 +1,0 @@
-/* eslint-env node */
-
-exports.isMacOS = () => process.platform === 'darwin';
-
-exports.isLinux = () => process.platform === 'linux';
-
-exports.isWindows = () => process.platform === 'win32';

--- a/js/modules/types/settings.js
+++ b/js/modules/types/settings.js
@@ -1,3 +1,0 @@
-const OS = require('../os');
-
-exports.isAudioNotificationSupported = () => !OS.isLinux();

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -17,7 +17,7 @@
   window.Whisper = window.Whisper || {};
   const { Settings } = Signal.Types;
 
-  const SETTINGS = {
+  const SettingNames = {
     OFF: 'off',
     COUNT: 'count',
     NAME: 'name',
@@ -66,7 +66,7 @@
       }
 
       const setting = this.getSetting();
-      if (setting === SETTINGS.OFF) {
+      if (setting === SettingNames.OFF) {
         return;
       }
 
@@ -87,16 +87,16 @@
 
       const last = this.last();
       switch (setting) {
-        case SETTINGS.COUNT:
+        case SettingNames.COUNT:
           title = 'Signal';
           message = newMessageCount;
           break;
-        case SETTINGS.NAME:
+        case SettingNames.NAME:
           title = newMessageCount;
           message = `Most recent from ${last.get('title')}`;
           iconUrl = last.get('iconUrl');
           break;
-        case SETTINGS.MESSAGE:
+        case SettingNames.MESSAGE:
           if (numNotifications === 1) {
             title = last.get('title');
           } else {
@@ -137,7 +137,7 @@
       this.clear();
     },
     getSetting() {
-      return storage.get('notification-setting') || SETTINGS.MESSAGE;
+      return storage.get('notification-setting') || SettingNames.MESSAGE;
     },
     onRemove() {
       console.log('remove notification');

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -42,12 +42,14 @@
       const isAudioNotificationSupported = Settings.isAudioNotificationSupported();
       const numNotifications = this.length;
       const userSetting = this.getUserSetting();
+      const hasNotificationSupport = !Boolean(config.polyfillNotifications);
 
       const status = Signal.Notifications.getStatus({
-        isEnabled,
+        hasNotificationSupport,
         isAppFocused,
         isAudioNotificationEnabled,
         isAudioNotificationSupported,
+        isEnabled,
         numNotifications,
         userSetting,
       });
@@ -102,16 +104,7 @@
 
       drawAttention();
 
-      if (config.polyfillNotifications) {
-        nodeNotifier.notify({
-          title,
-          message,
-          sound: false,
-        });
-        nodeNotifier.on('click', () => {
-          last.get('conversationId');
-        });
-      } else {
+      if (hasNotificationSupport) {
         const notification = new Notification(title, {
           body: message,
           icon: iconUrl,
@@ -123,6 +116,15 @@
           this,
           last.get('conversationId')
         );
+      } else {
+        nodeNotifier.notify({
+          title,
+          message,
+          sound: false,
+        });
+        nodeNotifier.on('click', () => {
+          last.get('conversationId');
+        });
       }
 
       // We don't want to notify the user about these same messages again

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -3,7 +3,9 @@
 
 /* global config: false */
 /* global ConversationController: false */
+/* global drawAttention: false */
 /* global i18n: false */
+/* global isFocused: false */
 /* global Signal: false */
 /* global storage: false */
 /* global Whisper: false */
@@ -34,7 +36,7 @@
     },
     update() {
       const { isEnabled } = this;
-      const isFocused = window.isFocused();
+      const isAppFocused = isFocused();
       const isAudioNotificationEnabled =
         storage.get('audio-notification') || false;
       const isAudioNotificationSupported = Settings.isAudioNotificationSupported();
@@ -42,7 +44,7 @@
         isAudioNotificationSupported && isAudioNotificationEnabled;
       const numNotifications = this.length;
       console.log('Update notifications:', {
-        isFocused,
+        isAppFocused,
         isEnabled,
         numNotifications,
         shouldPlayNotificationSound,
@@ -57,7 +59,7 @@
         return;
       }
 
-      const isNotificationOmitted = isFocused;
+      const isNotificationOmitted = isAppFocused;
       if (isNotificationOmitted) {
         this.clear();
         return;
@@ -68,7 +70,7 @@
         return;
       }
 
-      window.drawAttention();
+      drawAttention();
 
       let title;
       let message;

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -1,7 +1,5 @@
 /* global Backbone: false */
-/* global nodeNotifier: false */
 
-/* global config: false */
 /* global ConversationController: false */
 /* global drawAttention: false */
 /* global i18n: false */
@@ -42,10 +40,8 @@
       const isAudioNotificationSupported = Settings.isAudioNotificationSupported();
       const numNotifications = this.length;
       const userSetting = this.getUserSetting();
-      const hasNotificationSupport = !Boolean(config.polyfillNotifications);
 
       const status = Signal.Notifications.getStatus({
-        hasNotificationSupport,
         isAppFocused,
         isAudioNotificationEnabled,
         isAudioNotificationSupported,
@@ -104,28 +100,14 @@
 
       drawAttention();
 
-      if (hasNotificationSupport) {
-        const notification = new Notification(title, {
-          body: message,
-          icon: iconUrl,
-          tag: 'signal',
-          silent: !status.shouldPlayNotificationSound,
-        });
+      const notification = new Notification(title, {
+        body: message,
+        icon: iconUrl,
+        tag: 'signal',
+        silent: !status.shouldPlayNotificationSound,
+      });
 
-        notification.onclick = this.onClick.bind(
-          this,
-          last.get('conversationId')
-        );
-      } else {
-        nodeNotifier.notify({
-          title,
-          message,
-          sound: false,
-        });
-        nodeNotifier.on('click', () => {
-          last.get('conversationId');
-        });
-      }
+      notification.onclick = () => this.onClick(last.get('conversationId'));
 
       // We don't want to notify the user about these same messages again
       this.clear();

--- a/main.js
+++ b/main.js
@@ -4,7 +4,6 @@ const os = require('os');
 
 const _ = require('lodash');
 const electron = require('electron');
-const semver = require('semver');
 
 const { BrowserWindow, app, Menu, shell, ipcMain: ipc } = electron;
 
@@ -99,17 +98,6 @@ const loadLocale = require('./app/locale').load;
 let logger;
 let locale;
 
-const WINDOWS_8 = '8.0.0';
-const osRelease = os.release();
-const polyfillNotifications =
-  os.platform() === 'win32' && semver.lt(osRelease, WINDOWS_8);
-console.log(
-  'OS Release:',
-  osRelease,
-  '- notifications polyfill?',
-  polyfillNotifications
-);
-
 function prepareURL(pathSegments) {
   return url.format({
     pathname: path.join.apply(null, pathSegments),
@@ -127,7 +115,6 @@ function prepareURL(pathSegments) {
       node_version: process.versions.node,
       hostname: os.hostname(),
       appInstance: process.env.NODE_APP_INSTANCE,
-      polyfillNotifications: polyfillNotifications ? true : undefined, // for stringify()
       proxyUrl: process.env.HTTPS_PROXY || process.env.https_proxy,
       importMode: importMode ? true : undefined, // for stringify()
     },

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/qs": "^6.5.1",
     "@types/react": "^16.3.1",
     "@types/react-dom": "^16.0.4",
+    "@types/semver": "^5.5.0",
     "@types/sinon": "^4.3.1",
     "arraybuffer-loader": "^1.0.3",
     "asar": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/qs": "^6.5.1",
     "@types/react": "^16.3.1",
     "@types/react-dom": "^16.0.4",
+    "@types/sinon": "^4.3.1",
     "arraybuffer-loader": "^1.0.3",
     "asar": "^0.14.0",
     "bower": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.21.0",
     "node-fetch": "https://github.com/scottnonnenberg/node-fetch.git#3e5f51e08c647ee5f20c43b15cf2d352d61c36b4",
-    "node-notifier": "^5.1.2",
     "os-locale": "^2.1.0",
     "pify": "^3.0.0",
     "proxy-agent": "^2.1.0",

--- a/preload.js
+++ b/preload.js
@@ -101,7 +101,6 @@ window.loadImage = require('blueimp-load-image');
 
 window.nodeBuffer = Buffer;
 window.nodeFetch = require('node-fetch');
-window.nodeNotifier = require('node-notifier');
 window.ProxyAgent = require('proxy-agent');
 
 // Note: when modifying this file, consider whether our React Components or Backbone Views

--- a/preload.js
+++ b/preload.js
@@ -200,7 +200,7 @@ window.Signal.Migrations.Migrations1DatabaseWithoutAttachmentData = require('./j
 
 window.Signal.Migrations.upgradeMessageSchema = upgradeMessageSchema;
 window.Signal.Notifications = require('./ts/notifications');
-window.Signal.OS = require('./js/modules/os');
+window.Signal.OS = require('./ts/OS');
 window.Signal.Settings = require('./js/modules/settings');
 window.Signal.Startup = require('./js/modules/startup');
 
@@ -211,7 +211,7 @@ window.Signal.Types.Errors = require('./js/modules/types/errors');
 
 window.Signal.Types.Message = Message;
 window.Signal.Types.MIME = require('./ts/types/MIME');
-window.Signal.Types.Settings = require('./js/modules/types/settings');
+window.Signal.Types.Settings = require('./ts/types/Settings');
 window.Signal.Util = require('./ts/util');
 
 window.Signal.Views = {};

--- a/preload.js
+++ b/preload.js
@@ -200,6 +200,7 @@ window.Signal.Migrations.Migrations0DatabaseWithAttachmentData = require('./js/m
 window.Signal.Migrations.Migrations1DatabaseWithoutAttachmentData = require('./js/modules/migrations/migrations_1_database_without_attachment_data');
 
 window.Signal.Migrations.upgradeMessageSchema = upgradeMessageSchema;
+window.Signal.Notifications = require('./ts/notifications');
 window.Signal.OS = require('./js/modules/os');
 window.Signal.Settings = require('./js/modules/settings');
 window.Signal.Startup = require('./js/modules/startup');

--- a/ts/OS.ts
+++ b/ts/OS.ts
@@ -1,0 +1,15 @@
+import is from '@sindresorhus/is';
+import os from 'os';
+import semver from 'semver';
+
+export const isMacOS = () => process.platform === 'darwin';
+export const isLinux = () => process.platform === 'linux';
+export const isWindows = (minVersion?: string) => {
+  const isPlatformValid = process.platform === 'win32';
+  const osRelease = os.release();
+  const isVersionValid = is.undefined(minVersion)
+    ? true
+    : semver.gte(osRelease, minVersion);
+
+  return isPlatformValid && isVersionValid;
+};

--- a/ts/notifications/getStatus.ts
+++ b/ts/notifications/getStatus.ts
@@ -1,0 +1,60 @@
+interface Environment {
+  isAppFocused: boolean;
+  isAudioNotificationEnabled: boolean;
+  isAudioNotificationSupported: boolean;
+  isEnabled: boolean;
+  numNotifications: number;
+  userSetting: UserSetting;
+}
+
+interface Status {
+  shouldClearNotifications: boolean;
+  shouldPlayNotificationSound: boolean;
+  shouldShowNotifications: boolean;
+  type: Type;
+}
+
+type UserSetting = 'off' | 'count' | 'name' | 'message';
+
+type Type =
+  | 'ok'
+  | 'disabled'
+  | 'appIsFocused'
+  | 'noNotifications'
+  | 'userSetting';
+
+export const getStatus = (environment: Environment): Status => {
+  const type = ((): Type => {
+    if (!environment.isEnabled) {
+      return 'disabled';
+    }
+
+    const hasNotifications = environment.numNotifications > 0;
+    if (!hasNotifications) {
+      return 'noNotifications';
+    }
+
+    if (environment.isAppFocused) {
+      return 'appIsFocused';
+    }
+
+    if (environment.userSetting === 'off') {
+      return 'userSetting';
+    }
+
+    return 'ok';
+  })();
+
+  const shouldPlayNotificationSound =
+    environment.isAudioNotificationSupported &&
+    environment.isAudioNotificationEnabled;
+  const shouldShowNotifications = type === 'ok';
+  const shouldClearNotifications = type === 'appIsFocused';
+
+  return {
+    shouldClearNotifications,
+    shouldPlayNotificationSound,
+    shouldShowNotifications,
+    type,
+  };
+};

--- a/ts/notifications/getStatus.ts
+++ b/ts/notifications/getStatus.ts
@@ -4,7 +4,6 @@ interface Environment {
   isAudioNotificationSupported: boolean;
   isEnabled: boolean;
   numNotifications: number;
-  hasNotificationSupport: boolean;
   userSetting: UserSetting;
 }
 
@@ -12,7 +11,6 @@ interface Status {
   shouldClearNotifications: boolean;
   shouldPlayNotificationSound: boolean;
   shouldShowNotifications: boolean;
-  hasNotificationSupport: boolean;
   type: Type;
 }
 
@@ -26,7 +24,6 @@ type Type =
   | 'userSetting';
 
 export const getStatus = ({
-  hasNotificationSupport,
   isAppFocused,
   isAudioNotificationEnabled,
   isAudioNotificationSupported,
@@ -56,14 +53,11 @@ export const getStatus = ({
   })();
 
   const shouldPlayNotificationSound =
-    isAudioNotificationSupported &&
-    isAudioNotificationEnabled &&
-    hasNotificationSupport;
+    isAudioNotificationSupported && isAudioNotificationEnabled;
   const shouldShowNotifications = type === 'ok';
   const shouldClearNotifications = type === 'appIsFocused';
 
   return {
-    hasNotificationSupport,
     shouldClearNotifications,
     shouldPlayNotificationSound,
     shouldShowNotifications,

--- a/ts/notifications/getStatus.ts
+++ b/ts/notifications/getStatus.ts
@@ -4,6 +4,7 @@ interface Environment {
   isAudioNotificationSupported: boolean;
   isEnabled: boolean;
   numNotifications: number;
+  hasNotificationSupport: boolean;
   userSetting: UserSetting;
 }
 
@@ -11,6 +12,7 @@ interface Status {
   shouldClearNotifications: boolean;
   shouldPlayNotificationSound: boolean;
   shouldShowNotifications: boolean;
+  hasNotificationSupport: boolean;
   type: Type;
 }
 
@@ -23,22 +25,30 @@ type Type =
   | 'noNotifications'
   | 'userSetting';
 
-export const getStatus = (environment: Environment): Status => {
+export const getStatus = ({
+  hasNotificationSupport,
+  isAppFocused,
+  isAudioNotificationEnabled,
+  isAudioNotificationSupported,
+  isEnabled,
+  numNotifications,
+  userSetting,
+}: Environment): Status => {
   const type = ((): Type => {
-    if (!environment.isEnabled) {
+    if (!isEnabled) {
       return 'disabled';
     }
 
-    const hasNotifications = environment.numNotifications > 0;
+    const hasNotifications = numNotifications > 0;
     if (!hasNotifications) {
       return 'noNotifications';
     }
 
-    if (environment.isAppFocused) {
+    if (isAppFocused) {
       return 'appIsFocused';
     }
 
-    if (environment.userSetting === 'off') {
+    if (userSetting === 'off') {
       return 'userSetting';
     }
 
@@ -46,12 +56,14 @@ export const getStatus = (environment: Environment): Status => {
   })();
 
   const shouldPlayNotificationSound =
-    environment.isAudioNotificationSupported &&
-    environment.isAudioNotificationEnabled;
+    isAudioNotificationSupported &&
+    isAudioNotificationEnabled &&
+    hasNotificationSupport;
   const shouldShowNotifications = type === 'ok';
   const shouldClearNotifications = type === 'appIsFocused';
 
   return {
+    hasNotificationSupport,
     shouldClearNotifications,
     shouldPlayNotificationSound,
     shouldShowNotifications,

--- a/ts/notifications/index.ts
+++ b/ts/notifications/index.ts
@@ -1,0 +1,3 @@
+import { getStatus } from './getStatus';
+
+export { getStatus };

--- a/ts/test/types/Settings_test.ts
+++ b/ts/test/types/Settings_test.ts
@@ -23,6 +23,21 @@ describe('Settings', () => {
     });
 
     context('on Windows', () => {
+      context('version 7', () => {
+        beforeEach(() => {
+          sandbox.stub(process, 'platform').value('win32');
+          sandbox.stub(os, 'release').returns('7.0.0');
+        });
+
+        afterEach(() => {
+          sandbox.restore();
+        });
+
+        it('should return false', () => {
+          assert.isFalse(Settings.isAudioNotificationSupported());
+        });
+      });
+
       context('version 8+', () => {
         beforeEach(() => {
           sandbox.stub(process, 'platform').value('win32');

--- a/ts/test/types/Settings_test.ts
+++ b/ts/test/types/Settings_test.ts
@@ -1,7 +1,8 @@
-const sinon = require('sinon');
-const { assert } = require('chai');
+import os from 'os';
+import sinon from 'sinon';
+import { assert } from 'chai';
 
-const Settings = require('../../../js/modules/types/settings');
+import * as Settings from '../../../ts/types/Settings';
 
 describe('Settings', () => {
   const sandbox = sinon.createSandbox();
@@ -22,16 +23,19 @@ describe('Settings', () => {
     });
 
     context('on Windows', () => {
-      beforeEach(() => {
-        sandbox.stub(process, 'platform').value('win32');
-      });
+      context('version 8+', () => {
+        beforeEach(() => {
+          sandbox.stub(process, 'platform').value('win32');
+          sandbox.stub(os, 'release').returns('8.0.0');
+        });
 
-      afterEach(() => {
-        sandbox.restore();
-      });
+        afterEach(() => {
+          sandbox.restore();
+        });
 
-      it('should return true', () => {
-        assert.isTrue(Settings.isAudioNotificationSupported());
+        it('should return true', () => {
+          assert.isTrue(Settings.isAudioNotificationSupported());
+        });
       });
     });
 

--- a/ts/types/Settings.ts
+++ b/ts/types/Settings.ts
@@ -1,0 +1,4 @@
+import * as OS from '../OS';
+
+export const isAudioNotificationSupported = () =>
+  OS.isWindows() || OS.isMacOS();

--- a/ts/types/Settings.ts
+++ b/ts/types/Settings.ts
@@ -1,4 +1,6 @@
 import * as OS from '../OS';
 
+const MIN_WINDOWS_VERSION = '8.0.0';
+
 export const isAudioNotificationSupported = () =>
-  OS.isWindows() || OS.isMacOS();
+  OS.isWindows(MIN_WINDOWS_VERSION) || OS.isMacOS();

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,6 +83,10 @@
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.1.tgz#6f6aaffaf7dba502ff5ca15e4aa18caee9b04995"
 
+"@types/semver@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
+
 "@types/sinon@^4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-4.3.1.tgz#32458f9b166cd44c23844eee4937814276f35199"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,10 +3789,6 @@ growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
 
-growly@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-
 grunt-cli@^1.2.0, grunt-cli@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/grunt-cli/-/grunt-cli-1.2.0.tgz#562b119ebb069ddb464ace2845501be97b35b6a8"
@@ -5881,15 +5877,6 @@ node-libs-browser@^2.0.0:
     url "^0.11.0"
     util "^0.10.3"
     vm-browserify "0.0.4"
-
-node-notifier@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
-  dependencies:
-    growly "^1.3.0"
-    semver "^5.3.0"
-    shellwords "^0.1.0"
-    which "^1.2.12"
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -7997,10 +7984,6 @@ shelljs@0.3.x:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
 
-shellwords@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
-
 signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -9507,7 +9490,7 @@ which@1, which@^1.2.9, which@~1.2.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.3.0:
+which@^1.2.10, which@^1.2.14, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,6 +83,10 @@
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.1.tgz#6f6aaffaf7dba502ff5ca15e4aa18caee9b04995"
 
+"@types/sinon@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-4.3.1.tgz#32458f9b166cd44c23844eee4937814276f35199"
+
 "@vxna/mini-html-webpack-template@^0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@vxna/mini-html-webpack-template/-/mini-html-webpack-template-0.1.6.tgz#64225d564da5fe610b6445523c245572923c00b8"


### PR DESCRIPTION
- [x] Test notifications on Windows 7.
- [x] Switch to Electron native notifications on Window 7.
- [x] Disable **Play audio notification** setting on Windows 7 since they are not natively supported.
- [x] Improve logging for notification status.
- [x] Investigate whether Electron notification support choosing custom sound on Windows. Answer: no. Source: https://github.com/electron/electron/blob/82329124ffcb2012d101c79236e82fbe6ba79c36/docs/api/notification.md#new-notificationoptions-experimental
- [x] Remove `node-notifier`.
- [x] **Infrastructure:** Port `OS` and `types/Settings` to TypeScript.
- [x] Add support for specifying minimum Windows version with `OS.isWindows(minVersion?: string)`.
