### PR TITLE
Revert "Add desktopName to package.json to fix linux badge"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "signal-desktop",
   "productName": "Signal",
   "description": "Private messaging from your desktop",
-  "desktopName": "signal-desktop.desktop",
   "repository": "https://github.com/signalapp/Signal-Desktop.git",
   "version": "1.25.2-beta.1",
   "license": "GPL-3.0",

--- a/prepare_beta_build.js
+++ b/prepare_beta_build.js
@@ -38,10 +38,6 @@ const STARTUP_WM_CLASS_PATH = 'build.linux.desktop.StartupWMClass';
 const PRODUCTION_STARTUP_WM_CLASS = 'Signal';
 const BETA_STARTUP_WM_CLASS = 'Signal Beta';
 
-const DESKTOP_NAME_PATH = 'desktopName';
-const PRODUCTION_DESKTOP_NAME = `${PRODUCTION_NAME}.desktop`;
-const BETA_DESKTOP_NAME = `${BETA_NAME}.desktop`;
-
 // -------
 
 function checkValue(object, objectPath, expected) {
@@ -57,7 +53,6 @@ checkValue(packageJson, NAME_PATH, PRODUCTION_NAME);
 checkValue(packageJson, PRODUCT_NAME_PATH, PRODUCTION_PRODUCT_NAME);
 checkValue(packageJson, APP_ID_PATH, PRODUCTION_APP_ID);
 checkValue(packageJson, STARTUP_WM_CLASS_PATH, PRODUCTION_STARTUP_WM_CLASS);
-checkValue(packageJson, DESKTOP_NAME_PATH, PRODUCTION_DESKTOP_NAME);
 
 // -------
 
@@ -65,7 +60,6 @@ _.set(packageJson, NAME_PATH, BETA_NAME);
 _.set(packageJson, PRODUCT_NAME_PATH, BETA_PRODUCT_NAME);
 _.set(packageJson, APP_ID_PATH, BETA_APP_ID);
 _.set(packageJson, STARTUP_WM_CLASS_PATH, BETA_STARTUP_WM_CLASS);
-_.set(packageJson, DESKTOP_NAME_PATH, BETA_DESKTOP_NAME);
 
 // -------
 


### PR DESCRIPTION
Reverts signalapp/Signal-Desktop#3390, which appears to be causing linux builds to fail to startup properly.