### PR TITLE
Fix context menu when spellchecker is off

### DIFF
--- a/js/spell_check.js
+++ b/js/spell_check.js
@@ -145,10 +145,15 @@ window.enableSpellCheck = () => {
   window.removeEventListener('contextmenu', defaultContextMenuHandler);
 };
 
-const defaultContextMenuHandler = () => {
+const defaultContextMenuHandler = e => {
+  // Only show the context menu in text editors.
+  if (!e.target.closest('textarea, input, [contenteditable="true"]')) {
+    return;
+  }
+
   const menu = buildEditorContextMenu({});
 
-  // @see js/spell_check.js:183
+  // @see js/spell_check.js:177
   setTimeout(() => {
     menu.popup(remote.getCurrentWindow());
   }, 30);


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
Previously when the user has the spellchecking setting turned off the context menu would flash instead of showing it on selected text of the conversation timeline. This behavior is due to the attempt of creating a context menu of different scope(`Editor`) on top of the targeted one.

This commit ensures proper context menu when spellchecking is turned off.

Fixes #3976
<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
