### PR TITLE
Fix SUPPORTED_MEDIA_DOMAINS regex whitelist

### DIFF
--- a/js/modules/link_previews.js
+++ b/js/modules/link_previews.js
@@ -68,7 +68,7 @@ function isStickerPack(link) {
   return (link || '').startsWith('https://signal.org/addstickers/');
 }
 
-const SUPPORTED_MEDIA_DOMAINS = /^([^.]+\.)*(ytimg.com|cdninstagram.com|redd.it|imgur.com|fbcdn.net|pinimg.com)$/i;
+const SUPPORTED_MEDIA_DOMAINS = /^([^.]+\.)*(ytimg\.com|cdninstagram\.com|redd\.it|imgur\.com|fbcdn\.net|pinimg\.com)$/i;
 function isMediaLinkInWhitelist(link) {
   try {
     const url = new URL(link);


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users


### Description

The `SUPPORTED_MEDIA_DOMAINS` regex whitelist, used to check if media link comes from a trusted (whitelisted) host is invalid. As in e.g. `redd.it` it uses `.` character between the TLD and domain label, and this character, when used in regexes, matches any character. As a result, the whitelist matches untrusted URLs like `https://redjit/` or `https://reddXit/`.

It seems this does not expose a direct security risk as of now or I couldn't find an example of such. However, if an attacker would control a DNS server we use, they could serve content from domains that bypass the whitelist.

Another problem with the current approach are future changes: a developer that adds e.g. `media.somenewcoolcdn.net` URL would likely add it in the same format, thus, enabling direct security risk, as an attacker could buy a `mediaXsomenewcoolcdn.net` domain and send us a preview link from it.

---

An example below:
```js
const SUPPORTED_MEDIA_DOMAINS = /^([^.]+\.)*(ytimg.com|cdninstagram.com|redd.it|imgur.com|fbcdn.net|pinimg.com)$/i;

console.log('Testing redd.it: ' + SUPPORTED_MEDIA_DOMAINS.test('redd.it'));
console.log('Testing reddjit: ' + SUPPORTED_MEDIA_DOMAINS.test('reddjit'));
```

Output:
```
$ node example.js
Testing redd.it: true
Testing reddjit: true
```

---

A visualisation of the incorrect regex:
![image](https://user-images.githubusercontent.com/10009354/61270978-88509100-a7a3-11e9-8ec4-e840baef0bed.png)
From https://regexper.com/#%5E%28%5B%5E.%5D%2B%5C.%29*%28ytimg.com%7Ccdninstagram.com%7Credd.it%7Cimgur.com%7Cfbcdn.net%7Cpinimg.com%29%24

The issue has been found with LGTM: https://lgtm.com/projects/g/signalapp/Signal-Desktop/snapshot/b626ef0b64bfa9867daff876a7cc680bc236897c/files/js/modules/link_previews.js?sort=name&dir=ASC&mode=heatmap#xdabadfc2bf20f0c3:1
