### PR TITLE
Remap zoom to Command+= on macOS

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -85,6 +85,7 @@ exports.createTemplate = (options, messages) => {
           label: messages.viewMenuResetZoom.message,
         },
         {
+          accelerator: platform === 'darwin' ? 'Command+=' : 'Control+Plus',
           role: 'zoomin',
           label: messages.viewMenuZoomIn.message,
         },

--- a/test/app/fixtures/menu-mac-os-setup.json
+++ b/test/app/fixtures/menu-mac-os-setup.json
@@ -115,6 +115,7 @@
         "role": "resetzoom"
       },
       {
+        "accelerator": "Command+=",
         "label": "Zoom In",
         "role": "zoomin"
       },

--- a/test/app/fixtures/menu-mac-os.json
+++ b/test/app/fixtures/menu-mac-os.json
@@ -102,6 +102,7 @@
         "role": "resetzoom"
       },
       {
+        "accelerator": "Command+=",
         "label": "Zoom In",
         "role": "zoomin"
       },

--- a/test/app/fixtures/menu-windows-linux-setup.json
+++ b/test/app/fixtures/menu-windows-linux-setup.json
@@ -74,6 +74,7 @@
         "role": "resetzoom"
       },
       {
+        "accelerator": "Control+Plus",
         "label": "Zoom In",
         "role": "zoomin"
       },

--- a/test/app/fixtures/menu-windows-linux.json
+++ b/test/app/fixtures/menu-windows-linux.json
@@ -63,6 +63,7 @@
         "role": "resetzoom"
       },
       {
+        "accelerator": "Control+Plus",
         "label": "Zoom In",
         "role": "zoomin"
       },


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [ X ] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [ X ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [ X ] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [ X ] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [ X ] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [ X ] My changes pass 100% of [local tests](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)
* [ X ] My changes are ready to be shipped to users


### Description

This fixes #3218 by re-mapping the zoom command in iOS to Command+=, since Command+Plus mapping is incorrect due to an [electron bug](https://github.com/electron/electron/issues/6731)

Manually tested on MacOS X 10.14.3
Also updated unit tests, and they are all passing. 