### PR TITLE
Fix linkify links in punycode form

### DIFF
--- a/js/modules/link_previews.js
+++ b/js/modules/link_previews.js
@@ -2,7 +2,6 @@
 
 const { isNumber, compact } = require('lodash');
 const he = require('he');
-const nodeUrl = require('url');
 const LinkifyIt = require('linkify-it');
 
 const linkify = LinkifyIt();
@@ -213,6 +212,9 @@ function assembleChunks(chunkDescriptors) {
 }
 
 const ASCII_PATTERN = new RegExp('[\\u0000-\\u007F]', 'g');
+const DOMAIN_PATTERN = new RegExp(
+  /^(?<protocol>https?:\/\/)?(?<domain>[^/]+).*$/
+);
 
 function isLinkSneaky(link) {
   const domain = getDomain(link);
@@ -226,12 +228,8 @@ function isLinkSneaky(link) {
     return true;
   }
 
-  // This is necesary because getDomain returns domains in punycode form.
-  const unicodeDomain = nodeUrl.domainToUnicode
-    ? nodeUrl.domainToUnicode(domain)
-    : domain;
-
-  const withoutPeriods = unicodeDomain.replace(/\./g, '');
+  const linkDomain = link.match(DOMAIN_PATTERN).groups.domain;
+  const withoutPeriods = linkDomain.replace(/\./g, '');
 
   const hasASCII = ASCII_PATTERN.test(withoutPeriods);
   const withoutASCII = withoutPeriods.replace(ASCII_PATTERN, '');

--- a/test/modules/link_previews_test.js
+++ b/test/modules/link_previews_test.js
@@ -391,5 +391,10 @@ describe('Link previews', () => {
       const link = 'r.id^s.id';
       assert.strictEqual(isLinkSneaky(link), true);
     });
+
+    it('returns false for punycode form', () => {
+      const link = 'https://xn--msic-0ra.example.com/';
+      assert.strictEqual(isLinkSneaky(link), false);
+    });
   });
 });


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
Links in punycode form were not being linkified due to false positive on `nodeUrl.domainToUnicode` part, parsing the original link into unicode and then making checks. We avoid making changes on the original link and proceed with checks.

This commit will linkify links in punycode form.

Fixes #3966 
<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
