### PR TITLE
MacOS: Hide from Dock when application is in tray

### DIFF
--- a/app/dock_icon.js
+++ b/app/dock_icon.js
@@ -1,0 +1,17 @@
+const { app } = require('electron');
+
+const dockIcon = {};
+
+dockIcon.show = () => {
+  if (process.platform === 'darwin') {
+    app.dock.show();
+  }
+};
+
+dockIcon.hide = () => {
+  if (process.platform === 'darwin') {
+    app.dock.hide();
+  }
+};
+
+module.exports = dockIcon;

--- a/app/tray_icon.js
+++ b/app/tray_icon.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 const { app, Menu, Tray } = require('electron');
+const dockIcon = require('./dock_icon');
 
 let trayContextMenu = null;
 let tray = null;
@@ -22,8 +23,10 @@ function createTrayIcon(getMainWindow, messages) {
     if (mainWindow) {
       if (mainWindow.isVisible()) {
         mainWindow.hide();
+        dockIcon.hide();
       } else {
         mainWindow.show();
+        dockIcon.show();
 
         // On some versions of GNOME the window may not be on top when restored.
         // This trick should fix it.

--- a/main.js
+++ b/main.js
@@ -24,6 +24,7 @@ const packageJson = require('./package.json');
 const Attachments = require('./app/attachments');
 const autoUpdate = require('./app/auto_update');
 const createTrayIcon = require('./app/tray_icon');
+const dockIcon = require('./app/dock_icon');
 const GlobalErrors = require('./js/modules/global_errors');
 const logging = require('./app/logging');
 const windowState = require('./app/window_state');
@@ -86,6 +87,9 @@ function showWindow() {
   if (tray) {
     tray.updateContextMenu();
   }
+
+  // show the app on the Dock in case it was hidden before
+  dockIcon.show();
 }
 
 if (!process.mas) {
@@ -333,6 +337,11 @@ function createWindow() {
       // toggle the visibility of the show/hide tray icon menu entries
       if (tray) {
         tray.updateContextMenu();
+      }
+
+      // hide the app from the Dock on macOS if the tray icon is enabled
+      if (usingTrayIcon) {
+        dockIcon.hide();
       }
     }
   });


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [X] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #2012 

Manual tests done:
* Run `yarn start --use-tray-icon` then close the Signal window.
Result: icon is hidden from the dock and from the cmd+tab switcher, tray icon is available to reopen the window.
* Open the window using the tray icon.
Result: app shows up on the dock and in the cmd+tab switcher.
* Run `yarn start` while the previous instance is running and is hidden.
Result: newly started instance exits, previously started instance opens its window and app shows up on the dock.

Operating system: macOS Sierra 10.12.6
