### PR TITLE
Fix issues regarding selection and text in the UI

### DIFF
--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -457,6 +457,7 @@ $loading-height: 16px;
   background-color: white;
   display: flex;
   align-items: center;
+  user-select: none;
 
   .content {
     margin-left: auto;

--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -244,6 +244,8 @@ input.search {
 
 .conversation.placeholder {
   text-align: center;
+  user-select: none;
+
   .container {
     position: absolute;
     height: 100%;

--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -31,6 +31,7 @@
 
   float: left;
   width: 300px;
+  user-select: none;
 
   .content {
     overflow-y: scroll;

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -1275,6 +1275,7 @@
 
 .module-conversation-header__avatar {
   min-width: 28px;
+  user-select: none;
 }
 
 .module-conversation-header__title {
@@ -2554,6 +2555,7 @@
   padding-bottom: 8px;
   border: 1px solid $color-dark-05;
   opacity: 0;
+  user-select: none;
 }
 
 .react-contextmenu--visible {

--- a/stylesheets/_settings.scss
+++ b/stylesheets/_settings.scss
@@ -1,4 +1,6 @@
 .settings {
+  user-select: none;
+
   &.modal {
     padding: 0;
     background-color: transparent;


### PR DESCRIPTION
### First time contributor checklist:

* [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signal-messenger/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [X] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

This PR fixes #2839 by preventing various UI elements from being selected when the user selects all text on screen. 

**Before the fix:** The top status message, entire sidebar contents, recipients avatar alt text, (hidden) context menu contents, and other elements would be selected and copied when user presses `Ctrl/Cmd+A` and then `Ctrl/Cmd+C`. 
**After the fix:** Only text within message bubbles (including timestamps), conversation status texts, and the recipients name and phone number are selected and copied. 

_Conversation View_ before/after screenshot:
![Conversation view before/after](https://cldup.com/SJNQqC-iHD.png)

This PR in turn also fixes #2274 because it prevents the sidebar from being selected via `Ctrl/Cmd+A` or mouse selection. I also extended the selection prevention to the conversation placeholder ('Welcome to Signal') view, settings view (see below), and loading view (excluding the loading text itself).

_Settings view_ before/after screenshot:
![Settings view before/after](https://cldup.com/hEtwkEtXxO.png)

-------

The PR is essentially a few lines of CSS changes, but I've split them into separate commits for easier review. I've tested by repeatedly reloading the app and trying to select different UI elements using the mouse or `Cmd+A`. 

I also spent some time copy/pasting entire conversations from my real conversations to a text editor, to see what got copied and what didn't. After the fix there is a massive reduction in unrelated UI text (noise) getting copied and now only the actual conversation remains. See screenshot below.

I've personally run in to the issue in regular use of Signal Desktop where I tried to copy a bunch of stuff from conversations and ended up having to carefully extract the actual content from the UI noise. 

_Output from select all, copy and paste_ before/after screenshot:
![Copy paste output before/after](https://cldup.com/QGlGkU0asZ.png)

-------

@scottnonnenberg-signal, you mentioned in #2360 (similar closed PR) that you would be open to merging something like this. I figured that I would take a crack at it since I knew how to approach a solution. 

This is my first PR to this project (or any of this size) so let me know if there's something I missed or should have done differently. I hope it's up to standards, because I'd be interested in contributing more in the future.