### PR TITLE
Contact account detail fixes

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -751,7 +751,7 @@
     },
     "notificationMostRecent": {
         "message": "Most recent:",
-        "description": "Displayed in notifications when setting is 'name and message' and "
+        "description": "Displayed in notifications when setting is 'name and message' and more than one message is waiting"
     },
     "messageNotSent": {
         "message": "Message not sent.",

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -1014,6 +1014,7 @@
 
       const view = new Whisper.ReactWrapperView({
         Component: Signal.Components.ContactDetail,
+        className: 'contact-detail-pane panel',
         props: {
           contact: contactSelector(contact, {
             regionCode,

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -1007,7 +1007,7 @@
       this.listenBack(view);
     },
 
-    showContactDetail(contact) {
+    showContactDetail({ contact, hasSignalAccount }) {
       const regionCode = storage.get('regionCode');
       const { contactSelector } = Signal.Types.Contact;
       const { getAbsoluteAttachmentPath } = window.Signal.Migrations;
@@ -1019,7 +1019,7 @@
             regionCode,
             getAbsoluteAttachmentPath,
           }),
-          hasSignalAccount: true,
+          hasSignalAccount,
           onSendMessage: () => {
             const number =
               contact.number && contact.number[0] && contact.number[0].value;

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -461,7 +461,7 @@
         this.contactHasSignalAccount || (number && haveConversation);
 
       // We store this value on this. because a re-render shouldn't kick off another
-      //   profile check. To the web.
+      //   profile check, going to the web.
       this.contactHasSignalAccount = hasLocalSignalAccount;
 
       const onSendMessage = number

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -862,6 +862,10 @@ span.status {
   margin-top: -2px;
 }
 
+.contact-detail-pane {
+  overflow-y: scroll;
+}
+
 .contact-detail {
   text-align: center;
   max-width: 300px;

--- a/stylesheets/android-dark.scss
+++ b/stylesheets/android-dark.scss
@@ -284,6 +284,12 @@ $text-dark_l2: darken($text-dark, 30%);
     }
   }
 
+  .contact-detail {
+    .additional-contact .type {
+      color: rgba(255, 255, 255, 0.5);
+    }
+  }
+
   .outgoing .quoted-message {
     background: rgba(255, 255, 255, 0.38);
 


### PR DESCRIPTION
1. We were always showing the 'Send message' button, even if the contact didn't have a Signal account
2. Contact method headers were not visible in dark theme
3. A very long contact will cause the contact details pane to break out of its container, make the whole thing scroll