### PR TITLE
Fix text alignment for RTL messages

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -446,12 +446,13 @@
   color: $color-light-90;
   font-size: 14px;
   line-height: 18px;
+  text-align: start ;
 
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
   white-space: pre-wrap;
-
+  
   a {
     text-decoration: underline;
     color: $color-light-90;

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -446,7 +446,7 @@
   color: $color-light-90;
   font-size: 14px;
   line-height: 18px;
-  text-align: start ;
+  text-align: start;
 
   overflow-wrap: break-word;
   word-wrap: break-word;


### PR DESCRIPTION
### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [ ] My changes are ready to be shipped to users

### Description

Adding auto text alignment property (`text-align: start`) to message container, for better RTL messages view:
![image](https://user-images.githubusercontent.com/4103710/43641692-28ce0c9e-9714-11e8-8514-7a1429118ae5.png)

Instead of:
![image](https://user-images.githubusercontent.com/4103710/43641705-35161aa0-9714-11e8-82d5-96654d557fc0.png)

