### PR TITLE
Close Emoji Panel on Escape Key Press

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -213,6 +213,7 @@
     },
 
     events: {
+      'keydown': 'escapeEmojiPanel',
       'submit .send': 'checkUnverifiedSendMessage',
       'input .send-message': 'updateMessageFieldSize',
       'keydown .send-message': 'updateMessageFieldSize',
@@ -1153,6 +1154,13 @@
       if (!this.emojiPanel) {
         this.openEmojiPanel();
       } else {
+        this.closeEmojiPanel();
+      }
+    },
+    escapeEmojiPanel(e){
+      // Close emoji panel on escape key press
+      const keyCode = e.keyCode || e.which;
+      if (keyCode == 27 && this.emojiPanel != null) {
         this.closeEmojiPanel();
       }
     },


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/liliakai/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/WhisperSystems/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
I thought a good feature to have would be to close the emoji panel whenever the user presses the `escape` key. In terms of testing, I ran everything locally on my machine (MacOS 10.13.3) and it worked as it should. All the local tests passed; I did not add any tests because I thought that would be too much for such a small feature, but I can if requested.