### PR TITLE
Linkify URLs with @ symbol

### DIFF
--- a/test/modules/link_previews_test.js
+++ b/test/modules/link_previews_test.js
@@ -305,6 +305,19 @@ describe('Link previews', () => {
       const actual = findLinks(text, caretLocation);
       assert.deepEqual(expected, actual);
     });
+
+    it('includes links with "special" characters', () => {
+      const text =
+        'Check out this link: https://en.wikipedia.org/wiki/@\nAnd this one too: https://en.wikipedia.org/wiki/:';
+
+      const expected = [
+        'https://en.wikipedia.org/wiki/@',
+        'https://en.wikipedia.org/wiki/:',
+      ];
+
+      const actual = findLinks(text);
+      assert.deepEqual(expected, actual);
+    });
   });
 
   describe('#isLinkSneaky', () => {

--- a/ts/components/conversation/Linkify.tsx
+++ b/ts/components/conversation/Linkify.tsx
@@ -14,7 +14,6 @@ interface Props {
 }
 
 const SUPPORTED_PROTOCOLS = /^(http|https):/i;
-const HAS_AT = /@/;
 
 export class Linkify extends React.Component<Props> {
   public static defaultProps: Partial<Props> = {
@@ -51,11 +50,7 @@ export class Linkify extends React.Component<Props> {
         }
 
         const { url, text: originalText } = match;
-        if (
-          SUPPORTED_PROTOCOLS.test(url) &&
-          !isLinkSneaky(url) &&
-          !HAS_AT.test(url)
-        ) {
+        if (SUPPORTED_PROTOCOLS.test(url) && !isLinkSneaky(url)) {
           results.push(
             <a key={count++} href={url}>
               {originalText}


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] A `yarn test` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

This reverts commit c1b680e and adds a test for URLs with `@` and `:`.  Unfortunately the commit message and code doesn't provide a reason why URLs with `@` symbols should not be parsed as links. As you can imagine, this certainly leads to problems. The `@` symbol is a valid character that may be used unencoded in URLs and is used on some sites. I also wasn't able to find an issue filed by the user mentioned in the commit message.

Signal on Android parses URLs with `@` symbols.

Is there a good reason to not parse URLs that include an `@` symbol? linkify-it would render email addresses as `mailto:` links, which I would regard a feature rather than a bug.