### PR TITLE
direct user to support page that matches their device language

### DIFF
--- a/main.js
+++ b/main.js
@@ -483,9 +483,49 @@ function openNewBugForm() {
   shell.openExternal('https://github.com/signalapp/Signal-Desktop/issues/new');
 }
 
+// the support only provides a subset of languages available within the app
+// so we have to list them out here and fallback to english if not included
+
+const SUPPORT_LANGUAGES = [
+  'ar',
+  'bn',
+  'de',
+  'en-us',
+  'es',
+  'fr',
+  'hi',
+  'hi-in',
+  'hc',
+  'id',
+  'it',
+  'ja',
+  'ko',
+  'mr',
+  'ms',
+  'nl',
+  'pl',
+  'pt',
+  'ru',
+  'sv',
+  'ta',
+  'te',
+  'tr',
+  'uk',
+  'ur',
+  'vi',
+  'zh-cn',
+  'zh-tw',
+];
+
 function openSupportPage() {
+  const userLanguage = app.getLocale();
+
+  const language = SUPPORT_LANGUAGES.includes(userLanguage)
+    ? userLanguage
+    : 'en-us';
+
   shell.openExternal(
-    'https://support.signal.org/hc/en-us/categories/202319038-Desktop'
+    `https://support.signal.org/hc/${language}/sections/360001602812`
   );
 }
 


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
Fixes #4343 
Tested on OS X 10.15 

I changed the URL to both be the newer redirect value as well as interpolating the user language. I found that there are extra languages supported by the desktop app than there are on the support page so I constructed valid values to check against.

I couldn't find a place where main.js was being tested, but one option is two move it out into a helper file and then test the locale getter, validation and interpolation part.

I tested this manually using `yarn start --lang=de` and `yarn start --lang=alien` with the expected results.

If there is a way to better sync the lists or reorganize the constant somewhere else just let me know.