### PR TITLE
Increase constrast in delete button for attachments via CSS blend mode

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -4092,6 +4092,7 @@ button.module-image__border-overlay:focus {
   width: 16px;
   height: 16px;
   z-index: 2;
+  mix-blend-mode: difference;
 
   background-image: url('../images/x-shadow-16.svg');
 


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

In some environments such as Win10 and Manjaro, the delete button for attachments in draft mode
overlays the attachment itself. Since the button is white, it´s hard to make out when the attachment
is also light in color.
Setting `mix-blend-mode: difference` on the button makes sure that it´s always highly contrasted from the attachment.

Before the change:
![delete-attachment-before](https://user-images.githubusercontent.com/23425025/82160394-56adc800-9895-11ea-9aa6-4fc16058c910.png)

After the change:
![delete-attachment-after](https://user-images.githubusercontent.com/23425025/82160399-5f060300-9895-11ea-8eca-0adb18b7ef76.png)
![delete-attachment-after-dark](https://user-images.githubusercontent.com/23425025/82160400-60cfc680-9895-11ea-867c-e6ed4b59a9cc.png)

Fixes: [#4236](https://github.com/signalapp/Signal-Desktop/issues/4236)

I only tested the change on Manjaro Linux as I don´t have a Windows machine set up for development.