### PR TITLE
Modify OS.isWindows to check platform before version

### DIFF
--- a/ts/OS.ts
+++ b/ts/OS.ts
@@ -5,8 +5,8 @@ import semver from 'semver';
 export const isMacOS = () => process.platform === 'darwin';
 export const isLinux = () => process.platform === 'linux';
 export const isWindows = (minVersion?: string) => {
-  if(process.platform !== 'win32') return false;
-  
+  if (process.platform !== 'win32') return false;
+
   const osRelease = os.release();
   const isVersionValid = is.undefined(minVersion)
     ? true

--- a/ts/OS.ts
+++ b/ts/OS.ts
@@ -5,11 +5,12 @@ import semver from 'semver';
 export const isMacOS = () => process.platform === 'darwin';
 export const isLinux = () => process.platform === 'linux';
 export const isWindows = (minVersion?: string) => {
-  const isPlatformValid = process.platform === 'win32';
+  if(process.platform !== 'win32') return false;
+  
   const osRelease = os.release();
   const isVersionValid = is.undefined(minVersion)
     ? true
     : semver.gte(osRelease, minVersion);
 
-  return isPlatformValid && isVersionValid;
+  return isVersionValid;
 };


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [X] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/liliakai/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/WhisperSystems/Signal-Desktop/tree/development) branch
* [X] My changes pass 100% of [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/WhisperSystems/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Previously OS.isWindows checked if the windows version matched the one required. This worked fine, except for the fact that it would end up comparing a linux kernel version to a windows version as it didn't check if the platform was Windows in the first place before.

This caused issues as it would throw an error when comparing with non-semver Linux kernels (such as Fedora). Tests would fail and notably the settings/preferences dialogs would fail to open. Now it checks if the current platform is Windows first, and if not, immediately returns false.

All tests pass now (previously on first checkout they failed on my system), and the preferences dialog successfully opens. No errors can be found in the console.

My OS is Fedora 28 x64.

Fixes: #2396
