### PR TITLE
Group update notifications use incorrect string

### DIFF
--- a/ts/components/conversation/GroupNotification.stories.tsx
+++ b/ts/components/conversation/GroupNotification.stories.tsx
@@ -179,6 +179,29 @@ const stories: Array<GroupNotificationStory> = [
         ],
         i18n,
       },
+      {
+        from: {
+          name: 'Alice',
+          phoneNumber: '(202) 555-1000',
+        },
+        changes: [
+          {
+            type: 'add',
+            contacts: [
+              {
+                phoneNumber: '(202) 555-1000',
+                profileName: 'Mr. Fire',
+                isMe: true,
+              },
+              {
+                phoneNumber: '(202) 555-1001',
+                profileName: 'Mrs. Ice',
+              },
+            ],
+          },
+        ],
+        i18n,
+      },
     ],
   ],
   [

--- a/ts/components/conversation/GroupNotification.tsx
+++ b/ts/components/conversation/GroupNotification.tsx
@@ -75,35 +75,25 @@ export class GroupNotification extends React.Component<Props> {
           throw new Error('Group update is missing contacts');
         }
 
-        if (contacts.length === 1) {
-          if (contactsIncludesMe) {
-            return <Intl i18n={i18n} id="youJoinedTheGroup" />;
-          } else {
-            return (
-              <Intl
-                i18n={i18n}
-                id="joinedTheGroup"
-                components={[otherPeopleWithCommas]}
-              />
-            );
-          }
-        }
-
-        const joinedKey =
-          contacts.length > 1 ? 'multipleJoinedTheGroup' : 'joinedTheGroup';
+        const otherPeopleNotifMsg =
+          otherPeople.length === 1
+            ? 'joinedTheGroup'
+            : 'multipleJoinedTheGroup';
 
         return (
           <>
-            <Intl
-              i18n={i18n}
-              id={joinedKey}
-              components={[otherPeopleWithCommas]}
-            />
-            {contactsIncludesMe ? (
+            {otherPeople.length > 0 && (
+              <Intl
+                i18n={i18n}
+                id={otherPeopleNotifMsg}
+                components={[otherPeopleWithCommas]}
+              />
+            )}
+            {contactsIncludesMe && (
               <div className="module-group-notification__change">
                 <Intl i18n={i18n} id="youJoinedTheGroup" />
               </div>
-            ) : null}
+            )}
           </>
         );
       case 'remove':


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #4341 

Logic selecting the group notification for adding users was wrong.

NOTE: previous commit for this ticket (#205ee6c) did not fix the issue.

Added test to storybook and manually tested (with Polish translation as the task reported) on Windows 10 Home 64b