### PR TITLE
Add keyboard shortcuts to change current conversation

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1153,6 +1153,22 @@
     "message": "Enable spell check of text entered in message composition box",
     "description": "Description of the media permission description"
   },
+  "shortcutConversationModifierDescription": {
+    "message": "Modifier to use with conversation change shortcut",
+    "description": "Description of the shortcut conversation setting"
+  },
+  "shortcutConversationModifierDescriptionControl": {
+    "message": "Control",
+    "description": "Description of the shortcut conversation setting"
+  },
+  "shortcutConversationModifierDescriptionMeta": {
+    "message": "Meta",
+    "description": "Description of the shortcut conversation setting"
+  },
+  "shortcutConversationModifierDescriptionAlt": {
+    "message": "Alt",
+    "description": "Description of the shortcut conversation setting"
+  },
   "clearDataHeader": {
     "message": "Clear Data",
     "description":

--- a/js/background.js
+++ b/js/background.js
@@ -268,6 +268,9 @@
         startSpellCheck();
       },
 
+      getShortcutChangeConversationModifier: () => storage.get('shortcut-change-conversation-modifier', 'control'),
+      setShortcutChangeConversationModifier: value => storage.put('shortcut-change-conversation-modifier', value),
+
       // eslint-disable-next-line eqeqeq
       isPrimary: () => textsecure.storage.user.getDeviceId() == '1',
       getSyncRequest: () =>

--- a/js/settings_start.js
+++ b/js/settings_start.js
@@ -39,6 +39,8 @@ const getInitialData = async () => ({
 
   spellCheck: await window.getSpellCheck(),
 
+  shortcutConversationModifierDescription: await window.getShortcutChangeConversationModifier(),
+
   mediaPermissions: await window.getMediaPermissions(),
 
   isPrimary: await window.isPrimary(),

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -209,13 +209,18 @@
     },
     // switches the conversation with ctrl/alt + up/down
     switchConversation(e) {
+      const modifierKey = window.storage.get('shortcut-change-conversation-modifier');
       const keyCode = e.which || e.keyCode;
       const conversations = getInboxCollection().models;
       const currentConversation =
         this.conversation_stack.lastConversation || conversations[0];
       let currentConversationIndex = -1;
 
-      if (!e.ctrlKey && !e.altKey) {
+      if (
+        !(e.ctrlKey && modifierKey === "control") &&
+        !(e.metaKey && modifierKey === "meta") &&
+        !(e.altKey && modifierKey === "alt")
+      ) {
         return;
       }
 

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -119,6 +119,7 @@
     },
     events: {
       click: 'onClick',
+      keyup: 'switchConversation',
     },
     setupLeftPane() {
       this.leftPaneView = new Whisper.ReactWrapperView({
@@ -205,6 +206,53 @@
     },
     onClick(e) {
       this.closeRecording(e);
+    },
+    // switches the conversation with ctrl/alt + up/down
+    switchConversation(e) {
+      const keyCode = e.which || e.keyCode;
+      const conversations = getInboxCollection().models;
+      const currentConversation =
+        this.conversation_stack.lastConversation || conversations[0];
+      let currentConversationIndex = -1;
+
+      if (!e.ctrlKey && !e.altKey) {
+        return;
+      }
+
+      function _compare(a, b) {
+        if (a.cachedProps.lastUpdated < b.cachedProps.lastUpdated) {
+          return 1;
+        } else if (a.cachedProps.lastUpdated > b.cachedProps.lastUpdated) {
+          return -1;
+        } else if (a.cachedProps.name < b.cachedProps.name) {
+          return -1;
+        } else if (a.cachedProps.name > b.cachedProps.name) {
+          return 1;
+        }
+        return 0;
+      }
+      conversations.sort(_compare);
+
+      currentConversationIndex = conversations.findIndex(
+        conversation => conversation.id === currentConversation.id
+      );
+
+      // down key
+      if (
+        keyCode === 40 &&
+        currentConversationIndex + 1 < conversations.length
+      ) {
+        this.openConversation(
+          conversations[currentConversationIndex + 1].id,
+          'Down key'
+        );
+        // up key
+      } else if (keyCode === 38 && currentConversationIndex > 0) {
+        this.openConversation(
+          conversations[currentConversationIndex - 1].id,
+          'Up key'
+        );
+      }
     },
   });
 

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -81,6 +81,12 @@
         setFn: window.setNotificationSetting,
       });
       new RadioButtonGroupView({
+        el: this.$('.shortcut-change-conversation-modifier-setting'),
+        name: 'shortcut-change-conversation-modifier-setting',
+        value: window.initialData.shortcutConversationModifierDescription,
+        setFn: window.setShortcutChangeConversationModifier,
+      });
+      new RadioButtonGroupView({
         el: this.$('.theme-settings'),
         name: 'theme-setting',
         value: window.initialData.themeSetting,
@@ -157,6 +163,10 @@
         mediaPermissionsDescription: i18n('mediaPermissionsDescription'),
         generalHeader: i18n('general'),
         spellCheckDescription: i18n('spellCheckDescription'),
+        shortcutConversationModifierDescription: i18n('shortcutConversationModifierDescription'),
+        shortcutConversationModifierDescriptionControl: i18n('shortcutConversationModifierDescriptionControl'),
+        shortcutConversationModifierDescriptionMeta: i18n('shortcutConversationModifierDescriptionMeta'),
+        shortcutConversationModifierDescriptionAlt: i18n('shortcutConversationModifierDescriptionAlt'),
         sendLinkPreviews: i18n('sendLinkPreviews'),
         linkPreviewsDescription: i18n('linkPreviewsDescription'),
       };

--- a/main.js
+++ b/main.js
@@ -970,6 +970,9 @@ installSettingsSetter('audio-notification');
 installSettingsGetter('spell-check');
 installSettingsSetter('spell-check');
 
+installSettingsGetter('shortcut-change-conversation-modifier');
+installSettingsSetter('shortcut-change-conversation-modifier');
+
 // This one is different because its single source of truth is userConfig, not IndexedDB
 ipc.on('get-media-permissions', event => {
   event.sender.send(

--- a/preload.js
+++ b/preload.js
@@ -151,6 +151,10 @@ installSetter('audio-notification', 'setAudioNotification');
 installGetter('spell-check', 'getSpellCheck');
 installSetter('spell-check', 'setSpellCheck');
 
+installGetter('shortcut-change-conversation-modifier', 'getShortcutChangeConversationModifier');
+installSetter('shortcut-change-conversation-modifier', 'setShortcutChangeConversationModifier');
+
+
 window.getMediaPermissions = () =>
   new Promise((resolve, reject) => {
     ipc.once('get-success-media-permissions', (_event, error, value) => {

--- a/settings.html
+++ b/settings.html
@@ -100,6 +100,15 @@
         <input type='checkbox' name='spell-check-setting' id='spell-check-setting' />
         <label for='spell-check-setting'>{{ spellCheckDescription }}</label>
       </div>
+      <h4>{{ shortcutConversationModifierDescription }}</h4>
+      <div class='shortcut-change-conversation-modifier-setting'>
+        <input type='radio' name='shortcut-change-conversation-modifier-setting' id='shortcut-change-conversation-modifier-control' value='control' />
+        <label for='shortcut-change-conversation-modifier-control'>{{ shortcutConversationModifierDescriptionControl }}</label>
+        <input type='radio' name='shortcut-change-conversation-modifier-setting' id='shortcut-change-conversation-modifier-meta' value='meta' />
+        <label for='shortcut-change-conversation-modifier-meta'>{{ shortcutConversationModifierDescriptionMeta }}</label>
+        <input type='radio' name='shortcut-change-conversation-modifier-setting' id='shortcut-change-conversation-modifier-alt' value='alt' />
+        <label for='shortcut-change-conversation-modifier-alt'>{{ shortcutConversationModifierDescriptionAlt }}</label>
+      </div>
     <hr>
     <div class='permissions-setting'>
       <h3>{{ permissions }}</h3>

--- a/settings_preload.js
+++ b/settings_preload.js
@@ -59,6 +59,9 @@ window.setHideMenuBar = makeSetter('hide-menu-bar');
 window.getSpellCheck = makeGetter('spell-check');
 window.setSpellCheck = makeSetter('spell-check');
 
+window.getShortcutChangeConversationModifier = makeGetter('shortcut-change-conversation-modifier');
+window.setShortcutChangeConversationModifier = makeSetter('shortcut-change-conversation-modifier');
+
 window.getNotificationSetting = makeGetter('notification-setting');
 window.setNotificationSetting = makeSetter('notification-setting');
 window.getAudioNotification = makeGetter('audio-notification');

--- a/test/index.html
+++ b/test/index.html
@@ -507,6 +507,7 @@
   <script type="text/javascript" src="views/whisper_view_test.js"></script>
   <script type="text/javascript" src="views/timestamp_view_test.js"></script>
   <script type="text/javascript" src="views/list_view_test.js"></script>
+  <script type="text/javascript" src="views/inbox_view_test.js"></script>
   <script type="text/javascript" src="views/network_status_view_test.js"></script>
   <script type="text/javascript" src="views/last_seen_indicator_view_test.js"></script>
   <script type='text/javascript' src='views/scroll_down_button_view_test.js'></script>

--- a/test/views/inbox_view_test.js
+++ b/test/views/inbox_view_test.js
@@ -1,0 +1,128 @@
+/* global Whisper */
+
+describe('InboxView', () => {
+  const inboxView = new Whisper.InboxView({
+    model: {},
+    window,
+    initialLoadComplete: () => {},
+  }).render();
+
+  describe('switching conversations with key events', () => {
+    let openConversationCalls;
+    const conversations = [
+      new Whisper.Conversation({
+        name: '1',
+        id: '+1',
+      }),
+      new Whisper.Conversation({
+        name: '2',
+        id: '+2',
+      }),
+      new Whisper.Conversation({
+        name: '3',
+        id: '+3',
+      }),
+    ];
+
+    beforeEach(() => {
+      const collection = window.getInboxCollection();
+      collection.reset([]);
+
+      collection.add(conversations[0]);
+      collection.add(conversations[1]);
+      collection.add(conversations[2]);
+
+      openConversationCalls = [];
+      inboxView.openConversation = () => {
+        openConversationCalls.push(arguments);
+      };
+    });
+
+    it('should do nothing if the alt or ctrl keys are not pressed', () => {
+      const event = {
+        keyCode: 40,
+      };
+      inboxView.conversation_stack.stack = [conversations[1]];
+      inboxView.switchConversation(event);
+
+      assert(openConversationCalls.length === 0);
+    });
+
+    describe('with the ctrl key down', () => {
+      const event = {
+        ctrlKey: true,
+      };
+
+      testKeyDownEvents(event);
+    });
+
+    describe('with the alt key down', () => {
+      const event = {
+        altKey: true,
+      };
+
+      testKeyDownEvents(event);
+    });
+
+    function testKeyDownEvents(event) {
+      const e = event;
+      describe('and the down key is pressed', () => {
+        before(() => {
+          e.keyCode = 40;
+        });
+
+        it('should select the first conversation if none were selected', () => {
+          inboxView.conversation_stack.stack = [];
+          inboxView.switchConversation(e);
+
+          assert(openConversationCalls.length === 1);
+          assert.deepEqual(openConversationCalls[0][1], conversations[0]);
+        });
+
+        it('should select the next conversation down when there is one', () => {
+          inboxView.conversation_stack.stack = [conversations[1]];
+          inboxView.switchConversation(e);
+
+          assert(openConversationCalls.length === 1);
+          assert.deepEqual(openConversationCalls[0][1], conversations[2]);
+        });
+
+        it('should do nothing when there are no more conversations', () => {
+          inboxView.conversation_stack.stack = [conversations[2]];
+          inboxView.switchConversation(e);
+
+          assert(openConversationCalls.length === 0);
+        });
+      });
+
+      describe('and the up key is pressed', () => {
+        before(() => {
+          e.keyCode = 38;
+        });
+
+        it('should select the first conversation if none were selected', () => {
+          inboxView.conversation_stack.stack = [];
+          inboxView.switchConversation(e);
+
+          assert(openConversationCalls.length === 1);
+          assert.deepEqual(openConversationCalls[0][1], conversations[0]);
+        });
+
+        it('should select the next conversation up when there is one', () => {
+          inboxView.conversation_stack.stack = [conversations[1]];
+          inboxView.switchConversation(e);
+
+          assert(openConversationCalls.length === 1);
+          assert.deepEqual(openConversationCalls[0][1], conversations[0]);
+        });
+
+        it('should do nothing when there are no more conversations', () => {
+          inboxView.conversation_stack.stack = [conversations[0]];
+          inboxView.switchConversation(e);
+
+          assert(openConversationCalls.length === 0);
+        });
+      });
+    }
+  });
+});

--- a/ts/util/lint/exceptions.json
+++ b/ts/util/lint/exceptions.json
@@ -549,7 +549,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/inbox_view.js",
     "line": "      this.$('.left-pane-placeholder').append(this.leftPaneView.el);",
-    "lineNumber": 130,
+    "lineNumber": 131,
     "reasonCategory": "usageTrusted",
     "updated": "2019-03-08T23:49:08.796Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -558,7 +558,7 @@
     "rule": "jQuery-append(",
     "path": "js/views/inbox_view.js",
     "line": "      this.$('.left-pane-placeholder').append(this.leftPaneView.el);",
-    "lineNumber": 130,
+    "lineNumber": 131,
     "reasonCategory": "usageTrusted",
     "updated": "2019-03-08T23:49:08.796Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -567,7 +567,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/inbox_view.js",
     "line": "      if (e && this.$(e.target).closest('.placeholder').length) {",
-    "lineNumber": 171,
+    "lineNumber": 172,
     "reasonCategory": "usageTrusted",
     "updated": "2019-03-08T23:49:08.796Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -576,7 +576,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/inbox_view.js",
     "line": "      this.$('#header, .gutter').addClass('inactive');",
-    "lineNumber": 175,
+    "lineNumber": 176,
     "reasonCategory": "usageTrusted",
     "updated": "2019-03-08T23:49:08.796Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -585,7 +585,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/inbox_view.js",
     "line": "      this.$('.conversation-stack').addClass('inactive');",
-    "lineNumber": 179,
+    "lineNumber": 180,
     "reasonCategory": "usageTrusted",
     "updated": "2019-03-08T23:49:08.796Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -594,7 +594,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/inbox_view.js",
     "line": "      this.$('.conversation:first .menu').trigger('close');",
-    "lineNumber": 181,
+    "lineNumber": 182,
     "reasonCategory": "usageTrusted",
     "updated": "2019-03-08T23:49:08.796Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -603,7 +603,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/inbox_view.js",
     "line": "      if (e && this.$(e.target).closest('.capture-audio').length > 0) {",
-    "lineNumber": 201,
+    "lineNumber": 202,
     "reasonCategory": "usageTrusted",
     "updated": "2019-03-08T23:49:08.796Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -612,7 +612,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/inbox_view.js",
     "line": "      this.$('.conversation:first .recorder').trigger('close');",
-    "lineNumber": 204,
+    "lineNumber": 205,
     "reasonCategory": "usageTrusted",
     "updated": "2019-03-08T23:49:08.796Z",
     "reasonDetail": "Protected from arbitrary input"


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

This PR adds some keyboard shortcuts to switch conversation: `Ctrl/Alt` + `Up/Down`.
This is mainly an update of this previous MR: https://github.com/signalapp/Signal-Desktop/pull/2042, and concerns at least the following issues: #512, #1104, #3154.

I tested those change locally on a development version, then on a local production release, both successfully. A first press on `tab`, or a click anywhere inside the app, is required on startup to give right focus for keyboard events.  
My conversation list include normal Signal conversation, empty ones (contacts that have Signal, but to who I never talked), and the `Note to self` contact (me). The shortcuts are of course able to travel the whole list, but sadly, it doesn't scroll on the conversation list once the focused conversation is out of the widget.  
Everything was made on Debian Buster.

