### PR TITLE
Fixes 4098 Default theme settings getter returns system if no setting is set to match default theme setting

### DIFF
--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -9,7 +9,7 @@
   window.Whisper = window.Whisper || {};
 
   function resolveTheme() {
-    const theme = storage.get('theme-setting') || 'light';
+    const theme = storage.get('theme-setting') || 'system';
     if (window.platform === 'darwin' && theme === 'system') {
       return window.systemTheme;
     }

--- a/sticker-creator/preload.js
+++ b/sticker-creator/preload.js
@@ -155,7 +155,7 @@ async function encrypt(data, key, iv) {
 const getThemeSetting = makeGetter('theme-setting');
 
 async function resolveTheme() {
-  const theme = (await getThemeSetting()) || 'light';
+  const theme = (await getThemeSetting()) || 'system';
   if (process.platform === 'darwin' && theme === 'system') {
     return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
   }


### PR DESCRIPTION
#3826 # First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
Fixes #4098

The default theme settings is "system" but the `theme-setting` getter was returning `light` if no setting was returned. This PR updates the `theme-setting` getter to return `system` by default and match the default radio selection in the theme settings menu.

Tested with Desktop App on macOS Catalina 10.15.3
Ran app with system theme setting as dark, observed the app ran in dark mode. Tested changing settings worked
Deleted ~/User/Application\ Support/Signal-development
Ran app with system theme setting as light, observed the app ran in light mode. Tested changing settings worked
