### PR TITLE
Enable write-ahead logging for increased SQLite performance

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -205,6 +205,17 @@ async function setupSQLCipher(instance, { key }) {
 
   // Because foreign key support is not enabled by default!
   await instance.run('PRAGMA foreign_keys = ON;');
+
+  // Try to enable write-ahead logging for increased performance,
+  // see https://www.sqlite.org/wal.html for details.
+  // Note that this is a persistent setting in the database.
+  const row = await instance.get('PRAGMA journal_mode = WAL;');
+  if (row.journal_mode === 'wal') {
+    // synchronous = NORMAL is safe with WAL mode
+    await instance.run('PRAGMA synchronous = NORMAL;');
+  } else {
+    console.log('setupSQLCipher: not using WAL mode');
+  }
 }
 
 async function updateToSchemaVersion1(currentVersion, instance) {


### PR DESCRIPTION
### First time contributor checklist:

* [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [X] My changes are ready to be shipped to users

I haven't marked the `yarn ready` but everything passes except that I get two questionable lines in `yarn lint-deps`. I assume this is because I'm building against my system electron and node. Note that I haven't touched the deps.

### Description
This enables write-ahead logging (WAL) in SQLite/SQLCipher and "NORMAL" as the "synchronous" mode. WAL increases performance in typical settings. It also ensures that "NORMAL" mode leaves the database always in consistent state, so we can additionally enable this mode for further performance improvements.

On my system (Linux, Intel(R) Core(TM) i7-7600U CPU @ 2.80GHz, ext4, fast enough connection), the startup time with 60 new self-sent messages is reduced drastically from 18 seconds to 10 seconds.

As opposed to the approach in #2668, WAL with NORMAL is consistent, i.e., the database will never be corrupted. (The only thing that can happen in case of a power loss/crash is that recent modifications are lost -- but my understanding is that this is something that the application should anyway be designed for, e.g., we could crash after receiving a record for the server but before even starting the database connection.)

See https://www.sqlite.org/wal.html and https://www.sqlite.org/pragma.html#pragma_synchronous for details and background.

Note for testing and benchmarking that setting WAL is persistent. To switch back to the default, use `PRAGMA journal_mode = DELETE`.

Related issues: #3010, #3171, #3172. I don't think that this PR should close these issues. 10 seconds is still very long for 60 messages, and we need to see what other people report. I assume much larger improvements are possible by optimizing the database code.