### PR TITLE
Media Gallery: Fix Media + Documents Attachment Classification

### DIFF
--- a/js/modules/types/message.js
+++ b/js/modules/types/message.js
@@ -24,11 +24,19 @@ const PRIVATE = 'private';
 //   - Attachments: Write attachment data to disk and store relative path to it.
 // Version 4
 //   - Quotes: Write thumbnail data to disk and store relative path to it.
-// Version 5
+// Version 5 (deprecated)
 //   - Attachments: Track number and kind of attachments for media gallery
 //     - `hasAttachments?: 1 | 0`
 //     - `hasVisualMediaAttachments?: 1 | undefined` (for media gallery ‘Media’ view)
 //     - `hasFileAttachments?: 1 | undefined` (for media gallery ‘Documents’ view)
+//   - IMPORTANT: Version 6 changes the classification of visual media and files.
+//     Therefore version 5 is considered deprecated. For an easier implementation,
+//     new files have the same classification in version 5 as in version 6.
+// Version 6 (supersedes attachment classification in version 5)
+//   - Attachments: Update classification for:
+//     - `hasVisualMediaAttachments`: Include all images and video regardless of
+//       whether Chromium can render it or not.
+//     - `hasFileAttachments`: Exclude voice messages.
 
 const INITIAL_SCHEMA_VERSION = 0;
 
@@ -205,6 +213,10 @@ const toVersion4 = exports._withSchemaVersion(
   exports._mapQuotedAttachments(Attachment.migrateDataToFileSystem)
 );
 const toVersion5 = exports._withSchemaVersion(5, initializeAttachmentMetadata);
+// IMPORTANT: We’ve updated our definition of `initializeAttachmentMetadata`, so
+// we need to run it again on existing items that have previously been incorrectly
+// classified:
+const toVersion6 = exports._withSchemaVersion(6, initializeAttachmentMetadata);
 
 const VERSIONS = [
   toVersion0,
@@ -213,6 +225,7 @@ const VERSIONS = [
   toVersion3,
   toVersion4,
   toVersion5,
+  toVersion6,
 ];
 exports.CURRENT_SCHEMA_VERSION = VERSIONS.length - 1;
 

--- a/js/modules/types/message.js
+++ b/js/modules/types/message.js
@@ -32,13 +32,6 @@ const PRIVATE = 'private';
 
 const INITIAL_SCHEMA_VERSION = 0;
 
-// Increment this version number every time we add a message schema upgrade
-// step. This will allow us to retroactively upgrade existing messages. As we
-// add more upgrade steps, we could design a pipeline that does this
-// incrementally, e.g. from version 0 / unknown -> 1, 1 --> 2, etc., similar to
-// how we do database migrations:
-exports.CURRENT_SCHEMA_VERSION = 5;
-
 // Public API
 exports.GROUP = GROUP;
 exports.PRIVATE = PRIVATE;
@@ -195,7 +188,6 @@ exports._mapQuotedAttachments = upgradeAttachment => async (
 };
 
 const toVersion0 = async message => exports.initializeSchemaVersion(message);
-
 const toVersion1 = exports._withSchemaVersion(
   1,
   exports._mapAttachments(Attachment.autoOrientJPEG)
@@ -214,6 +206,16 @@ const toVersion4 = exports._withSchemaVersion(
 );
 const toVersion5 = exports._withSchemaVersion(5, initializeAttachmentMetadata);
 
+const VERSIONS = [
+  toVersion0,
+  toVersion1,
+  toVersion2,
+  toVersion3,
+  toVersion4,
+  toVersion5,
+];
+exports.CURRENT_SCHEMA_VERSION = VERSIONS.length - 1;
+
 // UpgradeStep
 exports.upgradeSchema = async (rawMessage, { writeNewAttachmentData } = {}) => {
   if (!isFunction(writeNewAttachmentData)) {
@@ -221,17 +223,7 @@ exports.upgradeSchema = async (rawMessage, { writeNewAttachmentData } = {}) => {
   }
 
   let message = rawMessage;
-  const versions = [
-    toVersion0,
-    toVersion1,
-    toVersion2,
-    toVersion3,
-    toVersion4,
-    toVersion5,
-  ];
-
-  for (let i = 0, max = versions.length; i < max; i += 1) {
-    const currentVersion = versions[i];
+  for (let currentVersion of VERSIONS) {
     // We really do want this intra-loop await because this is a chained async action,
     //   each step dependent on the previous
     // eslint-disable-next-line no-await-in-loop

--- a/test/modules/types/message_test.js
+++ b/test/modules/types/message_test.js
@@ -2,6 +2,7 @@ const { assert } = require('chai');
 const sinon = require('sinon');
 
 const Message = require('../../../js/modules/types/message');
+const { SignalService } = require('../../../ts/protobuf');
 const {
   stringToArrayBuffer,
 } = require('../../../js/modules/string_to_array_buffer');
@@ -191,7 +192,8 @@ describe('Message', () => {
       const input = {
         attachments: [
           {
-            contentType: 'application/json',
+            contentType: 'audio/aac',
+            flags: SignalService.AttachmentPointer.Flags.VOICE_MESSAGE,
             data: stringToArrayBuffer('It’s easy if you try'),
             fileName: 'test\u202Dfig.exe',
             size: 1111,
@@ -202,7 +204,8 @@ describe('Message', () => {
       const expected = {
         attachments: [
           {
-            contentType: 'application/json',
+            contentType: 'audio/aac',
+            flags: 1,
             path: 'abc/abcdefg',
             fileName: 'test\uFFFDfig.exe',
             size: 1111,
@@ -210,7 +213,7 @@ describe('Message', () => {
         ],
         hasAttachments: 1,
         hasVisualMediaAttachments: undefined,
-        hasFileAttachments: 1,
+        hasFileAttachments: undefined,
         schemaVersion: Message.CURRENT_SCHEMA_VERSION,
       };
 

--- a/ts/components/Lightbox.md
+++ b/ts/components/Lightbox.md
@@ -1,3 +1,5 @@
+## Image (supported format)
+
 ```js
 const noop = () => {};
 
@@ -5,8 +7,54 @@ const noop = () => {};
   <Lightbox
     objectURL="https://placekitten.com/800/600"
     contentType="image/jpeg"
-    onNext={noop}
-    onPrevious={noop}
+    onSave={noop}
+  />
+</div>;
+```
+
+## Image (unsupported format)
+
+```js
+const noop = () => {};
+
+<div style={{ position: 'relative', width: '100%', height: 500 }}>
+  <Lightbox objectURL="foo.tif" contentType="image/tiff" onSave={noop} />
+</div>;
+```
+
+## Video (supported format)
+
+```js
+const noop = () => {};
+
+<div style={{ position: 'relative', width: '100%', height: 500 }}>
+  <Lightbox
+    objectURL="fixtures/pixabay-Soap-Bubble-7141.mp4"
+    contentType="video/mp4"
+    onSave={noop}
+  />
+</div>;
+```
+
+## Video (unsupported format)
+
+```js
+const noop = () => {};
+
+<div style={{ position: 'relative', width: '100%', height: 500 }}>
+  <Lightbox objectURL="foo.mov" contentType="video/quicktime" onSave={noop} />
+</div>;
+```
+
+## Unsupported file format
+
+```js
+const noop = () => {};
+
+<div style={{ position: 'relative', width: '100%', height: 600 }}>
+  <Lightbox
+    objectURL="tsconfig.json"
+    contentType="application/json"
     onSave={noop}
   />
 </div>;

--- a/ts/components/styles/Colors.ts
+++ b/ts/components/styles/Colors.ts
@@ -2,3 +2,4 @@
  * @prettier
  */
 export const TEXT_SECONDARY = '#bbb';
+export const ICON_SECONDARY = '#ccc';

--- a/ts/styles/colorSVG.ts
+++ b/ts/styles/colorSVG.ts
@@ -1,0 +1,7 @@
+export const colorSVG = (url: string, color: string) => {
+  return {
+    WebkitMask: `url(${url}) no-repeat center`,
+    WebkitMaskSize: '100%',
+    backgroundColor: color,
+  };
+};

--- a/ts/test/types/Attachment_test.ts
+++ b/ts/test/types/Attachment_test.ts
@@ -59,6 +59,45 @@ describe('Attachment', () => {
     });
   });
 
+  describe('isFile', () => {
+    it('should return true for JSON', () => {
+      const attachment: Attachment.Attachment = {
+        fileName: 'foo.json',
+        data: stringToArrayBuffer('{"foo": "bar"}'),
+        contentType: MIME.APPLICATION_JSON,
+      };
+      assert.isTrue(Attachment.isFile(attachment));
+    });
+
+    it('should return false for images', () => {
+      const attachment: Attachment.Attachment = {
+        fileName: 'meme.gif',
+        data: stringToArrayBuffer('gif'),
+        contentType: MIME.IMAGE_GIF,
+      };
+      assert.isFalse(Attachment.isFile(attachment));
+    });
+
+    it('should return false for videos', () => {
+      const attachment: Attachment.Attachment = {
+        fileName: 'meme.mp4',
+        data: stringToArrayBuffer('mp4'),
+        contentType: MIME.VIDEO_MP4,
+      };
+      assert.isFalse(Attachment.isFile(attachment));
+    });
+
+    it('should return false for voice message attachment', () => {
+      const attachment: Attachment.Attachment = {
+        fileName: 'Voice Message.aac',
+        flags: SignalService.AttachmentPointer.Flags.VOICE_MESSAGE,
+        data: stringToArrayBuffer('voice message'),
+        contentType: MIME.AUDIO_AAC,
+      };
+      assert.isFalse(Attachment.isFile(attachment));
+    });
+  });
+
   describe('isVoiceMessage', () => {
     it('should return true for voice message attachment', () => {
       const attachment: Attachment.Attachment = {

--- a/ts/test/types/Attachment_test.ts
+++ b/ts/test/types/Attachment_test.ts
@@ -59,6 +59,45 @@ describe('Attachment', () => {
     });
   });
 
+  describe('isVisualMedia', () => {
+    it('should return true for images', () => {
+      const attachment: Attachment.Attachment = {
+        fileName: 'meme.gif',
+        data: stringToArrayBuffer('gif'),
+        contentType: MIME.IMAGE_GIF,
+      };
+      assert.isTrue(Attachment.isVisualMedia(attachment));
+    });
+
+    it('should return true for videos', () => {
+      const attachment: Attachment.Attachment = {
+        fileName: 'meme.mp4',
+        data: stringToArrayBuffer('mp4'),
+        contentType: MIME.VIDEO_MP4,
+      };
+      assert.isTrue(Attachment.isVisualMedia(attachment));
+    });
+
+    it('should return false for voice message attachment', () => {
+      const attachment: Attachment.Attachment = {
+        fileName: 'Voice Message.aac',
+        flags: SignalService.AttachmentPointer.Flags.VOICE_MESSAGE,
+        data: stringToArrayBuffer('voice message'),
+        contentType: MIME.AUDIO_AAC,
+      };
+      assert.isFalse(Attachment.isVisualMedia(attachment));
+    });
+
+    it('should return false for other attachments', () => {
+      const attachment: Attachment.Attachment = {
+        fileName: 'foo.json',
+        data: stringToArrayBuffer('{"foo": "bar"}'),
+        contentType: MIME.APPLICATION_JSON,
+      };
+      assert.isFalse(Attachment.isVisualMedia(attachment));
+    });
+  });
+
   describe('isFile', () => {
     it('should return true for JSON', () => {
       const attachment: Attachment.Attachment = {

--- a/ts/test/types/message/initializeAttachmentMetadata_test.ts
+++ b/ts/test/types/message/initializeAttachmentMetadata_test.ts
@@ -3,13 +3,14 @@ import { assert } from 'chai';
 
 import * as Message from '../../../../ts/types/message/initializeAttachmentMetadata';
 import { IncomingMessage } from '../../../../ts/types/Message';
+import { SignalService } from '../../../../ts/protobuf';
 import * as MIME from '../../../../ts/types/MIME';
 // @ts-ignore
 import { stringToArrayBuffer } from '../../../../js/modules/string_to_array_buffer';
 
 describe('Message', () => {
   describe('initializeAttachmentMetadata', () => {
-    it('should handle visual media attachments', async () => {
+    it('should classify visual media attachments', async () => {
       const input: IncomingMessage = {
         type: 'incoming',
         conversationId: 'foo',
@@ -43,6 +44,90 @@ describe('Message', () => {
         ],
         hasAttachments: 1,
         hasVisualMediaAttachments: 1,
+        hasFileAttachments: undefined,
+      };
+
+      const actual = await Message.initializeAttachmentMetadata(input);
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should classify file attachments', async () => {
+      const input: IncomingMessage = {
+        type: 'incoming',
+        conversationId: 'foo',
+        id: '11111111-1111-1111-1111-111111111111',
+        timestamp: 1523317140899,
+        received_at: 1523317140899,
+        sent_at: 1523317140800,
+        attachments: [
+          {
+            contentType: MIME.APPLICATION_OCTET_STREAM,
+            data: stringToArrayBuffer('foo'),
+            fileName: 'foo.bin',
+            size: 1111,
+          },
+        ],
+      };
+      const expected: IncomingMessage = {
+        type: 'incoming',
+        conversationId: 'foo',
+        id: '11111111-1111-1111-1111-111111111111',
+        timestamp: 1523317140899,
+        received_at: 1523317140899,
+        sent_at: 1523317140800,
+        attachments: [
+          {
+            contentType: MIME.APPLICATION_OCTET_STREAM,
+            data: stringToArrayBuffer('foo'),
+            fileName: 'foo.bin',
+            size: 1111,
+          },
+        ],
+        hasAttachments: 1,
+        hasVisualMediaAttachments: undefined,
+        hasFileAttachments: 1,
+      };
+
+      const actual = await Message.initializeAttachmentMetadata(input);
+      assert.deepEqual(actual, expected);
+    });
+
+    it('should classify voice message attachments', async () => {
+      const input: IncomingMessage = {
+        type: 'incoming',
+        conversationId: 'foo',
+        id: '11111111-1111-1111-1111-111111111111',
+        timestamp: 1523317140899,
+        received_at: 1523317140899,
+        sent_at: 1523317140800,
+        attachments: [
+          {
+            contentType: MIME.AUDIO_AAC,
+            flags: SignalService.AttachmentPointer.Flags.VOICE_MESSAGE,
+            data: stringToArrayBuffer('foo'),
+            fileName: 'Voice Message.aac',
+            size: 1111,
+          },
+        ],
+      };
+      const expected: IncomingMessage = {
+        type: 'incoming',
+        conversationId: 'foo',
+        id: '11111111-1111-1111-1111-111111111111',
+        timestamp: 1523317140899,
+        received_at: 1523317140899,
+        sent_at: 1523317140800,
+        attachments: [
+          {
+            contentType: MIME.AUDIO_AAC,
+            flags: SignalService.AttachmentPointer.Flags.VOICE_MESSAGE,
+            data: stringToArrayBuffer('foo'),
+            fileName: 'Voice Message.aac',
+            size: 1111,
+          },
+        ],
+        hasAttachments: 1,
+        hasVisualMediaAttachments: undefined,
         hasFileAttachments: undefined,
       };
 

--- a/ts/types/Attachment.ts
+++ b/ts/types/Attachment.ts
@@ -1,7 +1,6 @@
 import is from '@sindresorhus/is';
 import moment from 'moment';
 
-import * as GoogleChrome from '../util/GoogleChrome';
 import * as MIME from './MIME';
 import { arrayBufferToObjectURL } from '../util/arrayBufferToObjectURL';
 import { saveURLAsFile } from '../util/saveURLAsFile';
@@ -35,9 +34,11 @@ export const isVisualMedia = (attachment: Attachment): boolean => {
     return false;
   }
 
-  const isSupportedImageType = GoogleChrome.isImageTypeSupported(contentType);
-  const isSupportedVideoType = GoogleChrome.isVideoTypeSupported(contentType);
-  return isSupportedImageType || isSupportedVideoType;
+  if (isVoiceMessage(attachment)) {
+    return false;
+  }
+
+  return MIME.isImage(contentType) || MIME.isVideo(contentType);
 };
 
 export const isVoiceMessage = (attachment: Attachment): boolean => {

--- a/ts/types/Attachment.ts
+++ b/ts/types/Attachment.ts
@@ -41,6 +41,24 @@ export const isVisualMedia = (attachment: Attachment): boolean => {
   return MIME.isImage(contentType) || MIME.isVideo(contentType);
 };
 
+export const isFile = (attachment: Attachment): boolean => {
+  const { contentType } = attachment;
+
+  if (is.undefined(contentType)) {
+    return false;
+  }
+
+  if (isVisualMedia(attachment)) {
+    return false;
+  }
+
+  if (isVoiceMessage(attachment)) {
+    return false;
+  }
+
+  return true;
+};
+
 export const isVoiceMessage = (attachment: Attachment): boolean => {
   const flag = SignalService.AttachmentPointer.Flags.VOICE_MESSAGE;
   const hasFlag =

--- a/ts/types/MIME.ts
+++ b/ts/types/MIME.ts
@@ -1,10 +1,12 @@
 export type MIMEType = string & { _mimeTypeBrand: any };
 
 export const APPLICATION_OCTET_STREAM = 'application/octet-stream' as MIMEType;
+export const APPLICATION_JSON = 'application/json' as MIMEType;
 export const AUDIO_AAC = 'audio/aac' as MIMEType;
 export const AUDIO_MP3 = 'audio/mp3' as MIMEType;
 export const IMAGE_GIF = 'image/gif' as MIMEType;
 export const IMAGE_JPEG = 'image/jpeg' as MIMEType;
+export const VIDEO_MP4 = 'video/mp4' as MIMEType;
 export const VIDEO_QUICKTIME = 'video/quicktime' as MIMEType;
 
 export const isJPEG = (value: MIMEType): boolean => value === 'image/jpeg';


### PR DESCRIPTION
- [x] Introduce schema version 6: Fix media gallery file type classifications:
  - [x] Exclude voice messages from **Documents**.
  - [x] Include all media (images + video), regardless of whether we can display it or not.
- [x] Fix lightbox layout for small screens.
- [x] Add support for unsupported file formats in lightbox:
  - [x] Show image icon for unsupported images, e.g. TIFF.
  - [x] Show video icon for unsupported videos, e.g. QuickTime.
  - [x] Show file icon for other unsupported files, e.g. JSON.
- [x] Show all lightbox variants in style guide.
- [x] **Infrastructure:** Port `colorSVG` to CSS-in-JS for React.