### PR TITLE
Generate old.reddit.com link previews [FREEBIE]

### DIFF
--- a/js/modules/link_previews.js
+++ b/js/modules/link_previews.js
@@ -27,6 +27,7 @@ const SUPPORTED_DOMAINS = [
   'm.youtube.com',
   'youtu.be',
   'reddit.com',
+  'old.reddit.com',
   'www.reddit.com',
   'm.reddit.com',
   'imgur.com',

--- a/test/modules/link_previews_test.js
+++ b/test/modules/link_previews_test.js
@@ -24,6 +24,10 @@ describe('Link previews', () => {
         isLinkInWhitelist('https://www.reddit.com/blah'),
         true
       );
+      assert.strictEqual(
+        isLinkInWhitelist('https://old.reddit.com/blah'),
+        true
+      );
       assert.strictEqual(isLinkInWhitelist('https://m.reddit.com/blah'), true);
       assert.strictEqual(isLinkInWhitelist('https://imgur.com/blah'), true);
       assert.strictEqual(isLinkInWhitelist('https://www.imgur.com/blah'), true);


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [ ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
Some people use the pre-redesign Reddit (https://old.reddit.com), this change adds support for generating ``old.reddit.com`` link previews.

//FREEBIE