### PR TITLE
Add InstantMessaging and Chat categories for deb package

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
       "deleteAppDataOnUninstall": true
     },
     "linux": {
-      "category": "Network",
+      "category": "Network;InstantMessaging;Chat",
       "desktop": {
         "StartupWMClass": "Signal"
       },


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

So I stumbled upon https://www.omgubuntu.co.uk/2019/07/material-shell-tiling-gnome-shell-extension/amp today. Installed it and took it for a test drive, switched through all desktops, one of which is for social and it had all my messengers but Signal.
![Screenshot from 2019-07-04 01-17-07](https://user-images.githubusercontent.com/5943908/60630243-998bbc00-9df9-11e9-99f2-09228ccef02e.png)

I figured to take a look at that and it did not seem to be a problem in the material shell, as it's not having a list of apps. So I checked signals and riots code and found this over at riot. 
https://github.com/vector-im/riot-web/blob/develop/package.json#L171

I haven't tested this, but it seems to be nothing that can hurt.