### PR TITLE
Improve slow DB query using INDEXED BY

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -2177,6 +2177,7 @@ async function getExpiredMessages() {
 async function getOutgoingWithoutExpiresAt() {
   const rows = await db.all(`
     SELECT json FROM messages
+    INDEXED BY messages_without_timer
     WHERE
       expireTimer > 0 AND
       expires_at IS NULL AND


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

I haven't marked the `yarn ready` but everything passes except that I get two questionable lines in `yarn lint-deps`. I assume this is because I'm building against my system electron and node. Note that I haven't touched the deps.

### Description

This improves the performance of database query which is run once at startup significantly.

Before:
`SQL channel job 170 (getOutgoingWithoutExpiresAt) succeeded in 533ms`

After:
No such line, i.e., < 10 ms. I think it was actually 1ms when I had enabled DB profiling.

The SQLite docs say that we should use "INDEXED BY" only if nothing else helps but I tried their entire checklist, and yes, nothing else helps... (See https://www.sqlite.org/queryplanner-ng.html#howtofix)

Related issues: #3010, #3171, #3172. 