### PR TITLE
Workaround for linux w/tmp mounted as noexec

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -192,6 +192,10 @@
     };
 
     const startSpellCheck = () => {
+      if (!window.enableSpellCheck || !window.disableSpellCheck) {
+        return;
+      }
+
       if (window.Events.getSpellCheck()) {
         window.enableSpellCheck();
       } else {


### PR DESCRIPTION
Spell check does not load if certain directories are mounted 'noexec' on linux. This change ensures that the recent feature to allow disabling spell check doesn't prevent startup of the app.

Fixes https://github.com/signalapp/Signal-Desktop/issues/2546