### PR TITLE
Pseudo-Lockscreen Functionality Using Keybindings to Hide UI

### DIFF
--- a/background.html
+++ b/background.html
@@ -387,6 +387,7 @@
   <script type='text/javascript' src='js/views/app_view.js'></script>
   <script type='text/javascript' src='js/views/clear_data_view.js'></script>
 
+  <script type='text/javascript' src='js/lockscreen.js'></script>
   <script type='text/javascript' src='js/wall_clock_listener.js'></script>
   <script type='text/javascript' src='js/rotate_signed_prekey_listener.js'></script>
   <script type='text/javascript' src='js/keychange_listener.js'></script>

--- a/js/lockscreen.js
+++ b/js/lockscreen.js
@@ -1,0 +1,13 @@
+// Hides UI with Ctrl+L, Un-hides with Ctrl+; or Ctrl +'
+
+document.onkeyup = function(lockscreen) {
+  if (lockscreen.ctrlKey && lockscreen.which == 76) {
+    document.body.style.display = "none";
+  }
+  if (lockscreen.ctrlKey && lockscreen.which == 186) {
+    document.body.style.display = "block";
+  }
+  if (lockscreen.ctrlKey && lockscreen.which == 222) {
+    document.body.style.display = "block";
+  }
+};

--- a/js/lockscreen.js
+++ b/js/lockscreen.js
@@ -1,13 +1,14 @@
 // Hides UI with Ctrl+L, Un-hides with Ctrl+; or Ctrl +'
 
+// eslint-disable-next-line func-names
 document.onkeyup = function(lockscreen) {
   if (lockscreen.ctrlKey && lockscreen.which == 76) {
-    document.body.style.display = "none";
+    document.body.style.display = 'none';
   }
   if (lockscreen.ctrlKey && lockscreen.which == 186) {
-    document.body.style.display = "block";
+    document.body.style.display = 'block';
   }
   if (lockscreen.ctrlKey && lockscreen.which == 222) {
-    document.body.style.display = "block";
+    document.body.style.display = 'block';
   }
 };


### PR DESCRIPTION
This change is to resolve the fact that there is no Screen Lock available in Signal Desktop,
as opposed to the mobile versions. This is not a fully-implemented password feature, however,
it does provide more privacy when leaving the application open by being able to hide the UI
by simply pressing <kbd>Ctrl</kbd> + <kdb>L</kbd>, and un-hiding the UI by simply pressing either <kbd>Ctrl</kbd> + <kbd>;</kbd> or <kbd>Ctrl</kbd> + <kbd>'</kbd>.

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Creates a pseudo-lockscreen by implementing <kbd>Ctrl</kbd> + <kbd>L</kbd> to hide the UI and show again using <kbd>Ctrl</kbd> + <kbd>;</kbd> or <kbd>Ctrl</kbd> + <kbd>'</kbd>.

This is a workaround for the fact that mobile versions have screen lock features, but there is no way to hide Signal Desktop while keeping it open without locking your entire computer.

Tested on MacOS Mojave and Ubuntu 18.04. 