### PR TITLE
Remove gconf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,8 +199,6 @@
     },
     "deb": {
       "depends": [
-        "gconf2",
-        "gconf-service",
         "libnotify4",
         "libappindicator1",
         "libxtst6",


### PR DESCRIPTION
### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [x] My changes are ready to be shipped to users

### Description
As requested in https://github.com/signalapp/Signal-Desktop/issues/2344#issuecomment-466486594

> @scottnonnenberg-signal
> Maybe one of you can do a little bit of testing/investigation and submit a tiny PR for the next beta?

I tested this by
* removing the `gconf2` and `gconf-service` dependencies from `packages.json`
* uninstalling all gconf packages from my system (Ubuntu 18.04)
* compiling the client and running it 24 hours (and counting)
* then on a fresh Ubuntu 18.04 docker container¹
  * installed `signal-desktop_1.22.0-beta.2_amd64.deb` with gconf dependencies untouched
  * installed `signal-desktop_1.22.0-beta.2_amd64.deb` with gconf dependencies removed on top of the previous package (i.e. updated)
  * removed the signal-desktop package

No errors encountered.

¹) See full log of this process: https://pastebin.com/PzWmeSV2