### PR TITLE
Ensure that messages expire at the proper time

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -541,7 +541,7 @@
       }
     },
 
-    onReadMessage(message) {
+    onReadMessage(message, readAt) {
       if (this.messageCollection.get(message.id)) {
         this.messageCollection.get(message.id).fetch();
       }
@@ -558,7 +558,10 @@
       // Lastly, we don't send read syncs for any message marked read due to a read
       //   sync. That's a notification explosion we don't need.
       return this.queueJob(() =>
-        this.markRead(message.get('received_at'), { sendReadReceipts: false })
+        this.markRead(message.get('received_at'), {
+          sendReadReceipts: false,
+          readAt,
+        })
       );
     },
 
@@ -1018,7 +1021,7 @@
                 'it was not in messageCollection.'
             );
           }
-          promises.push(m.markRead());
+          promises.push(m.markRead(options.readAt));
           const errors = m.get('errors');
           return {
             sender: m.get('source'),

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -7,6 +7,7 @@
 /* global Signal: false */
 /* global textsecure: false */
 /* global Whisper: false */
+/* global wrapDeferred: false */
 
 /* eslint-disable more/no-then */
 
@@ -798,7 +799,7 @@
           })
       );
     },
-    markRead(readAt) {
+    async markRead(readAt) {
       this.unset('unread');
       if (this.get('expireTimer') && !this.get('expirationStartTimestamp')) {
         this.set('expirationStartTimestamp', readAt || Date.now());
@@ -808,9 +809,7 @@
           messageId: this.id,
         })
       );
-      return new Promise((resolve, reject) => {
-        this.save().then(resolve, reject);
-      });
+      return wrapDeferred(this.save());
     },
     isExpiring() {
       return this.get('expireTimer') && this.get('expirationStartTimestamp');

--- a/js/read_syncs.js
+++ b/js/read_syncs.js
@@ -45,7 +45,10 @@
           return message
             ? message.markRead(receipt.get('read_at')).then(
                 function() {
-                  this.notifyConversation(message);
+                  // This notification may result in messages older than this one being
+                  //   marked read. We want those messages to have the same expire timer
+                  //   start time as this one, so we pass the read_at value through.
+                  this.notifyConversation(message, receipt.get('read_at'));
                   this.remove(receipt);
                 }.bind(this)
               )
@@ -53,13 +56,13 @@
         }.bind(this)
       );
     },
-    notifyConversation: function(message) {
+    notifyConversation: function(message, readAt) {
       var conversation = ConversationController.get({
         id: message.get('conversationId'),
       });
 
       if (conversation) {
-        conversation.onReadMessage(message);
+        conversation.onReadMessage(message, readAt);
       }
     },
   }))();


### PR DESCRIPTION
Fixes #2371

On a bulk read sync, we could sometimes mark older messages read in bulk. Depending on the order of the messages in the multi-message read sync, this might never happen, might happen all the time. Now we pipe the `read_at` value through to this bulk marking of messages read, ensuring that the message's expiration is properly calculated.