### PR TITLE
Use later button as cancel behavior

### DIFF
--- a/ts/updater/common.ts
+++ b/ts/updater/common.ts
@@ -157,7 +157,7 @@ export async function showUpdateDialog(
     message: messages.autoUpdateNewVersionMessage.message,
     detail: messages.autoUpdateNewVersionInstructions.message,
     defaultId: LATER_BUTTON,
-    cancelId: RESTART_BUTTON,
+    cancelId: LATER_BUTTON,
   };
 
   const { response } = await dialog.showMessageBox(mainWindow, options);


### PR DESCRIPTION
### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Users expect closing/cancelling a dialog box to cancel or otherwise prevent or postpone any action. Currently, when the "update available" dialog is closed by pressing `Esc` or clicking the close button, Signal proceeds with the update rather than postponing it. This corrects that unexpected behavior by making closing the dialog the equivalent of clicking the "later" button.

Fixes #2831.
