### PR TITLE
Group members count

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -931,6 +931,15 @@
   "groupMembers": {
     "message": "Group members"
   },
+  "groupMembersCount": {
+    "message": "$count$ members",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "20"
+      }
+    }
+  },
   "showMembers": {
     "message": "Show members"
   },

--- a/background.html
+++ b/background.html
@@ -148,6 +148,7 @@
 
   <script type='text/x-tmpl-mustache' id='group-member-list'>
     <div class='container' tabindex='0'>
+      {{ #membersCount }} <div>{{ membersCount }}</div>{{ /membersCount }}
       {{ #summary }} <div class='summary'>{{ summary }}</div>{{ /summary }}
     </div>
   </script>

--- a/js/views/group_member_list_view.js
+++ b/js/views/group_member_list_view.js
@@ -34,6 +34,7 @@
 
       return {
         members: i18n('groupMembers'),
+        membersCount: i18n('groupMembersCount', this.model.length),
         summary,
       };
     },


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
This PR is just a small change to add a members count to the top of the group members view. I noticed there wasn't one and it's useful to have one with large groups.

![image](https://user-images.githubusercontent.com/6254628/78407255-43ec7600-75fc-11ea-8442-02ed13c22f09.png)

I didn't write any tests for this feature as it doesn't seem necessary for such a small UI item.
I only tested this new feature on Ubuntu 18.04.2, but I don't see any likely OS-dependent problem.
