### PR TITLE
Fix text alignment for RTL quoted messages

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -728,6 +728,7 @@
   font-size: 14px;
   line-height: 18px;
   color: $color-gray-90;
+  text-align: start;
 
   a {
     color: $color-gray-90;


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description

Set the `text-align` property of the quoted text container element (`module-quote__primary__text`) to `start`, to align RTL messages properly (to right) when RTL messages are quoted.
