### PR TITLE
Add launch on login feature

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1161,7 +1161,11 @@
   },
   "spellCheckDescription": {
     "message": "Enable spell check of text entered in message composition box",
-    "description": "Description of the media permission description"
+    "description": "Description of the spell check setting"
+  },
+  "autoLaunchDescription": {
+    "message": "Launch Signal automatically when you login to your computer",
+    "description": "Description for the automatic launch setting"
   },
   "clearDataHeader": {
     "message": "Clear Data",

--- a/js/background.js
+++ b/js/background.js
@@ -261,6 +261,15 @@
         startSpellCheck();
       },
 
+      getAutoLaunch: () => window.signalAutoLauncher.isEnabled().catch(err => window.log.error(err)),
+      setAutoLaunch: value => {
+        if(value) {
+            window.signalAutoLauncher.enable();
+        }
+        else {
+            window.signalAutoLauncher.disable();
+        }
+      },
       // eslint-disable-next-line eqeqeq
       isPrimary: () => textsecure.storage.user.getDeviceId() == '1',
       getSyncRequest: () =>

--- a/js/settings_start.js
+++ b/js/settings_start.js
@@ -38,6 +38,7 @@ const getInitialData = async () => ({
   audioNotification: await window.getAudioNotification(),
 
   spellCheck: await window.getSpellCheck(),
+  autoLaunch: await window.getAutoLaunch(),
 
   mediaPermissions: await window.getMediaPermissions(),
 

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -108,6 +108,12 @@
         value: window.initialData.spellCheck,
         setFn: window.setSpellCheck,
       });
+      new CheckboxView({
+        el: this.$('.auto-launch-setting'),
+        name: 'auto-launch-setting',
+        value: window.initialData.autoLaunch,
+        setFn: window.setAutoLaunch,
+      });
       if (Settings.isHideMenuBarSupported()) {
         new CheckboxView({
           el: this.$('.menu-bar-setting'),
@@ -157,6 +163,7 @@
         mediaPermissionsDescription: i18n('mediaPermissionsDescription'),
         generalHeader: i18n('general'),
         spellCheckDescription: i18n('spellCheckDescription'),
+        autoLaunchDescription: i18n('autoLaunchDescription'),
         sendLinkPreviews: i18n('sendLinkPreviews'),
         linkPreviewsDescription: i18n('linkPreviewsDescription'),
       };

--- a/main.js
+++ b/main.js
@@ -962,6 +962,9 @@ installSettingsSetter('audio-notification');
 installSettingsGetter('spell-check');
 installSettingsSetter('spell-check');
 
+installSettingsGetter('auto-launch');
+installSettingsSetter('auto-launch');
+
 // This one is different because its single source of truth is userConfig, not IndexedDB
 ipc.on('get-media-permissions', event => {
   event.sender.send(

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@journeyapps/sqlcipher": "https://github.com/scottnonnenberg-signal/node-sqlcipher.git#2e28733b61640556b0272a3bfc78b0357daf71e6",
     "@sindresorhus/is": "0.8.0",
+    "auto-launch": "^5.0.5",
     "backbone": "1.3.3",
     "blob-util": "1.3.0",
     "blueimp-canvas-to-blob": "3.14.0",
@@ -209,11 +210,16 @@
       "target": [
         "nsis"
       ],
-      "extraFiles": [{
-        "from": "node_modules/@journeyapps/sqlcipher/build/Release/",
-        "to": ".",
-        "filter": ["msvcp140.dll", "vcruntime140.dll"]
-      }]
+      "extraFiles": [
+        {
+          "from": "node_modules/@journeyapps/sqlcipher/build/Release/",
+          "to": ".",
+          "filter": [
+            "msvcp140.dll",
+            "vcruntime140.dll"
+          ]
+        }
+      ]
     },
     "nsis": {
       "deleteAppDataOnUninstall": true

--- a/preload.js
+++ b/preload.js
@@ -2,6 +2,7 @@
 
 const electron = require('electron');
 const semver = require('semver');
+const AutoLaunch = require('auto-launch');
 
 const { deferredToPromise } = require('./js/modules/deferred_to_promise');
 
@@ -24,6 +25,10 @@ if (config.environment !== 'production') {
 if (config.appInstance) {
   title += ` - ${config.appInstance}`;
 }
+
+window.signalAutoLauncher = new AutoLaunch({
+  name: 'Signal',
+});
 
 window.platform = process.platform;
 window.getTitle = () => title;
@@ -150,6 +155,9 @@ installSetter('audio-notification', 'setAudioNotification');
 
 installGetter('spell-check', 'getSpellCheck');
 installSetter('spell-check', 'setSpellCheck');
+
+installGetter('auto-launch', 'getAutoLaunch');
+installSetter('auto-launch', 'setAutoLaunch');
 
 window.getMediaPermissions = () =>
   new Promise((resolve, reject) => {

--- a/settings.html
+++ b/settings.html
@@ -100,6 +100,10 @@
         <input type='checkbox' name='spell-check-setting' id='spell-check-setting' />
         <label for='spell-check-setting'>{{ spellCheckDescription }}</label>
       </div>
+      <div class='auto-launch-setting'>
+        <input type='checkbox' name='auto-launch-setting' id='auto-launch-setting' />
+        <label for='auto-launch-setting'>{{ autoLaunchDescription }}</label>
+      </div>
     <hr>
     <div class='permissions-setting'>
       <h3>{{ permissions }}</h3>

--- a/settings_preload.js
+++ b/settings_preload.js
@@ -15,6 +15,7 @@ window.platform = process.platform;
 window.theme = config.theme;
 window.i18n = i18n.setup(locale, localeMessages);
 
+
 function setSystemTheme() {
   window.systemTheme = systemPreferences.isDarkMode() ? 'dark' : 'light';
 }
@@ -58,6 +59,9 @@ window.setHideMenuBar = makeSetter('hide-menu-bar');
 
 window.getSpellCheck = makeGetter('spell-check');
 window.setSpellCheck = makeSetter('spell-check');
+
+window.getAutoLaunch = makeGetter('auto-launch');
+window.setAutoLaunch = makeSetter('auto-launch');
 
 window.getNotificationSetting = makeGetter('notification-setting');
 window.setNotificationSetting = makeSetter('notification-setting');

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,6 +514,11 @@ append-transform@^0.4.0:
   dependencies:
     default-require-extensions "^1.0.0"
 
+applescript@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/applescript/-/applescript-1.0.0.tgz#bb87af568cad034a4e48c4bdaf6067a3a2701317"
+  integrity sha1-u4evVoytA0pOSMS9r2Bno6JwExc=
+
 aproba@^1.0.3:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.1.tgz#95d3600f07710aa0e9298c726ad5ecf2eacbabab"
@@ -767,6 +772,17 @@ atob@^2.0.0:
 atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
+
+auto-launch@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/auto-launch/-/auto-launch-5.0.5.tgz#d14bd002b1ef642f85e991a6195ff5300c8ad3c0"
+  integrity sha512-ppdF4mihhYzMYLuCcx9H/c5TUOCev8uM7en53zWVQhyYAJrurd2bFZx3qQVeJKF2jrc7rsPRNN5cD+i23l6PdA==
+  dependencies:
+    applescript "^1.0.0"
+    mkdirp "^0.5.1"
+    path-is-absolute "^1.0.0"
+    untildify "^3.0.2"
+    winreg "1.2.4"
 
 autoprefixer@^6.3.1:
   version "6.7.7"
@@ -9828,6 +9844,11 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+untildify@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.3.tgz#1e7b42b140bcfd922b22e70ca1265bfe3634c7c9"
+  integrity sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==
+
 unused-filename@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unused-filename/-/unused-filename-1.0.0.tgz#d340880f71ae2115ebaa1325bef05cc6684469c6"
@@ -10228,6 +10249,11 @@ widest-line@^1.0.0:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+winreg@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/winreg/-/winreg-1.2.4.tgz#ba065629b7a925130e15779108cf540990e98d1b"
+  integrity sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs=
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.



Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #1653 and adds an option to the settings menu that launches Signal on startup.

No new unit tests were added. This has been tested on Windows 10. Other operating systems are assumed to work because the feature is based on [node-auto-launch](https://github.com/Teamwork/node-auto-launch).