### PR TITLE
Rebuild the message details page with css grids instead of html tables

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -2790,11 +2790,22 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
   margin-right: auto;
   padding: 20px;
   outline: none;
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-template-areas:
+    'message-container message-container'
+    'error-message-label error-message'
+    'label-sent date-time-sent'
+    'label-received date-time-received'
+    'label-contact .'
+    'contact-container contact-container'
+    'delete-button-container delete-button-container';
 }
 
 .module-message-detail__message-container {
   padding-top: 20px;
   padding-bottom: 20px;
+  grid-area: message-container;
 
   &::after {
     content: '.';
@@ -2809,6 +2820,33 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
   @include font-body-1-bold;
 }
 
+.module-message-detail__date-time {
+  text-align: right;
+  padding-right: 16px;
+}
+
+.module-message-detail__label-sent {
+  grid-area: label-sent;
+}
+.module-message-detail__label-received {
+  grid-area: label-received;
+}
+.module-message-detail__date-time-sent {
+  grid-area: date-time-sent;
+}
+.module-message-detail__date-time-received {
+  grid-area: date-time-received;
+}
+.module-message-detail__label-contact {
+  grid-area: label-contact;
+}
+.error-message-label {
+  grid-area: error-message-label;
+}
+.error-message {
+  grid-area: error-message;
+}
+
 .module-message-detail__unix-timestamp {
   @include light-theme {
     color: $color-gray-05;
@@ -2821,24 +2859,20 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
 .module-message-detail__delete-button-container {
   text-align: center;
   margin-top: 10px;
+  grid-area: delete-button-container;
 }
-
 .module-message-detail__delete-button {
   @include button-reset;
-
   @include keyboard-mode {
     &:focus {
       outline: -webkit-focus-ring-color auto 5px;
     }
   }
-
   border-radius: 5px;
   margin: 1em auto;
   padding: 1em;
-
   background-color: $color-accent-red;
   color: $color-white;
-
   @include light-theme {
     border: solid 1px $color-gray-45;
     box-shadow: 0 0 10px -3px $color-black-alpha-60;
@@ -2851,6 +2885,7 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
 
 .module-message-detail__contact-container {
   margin: 20px;
+  grid-area: contact-container;
 }
 
 .module-message-detail__contact {
@@ -2859,12 +2894,10 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
   flex-direction: row;
   align-items: center;
 }
-
 .module-message-detail__contact__text {
   margin-left: 10px;
   flex-grow: 1;
 }
-
 .module-message-detail__contact__error {
   color: $color-accent-red;
   font-weight: bold;
@@ -2876,11 +2909,9 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
   display: inline-block;
   margin-bottom: 2px;
 }
-
 .module-message-detail__contact__status-icon--sending {
   animation: module-message-detail__contact__status-icon--spinning 4s linear
     infinite;
-
   @include light-theme {
     @include color-svg('../images/sending.svg', $color-gray-60);
   }
@@ -2888,14 +2919,12 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
     @include color-svg('../images/sending.svg', $color-gray-25);
   }
 }
-
 @keyframes module-message-detail__contact__status-icon--spinning {
   100% {
     -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }
-
 .module-message-detail__contact__status-icon--sent {
   @include light-theme {
     @include color-svg('../images/check-circle-outline.svg', $color-gray-60);
@@ -2906,7 +2935,6 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
 }
 .module-message-detail__contact__status-icon--delivered {
   width: 18px;
-
   @include light-theme {
     @include color-svg('../images/double-check.svg', $color-gray-60);
   }
@@ -2916,7 +2944,6 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
 }
 .module-message-detail__contact__status-icon--read {
   width: 18px;
-
   @include light-theme {
     @include color-svg('../images/read.svg', $color-gray-60);
   }
@@ -2938,15 +2965,12 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
     );
   }
 }
-
 .module-message-detail__contact__unidentified-delivery-icon {
   margin-left: 6px;
   margin-right: 10px;
-
   width: 20px;
   height: 20px;
   display: inline-block;
-
   @include light-theme {
     @include color-svg('../images/unidentified-delivery.svg', $color-gray-60);
   }
@@ -2954,18 +2978,14 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
     @include color-svg('../images/unidentified-delivery.svg', $color-gray-25);
   }
 }
-
 .module-message-detail__contact__error-buttons {
   text-align: right;
 }
-
 .module-message-detail__contact__show-safety-number {
   @include button-reset;
   padding: 4px;
   border-radius: 4px;
-
   color: $color-white;
-
   @include light-theme {
     background-color: $color-gray-45;
   }
@@ -2979,7 +2999,6 @@ $timer-icons: '55', '50', '45', '40', '35', '30', '25', '20', '15', '10', '05',
   margin-top: 5px;
   padding: 4px;
   border-radius: 4px;
-
   color: $color-white;
   background-color: $color-accent-red;
 }

--- a/ts/components/conversation/MessageDetail.tsx
+++ b/ts/components/conversation/MessageDetail.tsx
@@ -160,48 +160,41 @@ export class MessageDetail extends React.Component<Props> {
         <div className="module-message-detail__message-container">
           <Message i18n={i18n} {...message} />
         </div>
-        <table className="module-message-detail__info">
-          <tbody>
-            {(errors || []).map((error, index) => (
-              <tr key={index}>
-                <td className="module-message-detail__label">
-                  {i18n('error')}
-                </td>
-                <td>
-                  {' '}
-                  <span className="error-message">{error.message}</span>{' '}
-                </td>
-              </tr>
-            ))}
-            <tr>
-              <td className="module-message-detail__label">{i18n('sent')}</td>
-              <td>
-                {moment(sentAt).format('LLLL')}{' '}
-                <span className="module-message-detail__unix-timestamp">
-                  ({sentAt})
-                </span>
-              </td>
-            </tr>
-            {receivedAt ? (
-              <tr>
-                <td className="module-message-detail__label">
-                  {i18n('received')}
-                </td>
-                <td>
-                  {moment(receivedAt).format('LLLL')}{' '}
-                  <span className="module-message-detail__unix-timestamp">
-                    ({receivedAt})
-                  </span>
-                </td>
-              </tr>
-            ) : null}
-            <tr>
-              <td className="module-message-detail__label">
-                {message.direction === 'incoming' ? i18n('from') : i18n('to')}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        {(errors || []).map((_error, index) => (
+          <div className="error-message-label" key={index}>
+            {i18n('error')}
+          </div>
+        ))}
+        {(errors || []).map((error, index) => (
+          <div className="error-message" key={index}>
+            <span>{error.message}</span>{' '}
+          </div>
+        ))}
+        <div className="module-message-detail__label-sent module-message-detail__label">
+          {i18n('sent')}
+        </div>
+        <div className="module-message-detail__date-time-sent module-message-detail__date-time">
+          {moment(sentAt).format('LLLL')}{' '}
+          <span className="module-message-detail__unix-timestamp">
+            ({sentAt})
+          </span>
+        </div>
+        {receivedAt ? (
+          <div className="module-message-detail__label-received module-message-detail__label">
+            {i18n('received')}
+          </div>
+        ) : null}
+        {receivedAt ? (
+          <div className="module-message-detail__date-time-received module-message-detail__date-time">
+            {moment(receivedAt).format('LLLL')}{' '}
+            <span className="module-message-detail__unix-timestamp">
+              ({receivedAt})
+            </span>
+          </div>
+        ) : null}
+        <div className="module-message-detail__label-contact module-message-detail__label">
+          {message.direction === 'incoming' ? i18n('from') : i18n('to')}
+        </div>
         {this.renderContacts()}
         {this.renderDeleteButton()}
       </div>


### PR DESCRIPTION
This is a rebuild for the message details page with css grids.
The goal of the rebuild is to make maintenace and adding features easier.

I've created an issue #4433 for this pull request.

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

Before the changes are ready to be shipped to users, more testing has to be done.

### Description

Rebuilds the message details page with css grids instead of html tables.
The goal is to make maintenance and adding features easier.

I tested the changes on Linux version 5.4.0-42-generic (buildd@lgw01-amd64-038) (gcc version 9.3.0 (Ubuntu 9.3.0-10ubuntu2)) #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020

I wasn't able to test the behavior when an error happens and the message can't be displayed. Does someone know how to do this?
<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->