### PR TITLE
Expire timer updates: don't send if updated via remote message

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -913,11 +913,11 @@
         wrapDeferred(message.save()),
         wrapDeferred(this.save({ expireTimer })),
       ]).then(() => {
-        if (message.isIncoming()) {
+        // if change was made remotely, don't send it to the number/group
+        if (receivedAt) {
           return message;
         }
 
-        // change was made locally, send it to the number/group
         let sendFunc;
         if (this.get('type') === 'private') {
           sendFunc = textsecure.messaging.sendExpirationTimerUpdateToNumber;


### PR DESCRIPTION
A recent change removed the `type` property to make `markRead()` behave properly, but that broke our 'should we send an update?' logic. So instead of using `isIncoming()` we now use what we previously used to determine whether a message was incoming: `receivedAt`.

Fixes https://github.com/signalapp/Signal-Desktop/issues/2472
Bug introduced here: https://github.com/signalapp/Signal-Desktop/commit/dfa1f0797c243fc6763423cece99285a2fc79657#diff-e7ea6b899ac298e9faa100a737a9b5a9L885