### PR TITLE
make sure scroll is hidden on about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -18,6 +18,7 @@
   <style>
     body {
       text-align: center;
+      overflow: hidden;
       background-color: #3a76f0;
       color: white;
       font-size: 14px;


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
Fixes #4205 

The CSS change prevents additional whitespace content on different devices to cause a scroll bar to be show. I replicated the issue screenshots by adding line breaks resulting in the same problem.

Note: I saw the previous PR to the other issue of the same nature. We don't need to set a fixed height and should just hide the extra whitespace instead.