### PR TITLE
MessageView: Add id from database to DOM for outgoing messages

### DIFF
--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -313,6 +313,7 @@
     onChange() {
       this.renderSent();
       this.renderQuote();
+      this.addId();
     },
     select(e) {
       this.$el.trigger('select', { message: this.model });
@@ -469,6 +470,13 @@
       const errorsCanBeContents = this.model.isIncoming() && hasErrors;
 
       return body || isGroupUpdate || isEndSession || errorsCanBeContents;
+    },
+    addId() {
+      // Because we initially render a sent Message before we've roundtripped with the
+      //   database, we don't have its id for that first render. We do get a change event,
+      //   however, and can add the id manually.
+      const { id } = this.model;
+      this.$el.attr('id', id);
     },
     render() {
       const contact = this.model.isIncoming() ? this.model.getContact() : null;


### PR DESCRIPTION
Sometimes you can't click on the quotation of a given message. A restart generally fixes it.

It turns out that any message sent by Desktop would be rendered without its unique `id` attribute, because we hadn't roundtripped with the database. And we had no machinery to go update that `id` attribute after the fact. Now we do. On any `change` event (which fires after that database roundtrip completes), we will add the proper `id` attribute. Yes, it is redundant, but I don't think checking for the existence of the id before adding it again would buy us very much.