### PR TITLE
Fix Broken Link to Support Page

### DIFF
--- a/main.js
+++ b/main.js
@@ -376,7 +376,7 @@ function openNewBugForm() {
 
 function openSupportPage() {
   shell.openExternal(
-    'https://support.signal.org/hc/en-us/categories/202319038-Desktop'
+    'https://support.signal.org/hc/en-us'
   );
 }
 


### PR DESCRIPTION
### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [X] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [X] My changes are ready to be shipped to users

### Description

Support Page no longer has a desktop category. So it might be a good idea to change the link to Signal Support Center.
