### PR TITLE
Improve performance of _getLeftPaneList

### DIFF
--- a/ts/state/selectors/conversations.ts
+++ b/ts/state/selectors/conversations.ts
@@ -91,11 +91,11 @@ export const _getConversationComparator = (
     const leftTitle = getConversationTitle(left, {
       i18n,
       ourRegionCode,
-    }).toLowerCase();
+    });
     const rightTitle = getConversationTitle(right, {
       i18n,
       ourRegionCode,
-    }).toLowerCase();
+    });
 
     return collator.compare(leftTitle, rightTitle);
   };
@@ -114,15 +114,13 @@ export const _getLeftPaneLists = (
   conversations: Array<ConversationType>;
   archivedConversations: Array<ConversationType>;
 } => {
-  const values = Object.values(lookup);
-  const sorted = values.sort(comparator);
-
   const conversations: Array<ConversationType> = [];
   const archivedConversations: Array<ConversationType> = [];
 
-  const max = sorted.length;
+  const values = Object.values(lookup);
+  const max = values.length;
   for (let i = 0; i < max; i += 1) {
-    let conversation = sorted[i];
+    let conversation = values[i];
     if (!conversation.activeAt) {
       continue;
     }
@@ -140,6 +138,9 @@ export const _getLeftPaneLists = (
       conversations.push(conversation);
     }
   }
+
+  conversations.sort(comparator);
+  archivedConversations.sort(comparator);
 
   return { conversations, archivedConversations };
 };

--- a/ts/types/PhoneNumber.ts
+++ b/ts/types/PhoneNumber.ts
@@ -1,6 +1,7 @@
 import { instance, PhoneNumberFormat } from '../util/libphonenumberInstance';
+import memoizee from 'memoizee';
 
-export function format(
+function _format(
   phoneNumber: string,
   options: {
     ourRegionCode: string;
@@ -20,6 +21,14 @@ export function format(
     return phoneNumber;
   }
 }
+
+export const format = memoizee(_format, {
+  primitive: true,
+  // Convert the arguments to a unique string, required for primitive mode.
+  normalizer: function(args) {
+      return JSON.stringify(args);
+  }
+});
 
 export function parse(
   phoneNumber: string,


### PR DESCRIPTION
### Contributor checklist:

* [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [X] My changes are ready to be shipped to users

As in my other PR #3395:
I haven't marked the `yarn ready` but everything passes except that I get two questionable lines in `yarn lint-deps`. I assume this is because I'm building against my system electron and node. Note that I haven't touched the deps.
(Maybe I'm too stupid to use the linters, I don't know -- I'm not a javascript guy.)

### Description
The left pane is regenerated in `_getLeftPaneList` after every sent or received message (I think even when downloading messages initially).  This regeneration step is very expensive on my configuration. Almost all of the time is spent sorting the array of conversations using a somewhat expensive comparison function, which sometimes needs to format phone numbers, and will format the same phone number multiple times (when it is compared to another multiple times).

This PR improves the performance  of `_getLeftPaneList` significantly on my configuration from 250-300 ms down to 2.5-3.0 ms. My system is Linux on an Intel(R) Core(TM) i7-7600U CPU @ 2.80GHz, and I have 188 visible conversations (maybe more in the background?). 

User experience impact:
Suddenly, Signal feels okay again. whereas it feels very sluggish for me when sending and receiving messages without this PR.

edit: This also improves the startup time with 60 self-sent messages from around 18 seconds to about 12 seconds. If I combine this PR with #3395, I get around 7 seconds. Your mileage may vary.
(Related issues: #3010, #3171, #3172.)