### PR TITLE
Update minimum height/width for better tiling support

### DIFF
--- a/main.js
+++ b/main.js
@@ -231,8 +231,8 @@ function handleCommonWindowEvents(window) {
 
 const DEFAULT_WIDTH = 800;
 const DEFAULT_HEIGHT = 610;
-const MIN_WIDTH = 680;
-const MIN_HEIGHT = 550;
+const MIN_WIDTH = 635;
+const MIN_HEIGHT = 500;
 const BOUNDS_BUFFER = 100;
 
 function isVisible(window, bounds) {

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -5516,7 +5516,7 @@ button.module-image__border-overlay:focus {
 
 .module-sticker-picker {
   @extend %module-composition-popper;
-  height: 400px;
+  height: 350px;
   display: grid;
   grid-template-rows: 44px 1fr;
   grid-template-columns: 1fr;
@@ -5728,7 +5728,7 @@ button.module-image__border-overlay:focus {
 
   &__content {
     width: 332px;
-    height: 356px;
+    height: 306px;
     padding: 8px 20px 16px 16px;
     overflow-y: auto;
     display: grid;
@@ -6623,7 +6623,7 @@ button.module-image__border-overlay:focus {
 
 .module-emoji-picker {
   @extend %module-composition-popper;
-  height: 428px;
+  height: 350px;
   display: grid;
   grid-template-rows: 44px 1fr;
   grid-template-columns: 1fr;


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
Smaller window sizes have been requested for a number of reasons including but not limited to matching the minimum size of other OSX apps, 640px wide monitor support, and quarter-tiling on 1080p screens.

No additional automation tests made sense for this PR, however I did check to ensure that after the alterations the emoji and sticker pickers both functioned appropriately at the new, smaller sizes in OSX, GNOME, and Windows 10.
    
This commit addresses:
- https://github.com/signalapp/Signal-Desktop/issues/1871
