### PR TITLE
Avatar color on ReactionViewer is now Contact Color rather than Grey

### DIFF
--- a/ts/components/conversation/ReactionViewer.tsx
+++ b/ts/components/conversation/ReactionViewer.tsx
@@ -5,13 +5,14 @@ import { ContactName } from './ContactName';
 import { Avatar, Props as AvatarProps } from '../Avatar';
 import { Emoji } from '../emoji/Emoji';
 import { useRestoreFocus } from '../../util/hooks';
+import { ColorType } from '../../types/Util';
 
 export type Reaction = {
   emoji: string;
   timestamp: number;
   from: {
     id: string;
-    color?: string;
+    color?: ColorType;
     avatarPath?: string;
     name?: string;
     profileName?: string;
@@ -151,6 +152,7 @@ export const ReactionViewer = React.forwardRef<HTMLDivElement, Props>(
                   avatarPath={from.avatarPath}
                   conversationType="direct"
                   size={32}
+                  color={from.color}
                   name={from.name}
                   profileName={from.profileName}
                   phoneNumber={from.phoneNumber}


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
Fixes #4167. 

In the ReactionViewer, when a contact has no profile photo, their avatar color now reflects the color in the rest of the app.

The from.color field in the ReactionViewer type is now a ColorType rather than a string, and the ReactionViewer passes that color down in the color prop to the Avatar.

Tested on Mac OS X 10.15.1. There are no UI tests as far as I can tell for the ReactionViewer component, so I did not add any additional automated tests to test this fix.
