### PR TITLE
Add font fallback candidates for CJK characters

### DIFF
--- a/stylesheets/_variables.scss
+++ b/stylesheets/_variables.scss
@@ -22,8 +22,8 @@
   font-weight: bold;
 }
 
-$roboto: Roboto, 'Helvetica Neue', Arial, Helvetica, sans-serif;
-$roboto-light: Roboto-Light, 'Helvetica Neue', Arial, Helvetica, sans-serif;
+$roboto: Roboto, 'Helvetica Neue', 'Source Sans Pro', 'Source Han Sans SC', 'Source Han Sans CN', 'Hiragino Sans GB', 'Hiragino Kaku Gothic', 'Microsoft Yahei UI', 'Arial', sans-serif;
+$roboto-light: Roboto-Light, 'Helvetica Neue', 'Source Sans Pro Light', 'Source Han Sans SC Light', 'Source Han Sans CN Light', 'Hiragino Sans GB Light', 'Hiragino Kaku Gothic Light', 'Microsoft Yahei UI Light', 'Arial', sans-serif;
 
 // New colors
 

--- a/stylesheets/_variables.scss
+++ b/stylesheets/_variables.scss
@@ -22,8 +22,8 @@
   font-weight: bold;
 }
 
-$roboto: Roboto, 'Helvetica Neue', 'Source Sans Pro', 'Source Han Sans SC', 'Source Han Sans CN', 'Hiragino Sans GB', 'Hiragino Kaku Gothic', 'Microsoft Yahei UI', 'Arial', sans-serif;
-$roboto-light: Roboto-Light, 'Helvetica Neue', 'Source Sans Pro Light', 'Source Han Sans SC Light', 'Source Han Sans CN Light', 'Hiragino Sans GB Light', 'Hiragino Kaku Gothic Light', 'Microsoft Yahei UI Light', 'Arial', sans-serif;
+$roboto: Roboto, 'Helvetica Neue', 'Source Sans Pro', 'Source Han Sans SC', 'Source Han Sans CN', 'Hiragino Sans GB', 'Hiragino Kaku Gothic', 'Microsoft Yahei UI', Helvetica, Arial, sans-serif;
+$roboto-light: Roboto-Light, 'Helvetica Neue', 'Source Sans Pro Light', 'Source Han Sans SC Light', 'Source Han Sans CN Light', 'Hiragino Sans GB Light', 'Hiragino Kaku Gothic Light', 'Microsoft Yahei UI Light',  Helvetica, Arial, sans-serif;
 
 // New colors
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
The default fallback font for Chinese charaters on Windows is SimSun,
![image](https://user-images.githubusercontent.com/13471233/44697098-e487c500-aaac-11e8-95cc-de47b349bad8.png)
which is old and not actually a sans-serif font.
![image](https://user-images.githubusercontent.com/13471233/44697426-3c72fb80-aaae-11e8-8437-bee0b2c8f78e.png)
And looks very different from the English alphabets.

With this commit:
![image](https://user-images.githubusercontent.com/13471233/44697341-ebfb9e00-aaad-11e8-81be-502b449645d6.png)
