### PR TITLE
Refactor event keycode to event key

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -1392,10 +1392,8 @@
     },
 
     updateMessageFieldSize(event) {
-      const keyCode = event.which || event.keyCode;
-
       if (
-        keyCode === 13 &&
+        event.key === "Enter" &&
         !event.altKey &&
         !event.shiftKey &&
         !event.ctrlKey

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -49,14 +49,13 @@
       if (!e.ctrlKey) {
         return;
       }
-      const keyCode = e.which || e.keyCode;
       const maxSize = 22; // if bigger text goes outside send-message textarea
       const minSize = 14;
-      if (keyCode === 189 || keyCode === 109) {
+      if (event.key === "-") {
         if (this.currentSize > minSize) {
           this.currentSize -= 1;
         }
-      } else if (keyCode === 187 || keyCode === 107) {
+      } else if (event.key === "=") {
         if (this.currentSize < maxSize) {
           this.currentSize += 1;
         }


### PR DESCRIPTION
### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/liliakai/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description

As brought up in #2354, `event.keycode` and `event.which` should no longer be used due to those functions being [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode). I swapped out the other two locations where I could see `event.keycode` being used with `event.key`. This passed all the local tests as well as preserved functionality when I tested on my machine 
