### PR TITLE
replace hardcoded blue color on _global.scss with $blue

### DIFF
--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -879,7 +879,7 @@ textarea {
     cursor: pointer;
     text-decoration: underline;
     margin: 0.5em;
-    color: #2090ea;
+    color: $blue;
   }
 
   .progress {


### PR DESCRIPTION
### First time contributor checklist:

* [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/liliakai/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [X] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [X] My changes are ready to be shipped to users

### Description
Replace hardcoded blue color on _global.cscc with $blue from _variables.csss
Because when I need to change the color style on _variable.scss, the result at manifest.css is not satisfying, since there is one `a.link` that still use old hardcoded color.

Does it address any outstanding issues in this project?
No

Please write a summary of your test approach:
  - What kind of manual testing did you do?
    Build, Run
  - Did you write any new tests?
    No
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
    Windows 10 Home Edition 64 bit, 8 GB of Ram.
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
    No
-->
