### PR TITLE
make sure closing window in fullscreen does not hang

### DIFF
--- a/main.js
+++ b/main.js
@@ -402,7 +402,21 @@ async function createWindow() {
 
     // Prevent the shutdown
     e.preventDefault();
-    mainWindow.hide();
+
+    /**
+     * if the user is in fullscreen mode and closes the window, not the
+     * application, we need them leave fullscreen first before closing it to
+     * prevent a black screen.
+     *
+     * issue: https://github.com/signalapp/Signal-Desktop/issues/4348
+     */
+
+    if (mainWindow.isFullScreen()) {
+      mainWindow.once('leave-full-screen', () => mainWindow.hide())
+      mainWindow.setFullScreen(false)
+    } else {
+      mainWindow.hide()
+    }
 
     // On Mac, or on other platforms when the tray icon is in use, the window
     // should be only hidden, not closed, when the user clicks the close button


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
Fixes: #4348 

### Testing
I tested this manually on OSX by entering full screen mode and then pressing CMD + W to close the window. After the code addition, it minimizes then closes the window. I didn't add the return to full screen logic since other applications like Firefox don't do the same, but open to suggestions.