### PR TITLE
Include desktopName

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "signal-desktop",
   "productName": "Signal",
   "description": "Private messaging from your desktop",
+  "desktopName": "signal-desktop.desktop",
   "repository": "https://github.com/signalapp/Signal-Desktop.git",
   "version": "1.25.1-beta.1",
   "license": "GPL-3.0",

--- a/prepare_beta_build.js
+++ b/prepare_beta_build.js
@@ -38,6 +38,10 @@ const STARTUP_WM_CLASS_PATH = 'build.linux.desktop.StartupWMClass';
 const PRODUCTION_STARTUP_WM_CLASS = 'Signal';
 const BETA_STARTUP_WM_CLASS = 'Signal Beta';
 
+const DESKTOP_NAME_PATH = 'desktopName';
+const PRODUCTION_DESKTOP_NAME = PRODUCTION_NAME + '.desktop';
+const BETA_DESKTOP_NAME = BETA_NAME + '.desktop';
+
 // -------
 
 function checkValue(object, objectPath, expected) {
@@ -53,6 +57,7 @@ checkValue(packageJson, NAME_PATH, PRODUCTION_NAME);
 checkValue(packageJson, PRODUCT_NAME_PATH, PRODUCTION_PRODUCT_NAME);
 checkValue(packageJson, APP_ID_PATH, PRODUCTION_APP_ID);
 checkValue(packageJson, STARTUP_WM_CLASS_PATH, PRODUCTION_STARTUP_WM_CLASS);
+checkValue(packageJson, DESKTOP_NAME_PATH, PRODUCTION_DESKTOP_NAME);
 
 // -------
 
@@ -60,6 +65,7 @@ _.set(packageJson, NAME_PATH, BETA_NAME);
 _.set(packageJson, PRODUCT_NAME_PATH, BETA_PRODUCT_NAME);
 _.set(packageJson, APP_ID_PATH, BETA_APP_ID);
 _.set(packageJson, STARTUP_WM_CLASS_PATH, BETA_STARTUP_WM_CLASS);
+_.set(packageJson, DESKTOP_NAME_PATH, BETA_DESKTOP_NAME);
 
 // -------
 

--- a/prepare_beta_build.js
+++ b/prepare_beta_build.js
@@ -39,8 +39,8 @@ const PRODUCTION_STARTUP_WM_CLASS = 'Signal';
 const BETA_STARTUP_WM_CLASS = 'Signal Beta';
 
 const DESKTOP_NAME_PATH = 'desktopName';
-const PRODUCTION_DESKTOP_NAME = PRODUCTION_NAME + '.desktop';
-const BETA_DESKTOP_NAME = BETA_NAME + '.desktop';
+const PRODUCTION_DESKTOP_NAME = `${PRODUCTION_NAME}.desktop`;
+const BETA_DESKTOP_NAME = `${BETA_NAME}.desktop`;
 
 // -------
 


### PR DESCRIPTION
Fixes: #3387

### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description
This ~~hopefully~~ fixes: #3387
Include `desktopName` field in `package.json`, this should allow electron to properly set badge count on Linux. This should make it easier for users to see that there new messages. 

~~Have not been able to test because of: https://github.com/signalapp/Signal-Desktop/issues/3389~~
I've now been able to test this.