### PR TITLE
Add pinterest domain and asset domains for link preview support

### DIFF
--- a/js/modules/link_previews.js
+++ b/js/modules/link_previews.js
@@ -34,6 +34,9 @@ const SUPPORTED_DOMAINS = [
   'instagram.com',
   'www.instagram.com',
   'm.instagram.com',
+  'pinterest.com',
+  'www.pinterest.com',
+  'pin.it',
 ];
 function isLinkInWhitelist(link) {
   try {
@@ -58,7 +61,7 @@ function isLinkInWhitelist(link) {
   }
 }
 
-const SUPPORTED_MEDIA_DOMAINS = /^([^.]+\.)*(ytimg.com|cdninstagram.com|redd.it|imgur.com|fbcdn.net)$/i;
+const SUPPORTED_MEDIA_DOMAINS = /^([^.]+\.)*(ytimg.com|cdninstagram.com|redd.it|imgur.com|fbcdn.net|pinimg.com)$/i;
 function isMediaLinkInWhitelist(link) {
   try {
     const url = new URL(link);

--- a/test/modules/link_previews_test.js
+++ b/test/modules/link_previews_test.js
@@ -37,6 +37,12 @@ describe('Link previews', () => {
         isLinkInWhitelist('https://m.instagram.com/blah'),
         true
       );
+      assert.strictEqual(isLinkInWhitelist('https://pinterest.com/blah'), true);
+      assert.strictEqual(
+        isLinkInWhitelist('https://www.pinterest.com/blah'),
+        true
+      );
+      assert.strictEqual(isLinkInWhitelist('https://pin.it/blah'), true);
     });
 
     it('returns false for subdomains', () => {
@@ -109,6 +115,10 @@ describe('Link previews', () => {
         isMediaLinkInWhitelist('https://i.imgur.com/something'),
         true
       );
+      assert.strictEqual(
+        isMediaLinkInWhitelist('https://pinimg.com/something'),
+        true
+      );
     });
 
     it('returns false for insecure protocol', () => {
@@ -128,6 +138,10 @@ describe('Link previews', () => {
       );
       assert.strictEqual(
         isMediaLinkInWhitelist('http://i.imgur.com/something'),
+        false
+      );
+      assert.strictEqual(
+        isMediaLinkInWhitelist('https://pinimg.com/something'),
         false
       );
     });


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description
We'd like signal to show link previews for Pinterest 😄
Android PR: https://github.com/signalapp/Signal-Android/pull/8760
iOS PR: https://github.com/signalapp/Signal-iOS/pull/4176

Please write a summary of your test approach:
  - What kind of manual testing did you do? We respect crawlers and open-graph
  - Did you write any new tests? Unit
