### PR TITLE
Prevent macOS from making requests to Apple every time the app is started

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,6 +260,9 @@
       "hardenedRuntime": true,
       "entitlements": "./build/entitlements.mac.plist",
       "icon": "build/icons/mac/icon.icns",
+      "asarUnpack": [
+        "**/*.node"
+      ],
       "publish": [
         {
           "provider": "generic",


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
The current `electron-builder` configuration in `package.json` includes native node modules in the asar archive. When Electron then runs the app it unpacks the native modules and then executes them. This triggers some kind of malware check in macOS and results in the OS making requests to Apple servers. In addition to the privacy issue, the app startup is delayed while these requests are in progress and isn't opened until they are either complete or timed out. This can result in a >1 min delay.

I've solved this by adding an option to the electron-builder configuration which prevents native modules from being included in the asar archive.

The difference in the the built app is that `node_modules/curve25519-n/build/Release/curve.node` and `node_modules/@journeyapps/sqlcipher/lib/binding/electron-v8.2-darwin-x64/node_sqlite3.node` is now located in `app.asar.unpacked/` instead of packaged into `app.asar`. When building it on my computer the size difference is an increase of 12KB.

Here's a few gifs of the behaviour:
Normal start
![a](https://user-images.githubusercontent.com/3668602/79235281-b31f6100-7e6b-11ea-8ff2-a99f28f73298.gif)

App startup when firewall drops the requests
![b](https://user-images.githubusercontent.com/3668602/79235299-b87cab80-7e6b-11ea-81ef-c341078725cc.gif)

The delayed startup can be reproduced by adding a rule
```
block drop out log (all) quick proto tcp from any to any port = 443
```
to the PF firewall.

