### PR TITLE
Harmonized filenames with Android version

### DIFF
--- a/ts/test/types/Attachment_test.ts
+++ b/ts/test/types/Attachment_test.ts
@@ -49,7 +49,7 @@ describe('Attachment', () => {
           attachment,
           timestamp,
         });
-        const expected = 'signal-attachment-1970-01-01-000000.mov';
+        const expected = 'signal-1970-01-01-000000.mov';
         assert.strictEqual(actual, expected);
       });
     });
@@ -65,7 +65,7 @@ describe('Attachment', () => {
           timestamp,
           index: 3,
         });
-        const expected = 'signal-attachment-1970-01-01-000000_003.mov';
+        const expected = 'signal-1970-01-01-000000_003.mov';
         assert.strictEqual(actual, expected);
       });
     });

--- a/ts/types/Attachment.ts
+++ b/ts/types/Attachment.ts
@@ -374,7 +374,7 @@ export const getSuggestedFilename = ({
     return attachment.fileName;
   }
 
-  const prefix = 'signal-attachment';
+  const prefix = 'signal';
   const suffix = timestamp
     ? moment(timestamp).format('-YYYY-MM-DD-HHmmss')
     : '';


### PR DESCRIPTION


<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

The Android app saves files with the filename format
`signal-YYYY-MM-DD-hhmmss.extension` but the desktop version
saves them with format `signal-attachment-YYYY-MM-DD-hhmmss.extension`.

The suggested filename when downloading an attachment in Attachment.ts now has the prefix 'signal' rather than 'signal-attachment'.

Fixes #4321

Tested on Mac OS X 10.15.1. Attachment_test.ts was modified to match the new filename prefix.
