### PR TITLE
Fix unclickable checkbox labels in settings

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -89,14 +89,14 @@
     <hr>
     <div class='spell-check-setting'>
       <h3>{{ spellCheckHeader }}</h3>
-      <input type='checkbox' name='spell-check-setting' />
+      <input type='checkbox' name='spell-check-setting' id='spell-check-setting' />
       <label for='spell-check-setting'>{{ spellCheckDescription }}</label>
     </div>
     <hr>
     <div class='permissions-setting'>
       <h3>{{ permissions }}</h3>
       <div class='media-permissions'>
-        <input type='checkbox' name='media-permissions' />
+        <input type='checkbox' name='media-permissions' id='media-permissions' />
         <label for='media-permissions'>{{ mediaPermissionsDescription }}</label>
       </div>
     </div>


### PR DESCRIPTION
### First time contributor checklist:

* [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [X] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [X] My changes are ready to be shipped to users

### Description

The tiny pull request fixes unclickable checkbox labels in settings