### PR TITLE
Autofocus conversation text input when switching back to application

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -215,6 +215,9 @@
       this.onFocus = () => {
         if (this.$el.css('display') !== 'none') {
           this.markRead();
+          if ((!this.panels || !this.panels.length) && !this.captureAudioView) {
+            this.$('.send-message').focus();
+          }
         }
       };
       this.window.addEventListener('focus', this.onFocus);


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Very simple fix to automatically focus the text input field of an open conversation when switching back to the Signal application. This prevents text being "lost" when you switch to the app and immediately start typing, without first manually clicking the input field to give it focus.
