### PR TITLE
Prevent unnecessary truncation of the conversation header text

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -2664,8 +2664,6 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
 
   @include font-body-1-bold;
 
-  // width of avatar (28px) and our 6px left margin
-  max-width: calc(100% - 34px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Fixes #3168

This CSS rule was causing conversation header text to be truncated even when there was enough white space to display the entire text at certain zoom levels and platforms, as reported in #3168.

With this fix, the conversation header is no longer truncated unnecessarily. When there is an actual lack of space, truncation behaves as expected.

### Testing

Testing was performed by opening the developer tools for the Signal Desktop window and switching off that CSS property, then manipulating the window to observe how the header text reacted. The expected truncation behavior was seen during:

- Changing zoom level
- Window scaling
- Changing the length of the header text

Operating systems tested on: 
- Chrome OS 81.0.4044.103 
- macOS 10.15.4 (19E287)

### Screenshots

| Before PR | After PR | After PR (narrow) |
|-----------|----------|-------------------|
|![Screenshot of Signal showing a conversation with its title truncated to "Note to S…" despite there being plenty of space.](https://user-images.githubusercontent.com/5957867/80534225-e9310a80-896c-11ea-9570-32c8696d8bc4.png)|![Screenshot of Signal showing a conversation with its title reading "Note to Self".](https://user-images.githubusercontent.com/5957867/80534409-2bf2e280-896d-11ea-921d-92b966140053.png)|![Screenshot of Signal showing a narrow conversation with its title truncated to  "Note …".](https://user-images.githubusercontent.com/5957867/80534414-2d240f80-896d-11ea-9c64-be79d565b127.png)|



