### PR TITLE
Changing the "update is available" flow from a alert dialog to a banner

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1490,20 +1490,8 @@
   "relink": {
     "message": "Relink"
   },
-  "autoUpdateNewVersionTitle": {
-    "message": "Signal update available"
-  },
   "autoUpdateNewVersionMessage": {
     "message": "There is a new version of Signal available."
-  },
-  "autoUpdateNewVersionInstructions": {
-    "message": "Press Restart Signal to apply the updates."
-  },
-  "autoUpdateRestartButtonLabel": {
-    "message": "Restart Signal"
-  },
-  "autoUpdateLaterButtonLabel": {
-    "message": "Later"
   },
   "leftTheGroup": {
     "message": "$name$ left the group",

--- a/app/auto_update.js
+++ b/app/auto_update.js
@@ -1,14 +1,10 @@
 const { autoUpdater } = require('electron-updater');
-const { dialog } = require('electron');
 
 const config = require('./config');
 const windowState = require('./window_state');
 
 const hour = 60 * 60;
 const autoUpdaterInterval = hour * 1000;
-
-const RESTART_BUTTON = 0;
-const LATER_BUTTON = 1;
 
 function autoUpdateDisabled() {
   return (
@@ -22,39 +18,11 @@ function checkForUpdates() {
   autoUpdater.checkForUpdates();
 }
 
-let showingDialog = false;
-function showUpdateDialog(mainWindow, messages) {
-  if (showingDialog || !mainWindow) {
-    return;
-  }
-  showingDialog = true;
-
-  const options = {
-    type: 'info',
-    buttons: [
-      messages.autoUpdateRestartButtonLabel.message,
-      messages.autoUpdateLaterButtonLabel.message,
-    ],
-    title: messages.autoUpdateNewVersionTitle.message,
-    message: messages.autoUpdateNewVersionMessage.message,
-    detail: messages.autoUpdateNewVersionInstructions.message,
-    defaultId: LATER_BUTTON,
-    cancelId: RESTART_BUTTON,
-  };
-
-  dialog.showMessageBox(mainWindow, options, response => {
-    if (response === RESTART_BUTTON) {
-      // We delay these update calls because they don't seem to work in this
-      //   callback - but only if the message box has a parent window.
-      // Fixes this bug: https://github.com/signalapp/Signal-Desktop/issues/1864
-      setTimeout(() => {
-        windowState.markShouldQuit();
-        autoUpdater.quitAndInstall();
-      }, 200);
-    }
-
-    showingDialog = false;
-  });
+function updateApp() {
+  setTimeout(() => {
+    windowState.markShouldQuit();
+    autoUpdater.quitAndInstall();
+  }, 200);
 }
 
 function onError(error) {
@@ -66,12 +34,23 @@ function initialize(getMainWindow, messages) {
     throw new Error('auto-update initialize needs localized messages');
   }
 
+  // Uncomment for testing
+  // setInterval(() => {
+  //   const win = getMainWindow();
+  //   if (win !== null) {
+  //     win.webContents.send('updateNeeded');
+  //   }
+  // }, 5000);
+
   if (autoUpdateDisabled()) {
     return;
   }
 
   autoUpdater.addListener('update-downloaded', () => {
-    showUpdateDialog(getMainWindow(), messages);
+    const win = getMainWindow();
+    if (win !== null) {
+      win.webContents.send('updateNeeded');
+    }
   });
   autoUpdater.addListener('error', onError);
 
@@ -82,4 +61,5 @@ function initialize(getMainWindow, messages) {
 
 module.exports = {
   initialize,
+  updateApp,
 };

--- a/background.html
+++ b/background.html
@@ -90,6 +90,13 @@
       {{ unreadMessages }}
     </div>
   </script>
+  <script type='text/x-tmpl-mustache' id='new_version_alert'>
+    <button class='upgrade-app'>{{ upgrade }}</button>
+    <span class="message">
+    {{ newVersionAvailable }}
+    </span>
+  </script>
+
   <script type='text/x-tmpl-mustache' id='expired_alert'>
     <a target='_blank' href='https://signal.org/download/'>
       <button class='upgrade'>{{ upgrade }}</button>

--- a/js/background.js
+++ b/js/background.js
@@ -509,6 +509,13 @@
     }
   });
 
+  Whisper.events.on('updateNeeded', () => {
+    const { appView } = window.owsDesktopApp;
+    if (appView) {
+      appView.showUpdateNeededBanner();
+    }
+  });
+
   async function start() {
     window.dispatchEvent(new Event('storage_ready'));
 

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -1,5 +1,5 @@
 /* global Backbone, Whisper, storage, _, ConversationController, $ */
-
+/* global i18n: false */
 /* eslint-disable more/no-then */
 
 // eslint-disable-next-line func-names
@@ -12,12 +12,14 @@
     initialize() {
       this.inboxView = null;
       this.installView = null;
+      this.updateNeededBanner = false;
 
       this.applyTheme();
       this.applyHideMenu();
     },
     events: {
       'click .openInstaller': 'openInstaller', // NetworkStatusView has this button
+      'click button.upgrade-app': 'upgradeApp',
       openInbox: 'openInbox',
     },
     applyTheme() {
@@ -177,6 +179,29 @@
           this.inboxView.openConversation(conversation);
         });
       }
+    },
+    upgradeApp(e) {
+      e.preventDefault();
+      window.upgradeApp();
+    },
+    showUpdateNeededBanner() {
+      if (!this.updateNeededBanner) {
+        const banner = new Whisper.NewVersionBanner().render();
+        banner.$el.prependTo(this.inboxView.$el);
+        this.$el.addClass('banner-up');
+        this.updateNeededBanner = true;
+      }
+    },
+  });
+
+  Whisper.NewVersionBanner = Whisper.View.extend({
+    templateName: 'new_version_alert',
+    className: 'newVersionAlert clearfix',
+    render_attributes() {
+      return {
+        newVersionAvailable: i18n('autoUpdateNewVersionMessage'),
+        upgrade: i18n('upgrade'),
+      };
     },
   });
 })();

--- a/main.js
+++ b/main.js
@@ -786,6 +786,11 @@ ipc.on('close-permissions-popup', () => {
   }
 });
 
+ipc.on('upgrade-app', () => {
+  logger.info('upgrading app');
+  autoUpdate.updateApp();
+});
+
 // Settings-related IPC calls
 
 function addDarkOverlay() {

--- a/preload.js
+++ b/preload.js
@@ -81,6 +81,8 @@ window.closeAbout = () => ipc.send('close-about');
 window.updateTrayIcon = unreadCount =>
   ipc.send('update-tray-icon', unreadCount);
 
+window.upgradeApp = () => ipc.send('upgrade-app');
+
 ipc.on('set-up-with-import', () => {
   Whisper.events.trigger('setupWithImport');
 });
@@ -91,6 +93,10 @@ ipc.on('set-up-as-new-device', () => {
 
 ipc.on('set-up-as-standalone', () => {
   Whisper.events.trigger('setupAsStandalone');
+});
+
+ipc.on('updateNeeded', () => {
+  Whisper.events.trigger('updateNeeded');
 });
 
 // Settings-related events

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -457,6 +457,31 @@ textarea {
   }
 }
 
+.newVersionAlert {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background: #ffff31;
+  padding: 10px;
+
+  button {
+    border: none;
+    border-radius: $border-radius;
+    color: white;
+    font-weight: bold;
+    line-height: 36px;
+    padding: 0 20px;
+    background: $blue;
+    margin-right: 20px;
+  }
+
+  .message {
+    font-size: 18px;
+    padding: 10px 0;
+  }
+}
+
 .inbox {
   position: relative;
 }

--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -6,6 +6,13 @@
   overflow: hidden;
 }
 
+.banner-up {
+  .conversation-stack,
+  .gutter {
+    height: calc(100% - 61px);
+  }
+}
+
 .expired {
   .conversation-stack,
   .gutter {


### PR DESCRIPTION
### First time contributor checklist:

* [ X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [X ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [ X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [ X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [ X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [X ] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [X ] My changes are ready to be shipped to users
* [X ] Yarn Lint Passes

### Description

This change moves the current alert dialog based "update is available" flow to one using an always visible top banner. There are several advantages to moving to a banner based flow.

1. This fixed #2659 where users noted that the alert flow hijacks focus and forces other fullscreen apps to have to be minimized, interrupting the users work.

2. An always visible banner should improve upgrade timelines. In the previous flow the user could cancel the dialog and subsequently forget to upgrade. 

3. Better UI flow keeps the message top of mind without interfering with the users messaging.

I manually tested these changes by sending the "update available" event using a timeout after app start. I did not test the actual upgrade mechanism as I have not changed that part it still uses the existing electron auto-update functionality. I only tested that it gets called.

<img width="1552" alt="screen shot 2018-08-17 at 2 34 07 pm" src="https://user-images.githubusercontent.com/832235/44282982-d45d2380-a22a-11e8-9c54-3870dfb6d25f.png">
