### PR TITLE
Windows 7 Notifications: Disable Grouping

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,4 @@ end_of_line = lf
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[{js/modules/**/*.js, ts/**/*.ts, test/app/**/*.js, test/modules/**/*.js}]
 indent_size = 2

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -100,16 +100,15 @@
 
       drawAttention();
 
+      const isNotificationGroupingSupported = Settings.isNotificationGroupingSupported();
       const notification = new Notification(title, {
         body: message,
         icon: iconUrl,
-        tag: 'signal',
+        tag: isNotificationGroupingSupported ? 'signal' : undefined,
         silent: !status.shouldPlayNotificationSound,
       });
-
       notification.onclick = () => this.onClick(last.get('conversationId'));
 
-      // We don't want to notify the user about these same messages again
       this.clear();
     },
     getUserSetting() {

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -38,6 +38,7 @@
       const isAudioNotificationEnabled =
         storage.get('audio-notification') || false;
       const isAudioNotificationSupported = Settings.isAudioNotificationSupported();
+      const isNotificationGroupingSupported = Settings.isNotificationGroupingSupported();
       const numNotifications = this.length;
       const userSetting = this.getUserSetting();
 
@@ -50,7 +51,12 @@
         userSetting,
       });
 
-      console.log('Update notifications:', status);
+      console.log(
+        'Update notifications:',
+        Object.assign({}, status, {
+          isNotificationGroupingSupported,
+        })
+      );
 
       if (status.type !== 'ok') {
         if (status.shouldClearNotifications) {
@@ -100,7 +106,6 @@
 
       drawAttention();
 
-      const isNotificationGroupingSupported = Settings.isNotificationGroupingSupported();
       const notification = new Notification(title, {
         body: message,
         icon: iconUrl,

--- a/ts/test/types/Settings_test.ts
+++ b/ts/test/types/Settings_test.ts
@@ -68,4 +68,66 @@ describe('Settings', () => {
       });
     });
   });
+
+  describe('isNotificationGroupingSupported', () => {
+    context('on macOS', () => {
+      beforeEach(() => {
+        sandbox.stub(process, 'platform').value('darwin');
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return true', () => {
+        assert.isTrue(Settings.isNotificationGroupingSupported());
+      });
+    });
+
+    context('on Windows', () => {
+      context('version 7', () => {
+        beforeEach(() => {
+          sandbox.stub(process, 'platform').value('win32');
+          sandbox.stub(os, 'release').returns('7.0.0');
+        });
+
+        afterEach(() => {
+          sandbox.restore();
+        });
+
+        it('should return false', () => {
+          assert.isFalse(Settings.isNotificationGroupingSupported());
+        });
+      });
+
+      context('version 8+', () => {
+        beforeEach(() => {
+          sandbox.stub(process, 'platform').value('win32');
+          sandbox.stub(os, 'release').returns('8.0.0');
+        });
+
+        afterEach(() => {
+          sandbox.restore();
+        });
+
+        it('should return true', () => {
+          assert.isTrue(Settings.isNotificationGroupingSupported());
+        });
+      });
+    });
+
+    context('on Linux', () => {
+      beforeEach(() => {
+        sandbox.stub(process, 'platform').value('linux');
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return true', () => {
+        assert.isTrue(Settings.isNotificationGroupingSupported());
+      });
+    });
+  });
 });

--- a/ts/types/Settings.ts
+++ b/ts/types/Settings.ts
@@ -4,3 +4,8 @@ const MIN_WINDOWS_VERSION = '8.0.0';
 
 export const isAudioNotificationSupported = () =>
   OS.isWindows(MIN_WINDOWS_VERSION) || OS.isMacOS();
+
+// Using `Notification::tag` has a bug on Windows 7:
+// https://github.com/electron/electron/issues/11189
+export const isNotificationGroupingSupported = () =>
+  !OS.isWindows() || OS.isWindows(MIN_WINDOWS_VERSION);


### PR DESCRIPTION
Grouping of notifications is not supported on Windows 7 due this bug: https://github.com/electron/electron/issues/11189

- [x] Disable notification grouping (using `tag`) on Windows 7.
- [x] Log notification grouping support.
- [x] **Infrastructure:** Use 2-space indentation for all files (better integration with Prettier.)
