### PR TITLE
Remove --no-sandbox from Linux builds for better security

### DIFF
--- a/patches/app-builder-lib+22.3.6.patch
+++ b/patches/app-builder-lib+22.3.6.patch
@@ -13,19 +13,6 @@ index 72a59df..0a9a8b8 100644
      }
 
      await packager.info.callArtifactBuildCompleted({
-diff --git a/node_modules/app-builder-lib/out/targets/LinuxTargetHelper.js b/node_modules/app-builder-lib/out/targets/LinuxTargetHelper.js
-index 6e674b9..8e5be4f 100644
---- a/node_modules/app-builder-lib/out/targets/LinuxTargetHelper.js
-+++ b/node_modules/app-builder-lib/out/targets/LinuxTargetHelper.js
-@@ -135,7 +135,7 @@ class LinuxTargetHelper {
-         exec += executableArgs.join(" ");
-       }
-
--      exec += " %U";
-+      exec += " --no-sandbox %U";
-     }
-
-     const desktopMeta = Object.assign(Object.assign({
 diff --git a/node_modules/app-builder-lib/templates/linux/after-install.tpl b/node_modules/app-builder-lib/templates/linux/after-install.tpl
 index 16eab30..0077182 100644
 --- a/node_modules/app-builder-lib/templates/linux/after-install.tpl


### PR DESCRIPTION

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

    Remove --no-sandbox from Linux builds for better security
    
    Including `--no-sandbox` explicitly reduces security and is very much
    not recommended by upstream Electron project. This commit removes that
    part of the patch.
    
    Some folks will experience issues because their kernels don't have user
    namespaces and because that patch also disables the suid sandbox. You
    have two options for that: shift the burden to package managers to
    enable the suid bit on the suid sandbox, so that ones without user
    namespaces can choose to do that, or simply reenable it.
    
    Either way, shipping with --no-sandbox is irresponsible.