### PR TITLE
Change tray icon click to always show/focus window

### DIFF
--- a/app/tray_icon.js
+++ b/app/tray_icon.js
@@ -36,6 +36,23 @@ function createTrayIcon(getMainWindow, messages) {
     tray.updateContextMenu();
   };
 
+  tray.showWindow = () => {
+    const mainWindow = getMainWindow();
+    if (mainWindow) {
+      if (!mainWindow.isVisible()) {
+        mainWindow.show();
+      }
+
+      // On some versions of GNOME the window may not be on top when restored.
+      // This trick should fix it.
+      // Thanks to: https://github.com/Enrico204/Whatsapp-Desktop/commit/6b0dc86b64e481b455f8fce9b4d797e86d000dc1
+      mainWindow.setAlwaysOnTop(true);
+      mainWindow.focus();
+      mainWindow.setAlwaysOnTop(false);
+    }
+    tray.updateContextMenu();
+  };
+
   tray.updateContextMenu = () => {
     const mainWindow = getMainWindow();
 
@@ -70,7 +87,7 @@ function createTrayIcon(getMainWindow, messages) {
     }
   };
 
-  tray.on('click', tray.toggleWindowVisibility);
+  tray.on('click', tray.showWindow);
 
   tray.setToolTip(messages.trayTooltip.message);
   tray.updateContextMenu();

--- a/app/tray_icon.js
+++ b/app/tray_icon.js
@@ -17,6 +17,17 @@ function createTrayIcon(getMainWindow, messages) {
 
   tray = new Tray(iconNoNewMessages);
 
+  tray.forceOnTop = mainWindow => {
+    if (mainWindow) {
+      // On some versions of GNOME the window may not be on top when restored.
+      // This trick should fix it.
+      // Thanks to: https://github.com/Enrico204/Whatsapp-Desktop/commit/6b0dc86b64e481b455f8fce9b4d797e86d000dc1
+      mainWindow.setAlwaysOnTop(true);
+      mainWindow.focus();
+      mainWindow.setAlwaysOnTop(false);
+    }
+  }
+
   tray.toggleWindowVisibility = () => {
     const mainWindow = getMainWindow();
     if (mainWindow) {
@@ -25,12 +36,7 @@ function createTrayIcon(getMainWindow, messages) {
       } else {
         mainWindow.show();
 
-        // On some versions of GNOME the window may not be on top when restored.
-        // This trick should fix it.
-        // Thanks to: https://github.com/Enrico204/Whatsapp-Desktop/commit/6b0dc86b64e481b455f8fce9b4d797e86d000dc1
-        mainWindow.setAlwaysOnTop(true);
-        mainWindow.focus();
-        mainWindow.setAlwaysOnTop(false);
+        tray.forceOnTop(mainWindow);
       }
     }
     tray.updateContextMenu();
@@ -43,12 +49,7 @@ function createTrayIcon(getMainWindow, messages) {
         mainWindow.show();
       }
 
-      // On some versions of GNOME the window may not be on top when restored.
-      // This trick should fix it.
-      // Thanks to: https://github.com/Enrico204/Whatsapp-Desktop/commit/6b0dc86b64e481b455f8fce9b4d797e86d000dc1
-      mainWindow.setAlwaysOnTop(true);
-      mainWindow.focus();
-      mainWindow.setAlwaysOnTop(false);
+      tray.forceOnTop(mainWindow);
     }
     tray.updateContextMenu();
   };


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description

Fixes #2001 by making the behavior of Signal similar to Slack/Discord. If the tray icon is clicked, the window will be shown and brought into focus. Clicking the icon never hides the window.

Tested on Windows 10 x64.