### PR TITLE
Textual enhancements

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -300,7 +300,7 @@
       "Used as a label on a button allowing user to see more information"
   },
   "youLeftTheGroup": {
-    "message": "You left the group",
+    "message": "You can't send a message because you have left the group",
     "description":
       "Displayed when a user can't send a message because they have left the group"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -167,17 +167,17 @@
       "Only available on development modes, menu option to open up the standalone device setup sequence"
   },
   "loading": {
-    "message": "Loading...",
+    "message": "Loading…",
     "description":
       "Message shown on the loading screen before we've loaded any messages"
   },
   "optimizingApplication": {
-    "message": "Optimizing application...",
+    "message": "Optimizing application…",
     "description":
       "Message shown on the loading screen while we are doing application optimizations"
   },
   "migratingToSQLCipher": {
-    "message": "Optimizing messages... $status$ complete.",
+    "message": "Optimizing messages… $status$ complete.",
     "description":
       "Message shown on the loading screen while we are doing application optimizations",
     "placeholders": {
@@ -275,12 +275,12 @@
       "Message shown as the export location if we didn't capture the target directory"
   },
   "upgradingDatabase": {
-    "message": "Upgrading database. This may take some time...",
+    "message": "Upgrading database. This may take some time…",
     "description":
       "Message shown on the loading screen when we're changing database structure on first run of a new version"
   },
   "loadingMessages": {
-    "message": "Loading messages. $count$ so far...",
+    "message": "Loading messages. $count$ so far…",
     "description":
       "Message shown on the loading screen when we're catching up on the backlog of messages",
     "placeholders": {
@@ -592,7 +592,7 @@
       "Shown in toast when user attempts to send .exe file, for example"
   },
   "loadingPreview": {
-    "message": "Loading Preview...",
+    "message": "Loading Preview…",
     "description":
       "Shown while Signal Desktop is fetching metadata for a url in composition area"
   },
@@ -1001,7 +1001,7 @@
       "You haven't exchanged any messages with this contact yet. Your safety number with them will be available after the first message."
   },
   "moreInfo": {
-    "message": "More Info...",
+    "message": "More Info…",
     "description":
       "Shown on the drop-down menu for an individual message, takes you to message detail screen"
   },
@@ -1053,7 +1053,7 @@
       "Used for the icon layered on top of an image in message bubbles"
   },
   "addACaption": {
-    "message": "Add a caption...",
+    "message": "Add a caption…",
     "descripton":
       "Used as the placeholder text in the caption editor text field"
   },
@@ -1302,7 +1302,7 @@
       "Label for a button that syncs contacts and groups from your phone"
   },
   "syncing": {
-    "message": "Importing...",
+    "message": "Importing…",
     "description": "Label for a disabled sync button while sync is in progress."
   },
   "syncFailed": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1397,7 +1397,7 @@
     "placeholders": {
       "time": {
         "content": "$1",
-        "example": "10m"
+        "example": "10 min"
       }
     }
   },
@@ -1408,7 +1408,7 @@
     "placeholders": {
       "time": {
         "content": "$1",
-        "example": "10m"
+        "example": "10 min"
       }
     }
   },
@@ -1423,7 +1423,7 @@
       },
       "time": {
         "content": "$2",
-        "example": "10m"
+        "example": "10 min"
       }
     }
   },
@@ -1497,57 +1497,57 @@
       "Short format indicating current timer setting in the conversation list snippet"
   },
   "timerOption_5_seconds_abbreviated": {
-    "message": "5s",
+    "message": "5 s",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_10_seconds_abbreviated": {
-    "message": "10s",
+    "message": "10 s",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_30_seconds_abbreviated": {
-    "message": "30s",
+    "message": "30 s",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_1_minute_abbreviated": {
-    "message": "1min",
+    "message": "1 min",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_5_minutes_abbreviated": {
-    "message": "5min",
+    "message": "5 min",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_30_minutes_abbreviated": {
-    "message": "30min",
+    "message": "30 min",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_1_hour_abbreviated": {
-    "message": "1h",
+    "message": "1 h",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_6_hours_abbreviated": {
-    "message": "6h",
+    "message": "6 h",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_12_hours_abbreviated": {
-    "message": "12h",
+    "message": "12 h",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_1_day_abbreviated": {
-    "message": "1d",
+    "message": "1 d",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_1_week_abbreviated": {
-    "message": "1w",
+    "message": "1 w",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
@@ -1578,7 +1578,7 @@
     "placeholders": {
       "time": {
         "content": "$1",
-        "example": "1w"
+        "example": "1 w"
       }
     }
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1512,17 +1512,17 @@
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_1_minute_abbreviated": {
-    "message": "1m",
+    "message": "1min",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_5_minutes_abbreviated": {
-    "message": "5m",
+    "message": "5min",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },
   "timerOption_30_minutes_abbreviated": {
-    "message": "30m",
+    "message": "30min",
     "description":
       "Very short format indicating current timer setting in the conversation header"
   },


### PR DESCRIPTION
A few textual enhancements, following issues reported by translators on Transifex.

Relates to Android PR: https://github.com/signalapp/Signal-Android/pull/8715
Relates to iOS PR: https://github.com/signalapp/Signal-iOS/pull/4193

### Contributor checklist:

* [ ] My contribution is **not** related to translations.
The thing is, this contribution is related to the initial English text strings. This does belong on Github. Transifex does not offer a way to give feedback on original English text strings.

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

