### PR TITLE
Fix comparison for emoji injection at cursor location

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -1456,7 +1456,7 @@
       const colons = `:${emojiData[e.index].short_name}:`;
 
       const textarea = this.$messageField[0];
-      if (textarea.selectionStart || textarea.selectionStart === '0') {
+      if (textarea.selectionStart || textarea.selectionStart === 0) {
         const startPos = textarea.selectionStart;
         const endPos = textarea.selectionEnd;
 


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description

Fixes #2988. Literally removed two characters.

It seems that the line in question originally was using the equality (`==`) operator to compare the numeric `selectionStart` with the string `'0'`, but at some point was changed to the identity operator (`===`) without paying attention to the types being compared, thus the comparison always evaluates to `false`, resulting in emoji being appended to the end of the message when the caret is actually at the start. Changing the string value to a number restores the correct behavior.

Tested on Windows 10 x64.