### PR TITLE
Get rid of the white flash when the app starts up

### DIFF
--- a/background.html
+++ b/background.html
@@ -29,7 +29,7 @@
 
   <script type='text/x-tmpl-mustache' id='app-loading-screen'>
     <div class='content'>
-      <img src='images/icon_128.png'>
+      <img src='images/icon_250.png' height='150'>
       <div class='container'>
         <span class='dot'></span>
         <span class='dot'></span>
@@ -645,7 +645,7 @@
 <body>
   <div class='app-loading-screen'>
     <div class='content'>
-      <img src='images/icon_128.png'>
+      <img src='images/icon_250.png' height='150'>
       <div class='container'>
         <span class='dot'></span>
         <span class='dot'></span>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                 <span class='dot'></span>
                 <span class='dot'></span>
               </div>
-              <div class='message'>Loading...</div>
+              <div class='message'></div>
             </div>
         </div>
         <script type="text/javascript" src="js/index.js"></script>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <body id="signal-container" class='signal index'>
         <div class='app-loading-screen'>
             <div class='content'>
-              <img src='/images/icon_128.png'>
+              <img src='/images/icon_250.png' height='150'>
               <div class='container'>
                 <span class='dot'></span>
                 <span class='dot'></span>

--- a/main.js
+++ b/main.js
@@ -209,6 +209,7 @@ function createWindow() {
       minWidth: MIN_WIDTH,
       minHeight: MIN_HEIGHT,
       autoHideMenuBar: false,
+      backgroundColor: '#2090EA',
       webPreferences: {
         nodeIntegration: false,
         nodeIntegrationInWorker: false,

--- a/main.js
+++ b/main.js
@@ -209,7 +209,10 @@ function createWindow() {
       minWidth: MIN_WIDTH,
       minHeight: MIN_HEIGHT,
       autoHideMenuBar: false,
-      backgroundColor: '#2090EA',
+      backgroundColor:
+        config.environment === 'test' || config.environment === 'test-lib'
+          ? '#ffffff' // Tests should always be rendered on a white background
+          : '#2090EA',
       webPreferences: {
         nodeIntegration: false,
         nodeIntegrationInWorker: false,

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -454,7 +454,8 @@ $loading-height: 16px;
   right: 0;
   top: 0;
   bottom: 0;
-  background-color: white;
+  background-color: $color-signal-blue;
+  color: $color-white;
   display: flex;
   align-items: center;
   user-select: none;
@@ -478,7 +479,7 @@ $loading-height: 16px;
   .dot {
     width: 14px;
     height: 14px;
-    border: 3px solid $blue;
+    border: 3px solid $color-white;
     border-radius: 50%;
     float: left;
     margin: 0 6px;


### PR DESCRIPTION
### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [X] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [ ] My changes are ready to be shipped to users

### Description
(Fixes #1410 and fixes #2925)

#### Background
This PR is an attempt to fix a visual annoyance when the app starts up. When Signal (ie. Electron) starts up, a white FOUC (Flash Of Unstyled Content) occurs, because the initial page being rendered is a plain HTML file without styling. The assets are only loaded afterwards and those render the Signal logo and a loading text. This is specially awkward for those who use the dark theme (like myself) who are treated to a blindingly white screen for a few seconds before the assets and user settings are loaded, switching the theme to that pleasant dark mode.

I dug around the issues and found two other instances of this being discussed. First as a bug in #1410 and more recently as a feature request in #2925. 

In #1410, @scottnonnenberg-signal lays out why implementing loading of the user's selected theme and injecting it before the app is ready to start would be, _"A bit too much engineering for my taste"_ and I fully agree. So I decided to take a crack at the simpler solution proposed in the discussion: Replacing the white screen with a pleasant blue screen that works for both themes (and avoids adding more messy code).

I started by poking around the CSS and templates (I'm still new to the codebase) and figuring out where different colors are being set and used. I then tried different solutions to get the Signal Blue™ to render as the default background and it turned out to be as easy as I hoped, using the Electron `BrowserWindow` options. I only had to invert the colors of the loading elements to make it work. (And account for the testing pages too.)

#### Proposed solution

I have made 4 short screencaps of Signal Desktop starting up showing the problem and the solution:

* [Video: The problem (light theme)](https://cloudup.com/iM3vdK8lm37)
* [Video: The problem (dark theme)](https://cloudup.com/iSO76WcTKvq)
* [Video: Proposed solution (light theme)](https://cloudup.com/iXofcy1jaKW)
* [Video: Proposed solution (dark theme)](https://cloudup.com/iiMLyqXIGhY)

(**Note:** The sidebar/inbox in Signal in the videos is not broken. Hiding the conversations was just the easiest way to censor my real conversations without starting up a video editor 😇)

I feel like this works quite well for both themes and effectively kills the eye sore of the white FOUC for dark theme users, while not making things worse for light theme users. 
Also the Signal Blue™ just looks great and makes the app feel less Electron-y and webapp-y. (It's made me want to create a fully Signal Blue™ theme someday 🙈). 

I guess two further improvements could be:
* Remove the "loading" text. The text isn't localized because the app (and settings) are still loading, [see example here](https://github.com/signalapp/Signal-Desktop/issues/1410#issuecomment-326807561).
* Maybe replace the Signal logo in the loading screen with a logo without the border around it. 

While this is a minor fix code-wise, it has a big impact on the design, so I imagine there will be a discussion. What does the team and everyone else think of this? 