### PR TITLE
fix: emoji picker doesn't show up in draft after conversation switch

### DIFF
--- a/ts/components/CompositionInput.tsx
+++ b/ts/components/CompositionInput.tsx
@@ -163,8 +163,8 @@ const compositeDecorator = new CompositeDecorator([
           {children}
         </Emoji>
       ) : (
-        children
-      ),
+          children
+        ),
   },
 ]);
 
@@ -228,7 +228,7 @@ export const CompositionInput = ({
     null
   );
   const dirtyRef = React.useRef(false);
-  const focusRef = React.useRef(false);
+  const focusRef = startingText ? React.useRef(true) : React.useRef(false);
   const editorStateRef = React.useRef<EditorState>(editorRenderState);
   const rootElRef = React.useRef<HTMLDivElement>();
 
@@ -501,22 +501,22 @@ export const CompositionInput = ({
 
       let newContent = replaceWord
         ? Modifier.replaceText(
-            oldContent,
-            selection.merge({
-              anchorOffset: word.start,
-              focusOffset: word.end,
-            }) as SelectionState,
-            emojiContent,
-            undefined,
-            emojiEntityKey
-          )
+          oldContent,
+          selection.merge({
+            anchorOffset: word.start,
+            focusOffset: word.end,
+          }) as SelectionState,
+          emojiContent,
+          undefined,
+          emojiEntityKey
+        )
         : Modifier.insertText(
-            oldContent,
-            selection,
-            emojiContent,
-            undefined,
-            emojiEntityKey
-          );
+          oldContent,
+          selection,
+          emojiContent,
+          undefined,
+          emojiEntityKey
+        );
 
       const afterSelection = newContent.getSelectionAfter();
 
@@ -796,56 +796,56 @@ export const CompositionInput = ({
       </Reference>
       {emojiResults.length > 0 && popperRoot
         ? createPortal(
-            <Popper placement="top" key={searchText}>
-              {({ ref, style }) => (
-                <div
-                  ref={ref}
-                  className="module-composition-input__emoji-suggestions"
-                  style={{
-                    ...style,
-                    width: editorWidth,
-                  }}
-                  role="listbox"
-                  aria-expanded={true}
-                  aria-activedescendant={`emoji-result--${
-                    emojiResults[emojiResultsIndex].short_name
+          <Popper placement="top" key={searchText}>
+            {({ ref, style }) => (
+              <div
+                ref={ref}
+                className="module-composition-input__emoji-suggestions"
+                style={{
+                  ...style,
+                  width: editorWidth,
+                }}
+                role="listbox"
+                aria-expanded={true}
+                aria-activedescendant={`emoji-result--${
+                  emojiResults[emojiResultsIndex].short_name
                   }`}
-                >
-                  {emojiResults.map((emoji, index) => (
-                    <button
-                      key={emoji.short_name}
-                      id={`emoji-result--${emoji.short_name}`}
-                      role="option button"
-                      aria-selected={emojiResultsIndex === index}
-                      onMouseDown={() => {
-                        insertEmoji(
-                          { shortName: emoji.short_name, skinTone },
-                          true
-                        );
-                        onPickEmoji({ shortName: emoji.short_name });
-                      }}
-                      className={classNames(
-                        'module-composition-input__emoji-suggestions__row',
-                        emojiResultsIndex === index
-                          ? 'module-composition-input__emoji-suggestions__row--selected'
-                          : null
-                      )}
-                    >
-                      <Emoji
-                        shortName={emoji.short_name}
-                        size={16}
-                        skinTone={skinTone}
-                      />
-                      <div className="module-composition-input__emoji-suggestions__row__short-name">
-                        :{emoji.short_name}:
+              >
+                {emojiResults.map((emoji, index) => (
+                  <button
+                    key={emoji.short_name}
+                    id={`emoji-result--${emoji.short_name}`}
+                    role="option button"
+                    aria-selected={emojiResultsIndex === index}
+                    onMouseDown={() => {
+                      insertEmoji(
+                        { shortName: emoji.short_name, skinTone },
+                        true
+                      );
+                      onPickEmoji({ shortName: emoji.short_name });
+                    }}
+                    className={classNames(
+                      'module-composition-input__emoji-suggestions__row',
+                      emojiResultsIndex === index
+                        ? 'module-composition-input__emoji-suggestions__row--selected'
+                        : null
+                    )}
+                  >
+                    <Emoji
+                      shortName={emoji.short_name}
+                      size={16}
+                      skinTone={skinTone}
+                    />
+                    <div className="module-composition-input__emoji-suggestions__row__short-name">
+                      :{emoji.short_name}:
                       </div>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </Popper>,
-            popperRoot
-          )
+                  </button>
+                ))}
+              </div>
+            )}
+          </Popper>,
+          popperRoot
+        )
         : null}
     </Manager>
   );


### PR DESCRIPTION
### First time contributor checklist:

* [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/https://signal.org/cla/)

### Contributor checklist:

* [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Fixes #3656 

Testing has been done manually since I didn't find where I could put unit testing for CompositionInput component. If you tell me where to write new tests, I'll do it ;) The testing was to do what's described in the issue: 
- begin to write a draft
- change conversation
- go back to first conversation
- try to insert emoji and see that picker doesn't show up.

The problem was that the Editor is focused but the onFocus effect is not called, so we didn't enter in the picker part of the editor state change function.

Done on OS X 10.12.6.
