### PR TITLE
Add allow_caps option for emoji conversion

### DIFF
--- a/ts/util/emoji.ts
+++ b/ts/util/emoji.ts
@@ -24,7 +24,7 @@ export function findImage(value: string, variation?: string) {
 
 export function replaceColons(str: string) {
   return str.replace(instance.rx_colons, m => {
-    const name = m.substr(1, m.length - 2);
+    const name = m.substr(1, m.length - 2).toLowerCase();
     const code = instance.map.colons[name];
     if (code) {
       return instance.data[code][0][0];


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/liliakai/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description

This turns on the `allow_caps` flag on `js-emoji`’s `EmojiConvertor`, which you can see the effect of in [the tests](https://github.com/iamcal/js-emoji/blob/762bd59586ba6f5e15b4065e897266094cde6ff9/test/colons.spec.js#L43). I’m suggesting this because I’ve on occasion been holding shift too long after typing the initial colon for an emoji and sending people messages containing things like `:Laughing:`. It seems friendlier to try to interpret everything between colons as a possible emoji name, rather than ignoring things because of case-sensitivity.

I chose not to add a test for this because it seemed redundant to be testing `js-emoji`’s functionality, but it would be pretty easy if that’s desirable.

Thanks for this application, it makes it much easier to message my friends while I’m working! 💞