### PR TITLE
Update node-gyp and electron.

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "cross-env": "5.2.0",
     "css-loader": "3.2.0",
     "dashdash": "1.14.1",
-    "electron": "8.2.5",
+    "electron": "9.0.4",
     "electron-builder": "22.3.6",
     "electron-mocha": "8.1.1",
     "electron-notarize": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "moment": "2.21.0",
     "mustache": "2.3.0",
     "node-fetch": "https://github.com/scottnonnenberg-signal/node-fetch.git#3e5f51e08c647ee5f20c43b15cf2d352d61c36b4",
-    "node-gyp": "5.0.3",
+    "node-gyp": "6.1.0",
     "normalize-path": "3.0.0",
     "os-locale": "3.0.1",
     "p-map": "2.1.0",
@@ -143,6 +143,7 @@
     "zkgroup": "https://github.com/signalapp/signal-zkgroup-node.git#2d7db946cc88492b65cc66e9aa9de0c9e664fd8d"
   },
   "resolutions": {
+    "node-sass/node-gyp": "^6.0.0",
     "fbjs/isomorphic-fetch/node-fetch": "https://github.com/scottnonnenberg-signal/node-fetch.git#3e5f51e08c647ee5f20c43b15cf2d352d61c36b4"
   },
   "devDependencies": {


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

This updates electron to 9.0.4 and node-gyp to 6.1.0. node-gyp is updated to a version which supports python3 required by current distributions as python2 is EOL, see commit messages for details.

Changes have been tested and are working in:

https://build.opensuse.org/package/show/network:im:signal/signal-desktop

P.S. It would be great to have gpg armor files for release tarballs :-)