### PR TITLE
Update search for colon-syntax emoji to ignore case

### DIFF
--- a/ts/components/emoji/lib.ts
+++ b/ts/components/emoji/lib.ts
@@ -255,6 +255,7 @@ export function replaceColons(str: string) {
   return str.replace(/:[a-z0-9-_+]+:(?::skin-tone-[1-5]:)?/gi, m => {
     const [shortName = '', skinTone = '0'] = m
       .replace('skin-tone-', '')
+      .toLowerCase()
       .split(':')
       .filter(Boolean);
 

--- a/ts/test/components/emoji/lib_test.ts
+++ b/ts/test/components/emoji/lib_test.ts
@@ -22,4 +22,9 @@ describe('replaceColons', () => {
     const unknownEmoji = replaceColons(':Unknown: :unknown:');
     assert.equal(unknownEmoji, ':Unknown: :unknown:');
   });
+
+  it('converts short names to lowercase before matching them', () => {
+    const emojiWithCaps = replaceColons('hello :Grinning:');
+    assert.equal(emojiWithCaps, 'hello 😀');
+  })
 });

--- a/ts/test/components/emoji/lib_test.ts
+++ b/ts/test/components/emoji/lib_test.ts
@@ -26,5 +26,5 @@ describe('replaceColons', () => {
   it('converts short names to lowercase before matching them', () => {
     const emojiWithCaps = replaceColons('hello :Grinning:');
     assert.equal(emojiWithCaps, 'hello 😀');
-  })
+  });
 });

--- a/ts/test/components/emoji/lib_test.ts
+++ b/ts/test/components/emoji/lib_test.ts
@@ -1,0 +1,25 @@
+import { assert } from 'chai';
+
+import { replaceColons } from '../../../components/emoji/lib';
+
+describe('replaceColons', () => {
+  it('replaces known emoji short names between colons', () => {
+    const anEmoji = replaceColons('hello :grinning:');
+    assert.equal(anEmoji, 'hello 😀');
+  });
+
+  it('understands skin tone modifiers', () => {
+    const skinToneModifierEmoji = replaceColons('hello :wave::skin-tone-5:!');
+    assert.equal(skinToneModifierEmoji, 'hello 👋🏿!');
+  });
+
+  it('passes through strings with no colons', () => {
+    const noEmoji = replaceColons('hello');
+    assert.equal(noEmoji, 'hello');
+  });
+
+  it('ignores unknown emoji', () => {
+    const unknownEmoji = replaceColons(':Unknown: :unknown:');
+    assert.equal(unknownEmoji, ':Unknown: :unknown:');
+  });
+});


### PR DESCRIPTION
### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Hello again! This pull request brings back the change in #2353 to properly recognise colon-syntax emoji that have mistakenly-typed capital letters in them, an easy error to make when holding the shift key slightly too long after typing the colon. This was lost when 0e9d549 replaced the emoji picker.

This time, I’ve included tests that make assertions on the `replaceColons` function’s existing behaviour and a test that ensures it now ignores case when searching for known emoji short names.

Here’s a GIF of what it’s like without this change:

![signal-before](https://user-images.githubusercontent.com/43280/60772515-4053af00-a0bd-11e9-8721-d38598c40b2e.gif)

This is what it’s like in the development environment with this change:

![signal-after](https://user-images.githubusercontent.com/43280/60772546-8d378580-a0bd-11e9-9550-9d7a94190b98.gif)

I’m running macOS 10.14.4. The tests on Travis are [failing as of the most recent commit on `development`](https://travis-ci.org/signalapp/Signal-Desktop/builds/551872947) but you can see [here](https://travis-ci.org/backspace/Signal-Desktop/jobs/555419109#L821-L825) that the tests for the existing functionality pass, and that the [test for the new functionality passes](https://travis-ci.org/backspace/Signal-Desktop/jobs/555422625#L827) too.