### PR TITLE
Prevent sending message to wrong person

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -813,8 +813,14 @@
     "description": "Label for the time a message was received"
   },
   "sendMessage": {
-    "message": "Send a message",
-    "description": "Placeholder text in the message entry field"
+    "message": "Send a message to $name$",
+    "description": "Placeholder text in the message entry field",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "John"
+      }
+    }
   },
   "groupMembers": {
     "message": "Group members"

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -65,7 +65,7 @@
     template: $('#conversation').html(),
     render_attributes() {
       return {
-        'send-message': i18n('sendMessage'),
+        'send-message': i18n('sendMessage', this.model.getDisplayName()),
         'android-length-warning': i18n('androidMessageLengthWarning'),
       };
     },


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) - *NOTE* Couldn't get ChromeDriver to work, but other tests passed
* [x] My changes are ready to be shipped to users

### Description

All this change does is add the contacts's display name to the input box.

It's much easier to send a message to the wrong person in Signal Desktop because the input box is much farther from the active contact's name.

<img width="1552" alt="screen shot 2018-09-12 at 3 16 38 pm" src="https://user-images.githubusercontent.com/15787/45448383-341ae300-b6a0-11e8-9a2a-e893b5c3fced.png">

That is not a problem with the phone versions:

![img_2110](https://user-images.githubusercontent.com/15787/45448204-c4a4f380-b69f-11e8-8ba3-d4cc93fb4824.PNG)
