### PR TITLE
Add setting to toggle notification attention drawing

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1651,6 +1651,10 @@
     "message": "You can add notes for yourself in this conversation. If your account has any linked devices, new notes will be synced.",
     "description": "Description for the Note to Self conversation"
   },
+  "notificationDrawAttention": {
+    "message": "Draw attention to this window when a notification arrives",
+    "description": "Label text for the setting that controls whether new notifications draw attention to the window"
+  },
   "hideMenuBar": {
     "message": "Hide menu bar",
     "description": "Label text for menu bar visibility setting"

--- a/js/background.js
+++ b/js/background.js
@@ -373,6 +373,10 @@
         storage.get('notification-setting', 'message'),
       setNotificationSetting: value =>
         storage.put('notification-setting', value),
+      getNotificationDrawAttention: () =>
+        storage.get('notification-draw-attention', true),
+      setNotificationDrawAttention: value =>
+        storage.put('notification-draw-attention', value),
       getAudioNotification: () => storage.get('audio-notification'),
       setAudioNotification: value => storage.put('audio-notification', value),
       getCallRingtoneNotification: () =>

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -153,7 +153,13 @@
         message = i18n('newMessage');
       }
 
-      drawAttention();
+      const shouldDrawAttention = storage.get(
+        'notification-draw-attention',
+        true
+      );
+      if (shouldDrawAttention) {
+        drawAttention();
+      }
 
       this.lastNotification = window.Signal.Services.notify({
         platform: window.platform,

--- a/js/settings_start.js
+++ b/js/settings_start.js
@@ -36,6 +36,7 @@ const getInitialData = async () => ({
 
   notificationSetting: await window.getNotificationSetting(),
   audioNotification: await window.getAudioNotification(),
+  notificationDrawAttention: await window.getNotificationDrawAttention(),
 
   spellCheck: await window.getSpellCheck(),
 

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -113,6 +113,14 @@
           window.setThemeSetting(theme);
         },
       });
+      if (Settings.isDrawAttentionSupported()) {
+        new CheckboxView({
+          el: this.$('.draw-attention-setting'),
+          name: 'draw-attention-setting',
+          value: window.initialData.notificationDrawAttention,
+          setFn: window.setNotificationDrawAttention,
+        });
+      }
       if (Settings.isAudioNotificationSupported()) {
         new CheckboxView({
           el: this.$('.audio-notification-setting'),
@@ -204,9 +212,11 @@
         nameAndMessage: i18n('nameAndMessage'),
         noNameOrMessage: i18n('noNameOrMessage'),
         nameOnly: i18n('nameOnly'),
+        notificationDrawAttention: i18n('notificationDrawAttention'),
         audioNotificationDescription: i18n('audioNotificationDescription'),
         isAudioNotificationSupported: Settings.isAudioNotificationSupported(),
         isHideMenuBarSupported: Settings.isHideMenuBarSupported(),
+        isDrawAttentionSupported: Settings.isDrawAttentionSupported(),
         hasSystemTheme: true,
         themeLight: i18n('themeLight'),
         themeDark: i18n('themeDark'),

--- a/main.js
+++ b/main.js
@@ -1262,6 +1262,8 @@ installSettingsSetter('hide-menu-bar');
 
 installSettingsGetter('notification-setting');
 installSettingsSetter('notification-setting');
+installSettingsGetter('notification-draw-attention');
+installSettingsSetter('notification-draw-attention');
 installSettingsGetter('audio-notification');
 installSettingsSetter('audio-notification');
 

--- a/main.js
+++ b/main.js
@@ -64,10 +64,6 @@ const startInTray = process.argv.some(arg => arg === '--start-in-tray');
 const usingTrayIcon =
   startInTray || process.argv.some(arg => arg === '--use-tray-icon');
 
-const disableFlashFrame = process.argv.some(
-  arg => arg === '--disable-flash-frame'
-);
-
 const config = require('./app/config');
 
 // Very important to put before the single instance check, since it is based on the
@@ -1163,9 +1159,6 @@ ipc.on('add-setup-menu-items', () => {
 
 ipc.on('draw-attention', () => {
   if (!mainWindow) {
-    return;
-  }
-  if (disableFlashFrame) {
     return;
   }
 

--- a/preload.js
+++ b/preload.js
@@ -149,6 +149,8 @@ try {
 
   installGetter('notification-setting', 'getNotificationSetting');
   installSetter('notification-setting', 'setNotificationSetting');
+  installGetter('notification-draw-attention', 'getNotificationDrawAttention');
+  installSetter('notification-draw-attention', 'setNotificationDrawAttention');
   installGetter('audio-notification', 'getAudioNotification');
   installSetter('audio-notification', 'setAudioNotification');
 

--- a/settings.html
+++ b/settings.html
@@ -88,6 +88,13 @@
         <label for='notification-setting-off'>{{ disableNotifications }} </label>
       </div>
     </div>
+    {{ #isDrawAttentionSupported }}
+    <br />
+    <div class='draw-attention-setting'>
+      <input type='checkbox' name='notification-draw-attention' id='notification-draw-attention'/>
+      <label for='notification-draw-attention'>{{ notificationDrawAttention }}</label>
+    </div>
+    {{ /isDrawAttentionSupported }}
     <br />
     {{ #isAudioNotificationSupported }}
     <div class='audio-notification-setting'>

--- a/settings_preload.js
+++ b/settings_preload.js
@@ -60,6 +60,8 @@ window.setAlwaysRelayCalls = makeSetter('always-relay-calls');
 
 window.getNotificationSetting = makeGetter('notification-setting');
 window.setNotificationSetting = makeSetter('notification-setting');
+window.getNotificationDrawAttention = makeGetter('notification-draw-attention');
+window.setNotificationDrawAttention = makeSetter('notification-draw-attention');
 window.getAudioNotification = makeGetter('audio-notification');
 window.setAudioNotification = makeSetter('audio-notification');
 window.getCallRingtoneNotification = makeGetter('call-ringtone-notification');

--- a/ts/test/types/Settings_test.ts
+++ b/ts/test/types/Settings_test.ts
@@ -191,4 +191,65 @@ describe('Settings', () => {
       });
     });
   });
+  describe('isDrawAttentionSupported', () => {
+    context('on macOS', () => {
+      beforeEach(() => {
+        sandbox.stub(process, 'platform').value('darwin');
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return false', () => {
+        assert.isFalse(Settings.isDrawAttentionSupported());
+      });
+    });
+
+    context('on Windows', () => {
+      context('version 7', () => {
+        beforeEach(() => {
+          sandbox.stub(process, 'platform').value('win32');
+          sandbox.stub(os, 'release').returns('7.0.0');
+        });
+
+        afterEach(() => {
+          sandbox.restore();
+        });
+
+        it('should return true', () => {
+          assert.isTrue(Settings.isDrawAttentionSupported());
+        });
+      });
+
+      context('version 8+', () => {
+        beforeEach(() => {
+          sandbox.stub(process, 'platform').value('win32');
+          sandbox.stub(os, 'release').returns('8.0.0');
+        });
+
+        afterEach(() => {
+          sandbox.restore();
+        });
+
+        it('should return true', () => {
+          assert.isTrue(Settings.isDrawAttentionSupported());
+        });
+      });
+    });
+
+    context('on Linux', () => {
+      beforeEach(() => {
+        sandbox.stub(process, 'platform').value('linux');
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should return true', () => {
+        assert.isTrue(Settings.isDrawAttentionSupported());
+      });
+    });
+  });
 });

--- a/ts/types/Settings.ts
+++ b/ts/types/Settings.ts
@@ -12,3 +12,6 @@ export const isNotificationGroupingSupported = () =>
 
 // the "hide menu bar" option is specific to Windows and Linux
 export const isHideMenuBarSupported = () => !OS.isMacOS();
+
+// the "draw attention on notification" option is specific to Windows and Linux
+export const isDrawAttentionSupported = () => !OS.isMacOS();

--- a/ts/util/lint/exceptions.json
+++ b/ts/util/lint/exceptions.json
@@ -324,9 +324,9 @@
     "rule": "jQuery-appendTo(",
     "path": "js/settings_start.js",
     "line": "    window.view.$el.appendTo($body);",
-    "lineNumber": 63,
+    "lineNumber": 64,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Interacting with already-existing DOM nodes"
   },
   {
@@ -911,141 +911,154 @@
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
-    "line": "          el: this.$('.audio-notification-setting'),",
+    "line": "          el: this.$('.draw-attention-setting'),",
     "lineNumber": 118,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
+    "reasonDetail": "Protected from arbitrary input"
+  },
+  {
+    "rule": "jQuery-$(",
+    "path": "js/views/settings_view.js",
+    "line": "          el: this.$('.audio-notification-setting'),",
+    "lineNumber": 126,
+    "reasonCategory": "usageTrusted",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.spell-check-setting'),",
-    "lineNumber": 125,
+    "lineNumber": 133,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "          const $msg = this.$('.spell-check-setting-message');",
-    "lineNumber": 129,
+    "lineNumber": 137,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z"
+    "updated": "2020-08-21T11:29:29.636Z",
+    "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "          el: this.$('.menu-bar-setting'),",
-    "lineNumber": 142,
+    "lineNumber": 150,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.always-relay-calls-setting'),",
-    "lineNumber": 149,
+    "lineNumber": 157,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.call-ringtone-notification-setting'),",
-    "lineNumber": 155,
+    "lineNumber": 163,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z"
+    "updated": "2020-08-21T11:29:29.636Z",
+    "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.call-system-notification-setting'),",
-    "lineNumber": 161,
+    "lineNumber": 169,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z"
+    "updated": "2020-08-21T11:29:29.636Z",
+    "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.incoming-call-notification-setting'),",
-    "lineNumber": 167,
+    "lineNumber": 175,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z"
+    "updated": "2020-08-21T11:29:29.636Z",
+    "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.media-permissions'),",
-    "lineNumber": 173,
+    "lineNumber": 181,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.media-camera-permissions'),",
-    "lineNumber": 178,
+    "lineNumber": 186,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        this.$('.sync-setting').append(syncView.el);",
-    "lineNumber": 184,
+    "lineNumber": 192,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-append(",
     "path": "js/views/settings_view.js",
     "line": "        this.$('.sync-setting').append(syncView.el);",
-    "lineNumber": 184,
+    "lineNumber": 192,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Interacting with already-existing DOM nodes"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.sync').text(i18n('syncNow'));",
-    "lineNumber": 263,
+    "lineNumber": 273,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.sync').attr('disabled', 'disabled');",
-    "lineNumber": 267,
+    "lineNumber": 277,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.synced_at').hide();",
-    "lineNumber": 279,
+    "lineNumber": 289,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.sync_failed').hide();",
-    "lineNumber": 284,
+    "lineNumber": 294,
     "reasonCategory": "usageTrusted",
-    "updated": "2020-06-02T21:51:34.813Z",
+    "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
   },
   {


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

In many GNU/Linux setups, drawing attention when a notification arrives causes the Signal window to steal focus immediately and interrupt the user from what they were doing before the notification arrived. GNOME Shell is the most prominent example of this behavior, but there are likely other cases as well. Suddenly stealing focus on external events like this can even pose a security problem in some cases, e.g. if the user is in the middle of a typing a sudo password on one monitor while a notification arrives and focuses Signal on another monitor. See #4452 for more information.

Disabling attention drawing entirely for Linux is also problematic because some users rely on it as the sole indication of a new message, as seen in #3582 and #3611.

Commit f79069455932397105e025ef9bc04e74a9e6f612 improved the situation by adding a hidden `--disable-flash-frame` command-line argument, but this argument is undocumented and manually adding command-line arguments to the application's .desktop file is not user-friendly.

This commit adds a settings option for whether to draw attention when a new notification arrives to make it easy for all Linux users to obtain the appropriate behavior without relying on an undocumented command-line argument.

This fixes #4452.

I wrote a test for this new option that passes when I run it with Linux as a host OS, but it has not been tested on any other OSes at the moment.