### PR TITLE
Idle detector: Fix bug preventing it from ever turning off

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -78,6 +78,7 @@
   let isMigrationWithIndexComplete = false;
   let isMigrationWithoutIndexComplete = false;
   idleDetector.on('idle', async () => {
+    console.log('Idle processing started');
     const NUM_MESSAGES_PER_BATCH = 1;
 
     if (!isMigrationWithIndexComplete) {
@@ -108,6 +109,7 @@
     const areAllMigrationsComplete =
       isMigrationWithIndexComplete && isMigrationWithoutIndexComplete;
     if (areAllMigrationsComplete) {
+      console.log('All migrations are complete. Stopping idle detector.');
       idleDetector.stop();
     }
   });

--- a/js/modules/idle_detector.js
+++ b/js/modules/idle_detector.js
@@ -18,6 +18,10 @@ class IdleDetector extends EventEmitter {
   }
 
   stop() {
+    if (!this.handle) {
+      return;
+    }
+
     console.log('Stop idle detector');
     this._clearScheduledCallbacks();
   }
@@ -25,10 +29,12 @@ class IdleDetector extends EventEmitter {
   _clearScheduledCallbacks() {
     if (this.handle) {
       cancelIdleCallback(this.handle);
+      this.handle = null;
     }
 
     if (this.timeoutId) {
       clearTimeout(this.timeoutId);
+      this.timeoutId = null;
     }
   }
 
@@ -38,13 +44,13 @@ class IdleDetector extends EventEmitter {
       const { didTimeout } = deadline;
       const timeRemaining = deadline.timeRemaining();
       const isIdle = timeRemaining >= IDLE_THRESHOLD_MS;
-      if (isIdle || didTimeout) {
-        this.emit('idle', { timestamp: Date.now(), didTimeout, timeRemaining });
-      }
       this.timeoutId = setTimeout(
         () => this._scheduleNextCallback(),
         POLL_INTERVAL_MS
       );
+      if (isIdle || didTimeout) {
+        this.emit('idle', { timestamp: Date.now(), didTimeout, timeRemaining });
+      }
     });
   }
 }


### PR DESCRIPTION
Turns out that since `emit()` calls its handlers synchronously, we were attempting to turn everything off and then right after that a `setTimeout()` was scheduled to turn everything back on. Now the idle detector really turns off!