### PR TITLE
Escape should close/cancel "reply to"

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -458,6 +458,8 @@
           this.onEditorStateChange(msg, caretLocation),
         onTextTooLong: () => this.showToast(Whisper.MessageBodyTooLongToast),
         onChooseAttachment: this.onChooseAttachment.bind(this),
+        getQuotedMessage: () => this.model.get('quotedMessageId'),
+        clearQuotedMessage: () => this.setQuoteMessage(null),
         micCellEl,
         attachmentListEl,
       };
@@ -2582,8 +2584,7 @@
         this.quotedMessage = message;
 
         if (message) {
-          const quote = await this.model.makeQuote(this.quotedMessage);
-          this.quote = quote;
+          this.quote = await this.model.makeQuote(this.quotedMessage);
 
           this.focusMessageFieldAndClearDisabled();
         }

--- a/ts/components/CompositionArea.tsx
+++ b/ts/components/CompositionArea.tsx
@@ -43,7 +43,7 @@ export type Props = Pick<
   | 'onEditorSizeChange'
   | 'onEditorStateChange'
   | 'onTextTooLong'
-  | 'startingText'
+  | 'startingText' | 'clearQuotedMessage' | 'getQuotedMessage'
 > &
   Pick<
     EmojiButtonProps,
@@ -102,6 +102,8 @@ export const CompositionArea = ({
   clearShowIntroduction,
   showPickerHint,
   clearShowPickerHint,
+  clearQuotedMessage,
+  getQuotedMessage,
 }: Props) => {
   const [disabled, setDisabled] = React.useState(false);
   const [showMic, setShowMic] = React.useState(!startingText);
@@ -339,6 +341,8 @@ export const CompositionArea = ({
             onDirtyChange={setDirty}
             skinTone={skinTone}
             startingText={startingText}
+            clearQuotedMessage={clearQuotedMessage}
+            getQuotedMessage={getQuotedMessage}
           />
         </div>
         {!large ? (

--- a/ts/components/CompositionInput.tsx
+++ b/ts/components/CompositionInput.tsx
@@ -42,6 +42,8 @@ export type Props = {
   onTextTooLong(): unknown;
   onPickEmoji(o: EmojiPickDataType): unknown;
   onSubmit(message: string): unknown;
+  getQuotedMessage(): unknown;
+  clearQuotedMessage(): unknown;
 };
 
 export type InputApi = {
@@ -217,6 +219,8 @@ export const CompositionInput = ({
   onSubmit,
   skinTone,
   startingText,
+  getQuotedMessage,
+  clearQuotedMessage,
 }: Props) => {
   const [editorRenderState, setEditorRenderState] = React.useState(
     getInitialEditorState(startingText)
@@ -462,6 +466,8 @@ export const CompositionInput = ({
       if (emojiResults.length > 0) {
         e.preventDefault();
         resetEmojiResults();
+      } else if (getQuotedMessage()) {
+        clearQuotedMessage();
       }
     },
     [resetEmojiResults, emojiResults]


### PR DESCRIPTION
### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
Fixes #4332 

Use Escape to cancel "reply to": when focus is on the input and user is replying to a message (=a message is quoted), pressing Escape will unquote the message. The content of the input remains unchanged (ie. the input area is NOT cleared).

Manually tested on Win 10 Home x64.