### PR TITLE
Include about_preload.js in production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
       "!js/views/standalone_registration_view.js",
       "app/*",
       "preload.js",
+      "about_preload.js",
       "main.js",
       "images/**",
       "fonts/*",


### PR DESCRIPTION
Turns out that we continue to have problems with with version number in the about window. This time the production build had a bug that the development builds did not.

Fixes #2463 (for reals)