### PR TITLE
Make notification initials consistent with Avatar component

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1771,6 +1771,21 @@
       }
     },
 
+    getInitials(name) {
+      if (!name) {
+        return null;
+      }
+
+      const cleaned = name.replace(/[^A-Za-z\s]+/g, '').replace(/\s+/g, ' ');
+      const parts = cleaned.split(' ');
+      const initials = parts.map(part => part.trim()[0]);
+      if (!initials.length) {
+        return null;
+      }
+
+      return initials.slice(0, 2).join('');
+    },
+
     isPrivate() {
       return this.get('type') === 'private';
     },

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1817,7 +1817,7 @@
       } else if (this.isPrivate()) {
         return {
           color,
-          content: title ? title.trim()[0] : '#',
+          content: this.getInitials(title) || '#',
         };
       }
       return { url: 'images/group_default.png', color };


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description

Fixes #3001. The notification icon was inconsistent with the rest of the Signal app in that it used the first character of the conversation title when there was no profile image. The `Avatar` component used in the app UI uses a `getInitials` function to remove all non-word characters from the name, then gets up to two initials from the remaining word characters. This caused the icon shown in the notification to be different from the one shown everywhere else in the app window in cases where the user had two words in their name ("Mike Smith" would show as "MS" in the app, but only "M" in the notification) or if there were emoji or other characters in the name (":smile: Mike Smith" would show as "MS" in the app, but as ":smile:" in the notification).

The existing `getInitials` function is TypeScript, so I had to duplicate it in the conversation code since that is plain JavaScript.

Tested on Windows 10 x64.