### PR TITLE
Moved NetworkStatusView to standardised banner UI under AppView

### DIFF
--- a/background.html
+++ b/background.html
@@ -27,6 +27,12 @@
     When making changes to these templates, be sure to update test/index.html as well
   -->
 
+  <script type='text/x-tmpl-mustache' id='app-canvas'>
+    <div class='network-status-banner'></div>
+    <div class='other-banner'></div>
+    <div class='app-canvas'>
+    </div>
+  </script>
   <script type='text/x-tmpl-mustache' id='app-loading-screen'>
     <div class='content'>
       <img src='images/icon_128.png'>
@@ -50,7 +56,6 @@
   </script>
   <script type='text/x-tmpl-mustache' id='two-column'>
     <div class='gutter'>
-      <div class='network-status-container'></div>
       <div class='title-bar active'>
         <div class='logo'>Signal</div>
       </div>
@@ -375,8 +380,7 @@
 
   <script type='text/x-tmpl-mustache' id='networkStatus'>
     <div class='network-status-message'>
-      <h3>{{ message }}</h3>
-      <span>{{ instructions }}</span>
+      {{ message }} {{ instructions }}
     </div>
     {{ #reconnectDurationAsSeconds }}
     <div class="network-status-message">

--- a/js/background.js
+++ b/js/background.js
@@ -520,9 +520,13 @@
     });
 
     cancelInitializationMessage();
-    const appView = new Whisper.AppView({
-      el: $('body'),
-    });
+
+    const appView = new Whisper.AppView().render();
+    $('body')
+      .empty()
+      .append(appView.$el);
+    appView.showNetworkStatusView();
+
     window.owsDesktopApp.appView = appView;
 
     Whisper.WallClockListener.init(Whisper.events);
@@ -547,10 +551,10 @@
       appView.openDebugLog();
     });
     Whisper.events.on('unauthorized', () => {
-      appView.inboxView.networkStatusView.update();
+      appView.networkStatusView.update();
     });
     Whisper.events.on('reconnectTimer', () => {
-      appView.inboxView.networkStatusView.setSocketReconnectInterval(60000);
+      appView.networkStatusView.setSocketReconnectInterval(60000);
     });
     Whisper.events.on('contactsync', () => {
       if (appView.installView) {

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -1,4 +1,4 @@
-/* global Backbone, Whisper, storage, _, ConversationController, $ */
+/* global Whisper, storage, _, ConversationController, $ */
 
 /* eslint-disable more/no-then */
 
@@ -8,10 +8,14 @@
 
   window.Whisper = window.Whisper || {};
 
-  Whisper.AppView = Backbone.View.extend({
+  Whisper.AppView = Whisper.View.extend({
+    className: 'app-view',
+    templateName: 'app-canvas',
     initialize() {
       this.inboxView = null;
       this.installView = null;
+      this.networkStatusView = null;
+      this.updateNeededBanner = null;
 
       this.applyTheme();
       this.applyHideMenu();
@@ -23,15 +27,15 @@
     applyTheme() {
       const iOS = storage.get('userAgent') === 'OWI';
       const theme = storage.get('theme-setting') || 'light';
-      this.$el
+      $('body')
         .removeClass('light-theme')
         .removeClass('dark-theme')
         .addClass(`${theme}-theme`);
 
       if (iOS) {
-        this.$el.addClass('ios-theme');
+        $('body').addClass('ios-theme');
       } else {
-        this.$el.removeClass('ios-theme');
+        $('body').removeClass('ios-theme');
       }
     },
     applyHideMenu() {
@@ -40,8 +44,10 @@
       window.setMenuBarVisibility(!hideMenuBar);
     },
     openView(view) {
-      this.el.innerHTML = '';
-      this.el.append(view.el);
+      this.$el
+        .find('.app-canvas')
+        .empty()
+        .append(view.$el);
       this.delegateEvents();
     },
     openDebugLog() {
@@ -177,6 +183,43 @@
           this.inboxView.openConversation(conversation);
         });
       }
+    },
+    upgradeApp(e) {
+      e.preventDefault();
+      window.upgradeApp();
+    },
+    showUpdateNeededBanner() {
+      if (this.updateNeededBanner === null) {
+        this.updateNeededBanner = new Whisper.NewVersionBanner();
+
+        this.$el
+          .find('.other-banner')
+          .append(this.updateNeededBanner.render().el);
+
+        this.$el.addClass('banner-up');
+      }
+    },
+    showNetworkStatusView() {
+      if (this.networkStatusView === null) {
+        this.networkStatusView = new Whisper.NetworkStatusView();
+
+        this.$el
+          .find('.network-status-banner')
+          .append(this.networkStatusView.render().el);
+
+        this.networkStatusView.update();
+      }
+    },
+  });
+
+  Whisper.NewVersionBanner = Whisper.View.extend({
+    templateName: 'new_version_alert',
+    className: 'newVersionAlert clearfix',
+    render_attributes() {
+      return {
+        newVersionAvailable: i18n('autoUpdateNewVersionMessage'),
+        upgrade: i18n('upgrade'),
+      };
     },
   });
 })();

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -107,11 +107,6 @@
 
       const inboxCollection = getInboxCollection();
 
-      this.listenTo(inboxCollection, 'messageError', () => {
-        if (this.networkStatusView) {
-          this.networkStatusView.render();
-        }
-      });
       this.listenTo(inboxCollection, 'select', this.openConversation);
 
       this.inboxListView = new Whisper.ConversationListView({
@@ -146,11 +141,6 @@
         this.inboxListView.$el.hide();
       });
       this.listenTo(this.searchView, 'open', this.openConversation);
-
-      this.networkStatusView = new Whisper.NetworkStatusView();
-      this.$el
-        .find('.network-status-container')
-        .append(this.networkStatusView.render().el);
 
       extension.windows.onClosed(() => {
         this.inboxListView.stopListening();

--- a/js/views/network_status_view.js
+++ b/js/views/network_status_view.js
@@ -1,4 +1,5 @@
 /* global Whisper, extension, Backbone, moment, i18n */
+/* global $: false */
 
 // eslint-disable-next-line func-names
 (function() {
@@ -114,8 +115,10 @@
       this.render();
       if (this.model.attributes.hasInterruption) {
         this.$el.slideDown();
+        $('body').addClass('banner-up');
       } else {
         this.$el.hide();
+        $('body').removeClass('banner-up');
       }
     },
   });

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -833,3 +833,11 @@ textarea {
     -webkit-text-security: square;
   }
 }
+
+.app-view {
+  height: 100%;
+}
+
+.app-canvas {
+  height: 100%;
+}

--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -6,6 +6,14 @@
   overflow: hidden;
 }
 
+.banner-up {
+  height: calc(100% - 61px);
+
+  .app-canvas .app-view .gutter {
+    height: calc(100% - 60px);
+  }
+}
+
 .expired {
   .conversation-stack,
   .gutter {
@@ -36,28 +44,22 @@
     max-height: calc(100% - 88px);
   }
 }
-.network-status-container {
+.network-status-banner {
   .network-status {
     background: url('../images/error_red.svg') no-repeat left 10px center;
     background-size: 25px 25px;
     background-color: #fcd156;
-    padding: 10px;
+    padding: 20px;
     padding-left: 2 * $button-height;
     display: none;
+    height: 60px;
 
     .network-status-message {
-      h3 {
-        padding: 0px;
-        margin: 0px;
-        margin-bottom: 2px;
-        font-size: 14px;
-      }
-      span {
-        display: inline-block;
-        font-size: 12px;
-        padding: 0.5em 0;
-      }
+      text-align: center;
+      font-size: 20px;
+      font-weight: 300;
     }
+
     .action {
       button {
         border-radius: $border-radius;

--- a/stylesheets/_theme_dark.scss
+++ b/stylesheets/_theme_dark.scss
@@ -467,7 +467,7 @@ body.dark-theme {
       border: 2px solid $color-dark-85;
     }
   }
-  .network-status-container {
+  .network-status-banner {
     .network-status {
       background: url('../images/error_red.svg') no-repeat left 10px center;
       background-size: 25px 25px;

--- a/test/index.html
+++ b/test/index.html
@@ -38,7 +38,6 @@
   </script>
   <script type='text/x-tmpl-mustache' id='two-column'>
     <div class='gutter'>
-        <div class='network-status-container'></div>
         <div class='title-bar active' id='header'>
           <h1>Signal</h1>
           <div class='tool-bar clearfix'>
@@ -304,8 +303,7 @@
   </script>
   <script type='text/x-tmpl-mustache' id='networkStatus'>
     <div class='network-status-message'>
-      <h3>{{ message }}</h3>
-      <span>{{ instructions }}</span>
+        {{ message }} {{ instructions }}
     </div>
     {{ #reconnectDurationAsSeconds }}
     <div class="network-status-message">

--- a/test/views/network_status_view_test.js
+++ b/test/views/network_status_view_test.js
@@ -28,7 +28,7 @@ describe('NetworkStatusView', function() {
 
     beforeEach(function() {
       networkStatusView = new Whisper.NetworkStatusView();
-      $('.network-status-container').append(networkStatusView.el);
+      $('.network-status-banner').append(networkStatusView.el);
     });
     afterEach(function() {
       // prevents huge number of errors on console after running tests


### PR DESCRIPTION
### First time contributor checklist:

* [ X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [X ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [ X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [ X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [ X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [X ] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [X ] My changes are ready to be shipped to users
* [X ] Yarn Lint Passes

### Description

This change moved the network status alert view from inside of inbox view to the app view. Network status alerting should be app level. Additionally this change also adds a template to app view to start off standardising certain app level UI elements and to add app level UI elements. 

1. Removes network UI status reporting code from the inbox view to the app view.

2. Bringing a common look and feel to UI elements such as alert banners

3. Added a template to app view to allow for common app level UI elements

<img width="1552" alt="screen shot 2018-08-17 at 2 21 23 pm" src="https://user-images.githubusercontent.com/832235/44282572-7c71ed00-a229-11e8-8297-dc34118f1fc8.png">
