### PR TITLE
drop minimum sticker count to 1

### DIFF
--- a/sticker-creator/store/ducks/stickers.ts
+++ b/sticker-creator/store/ducks/stickers.ts
@@ -41,7 +41,7 @@ export const dismissToast = createAction<void>('stickers/dismissToast');
 export const resetStatus = createAction<void>('stickers/resetStatus');
 export const reset = createAction<void>('stickers/reset');
 
-export const minStickers = 4;
+export const minStickers = 1;
 export const maxStickers = 200;
 export const maxByteSize = 100 * 1024;
 


### PR DESCRIPTION
## First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

## Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

## Description

I currently have a sticker pack on Telegram which I cannot port to Signal because it has only two stickers. I don't see why we should arbitrarily require four stickers. I could also imagine a sticker pack with just one sticker in it, if that sticker is really good.

![epic sticker pack that I cannot upload because it only has two stickers](https://user-images.githubusercontent.com/538336/76927020-e510c800-68ab-11ea-90fd-a5c6152584ea.png)
