### PR TITLE
ISSUE-4496 -- Fix debug log "Copy" button text wrapping for localization

### DIFF
--- a/stylesheets/_debugLog.scss
+++ b/stylesheets/_debugLog.scss
@@ -29,26 +29,18 @@
   }
 
   .result {
-    $link-max-width: 400px;
-    $open-width: 100px;
     $open-height: 36px;
     text-align: center;
 
-    $group-max-width: $link-max-width + $open-width;
     .input-group {
-      display: inline-block;
-      width: 100%;
-      max-width: $group-max-width;
+      display: inline-flex;
     }
 
-    $open-pad-x: ($open-width - 40px) / 2;
-    $open-pad-y: ($open-height - 22px) / 2;
     .copy {
-      float: left;
-      display: inline-block;
-      width: $open-width;
       height: $open-height;
-      padding: $open-pad-y $open-pad-x;
+      text-align: center;
+      line-height: $open-height;
+      padding: 0 30px;
       color: unset;
       text-decoration: none;
       cursor: pointer;
@@ -74,9 +66,8 @@
 
     .link {
       border-radius: 5px 0 0 5px;
-      float: left;
-      width: calc(100% - #{$open-width});
-      max-width: $link-max-width;
+      flex-grow: 1;
+      min-width: 400px;
       height: $open-height;
       padding: 0 10px;
       outline-offset: -4px;


### PR DESCRIPTION
# Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes #4496 

Fix the "Copy" button text wrapping in the Debug Log form for localization.

### Test summary:

Manual testing steps:

1. In `normalizeLocaleName` (`localize.js`), edit the return value to anything besides `en`. (I used `pl` for the first test.)
2. Launch the app
3. In the menu, go to `View->Debug Log` to launch the Debug Log dialog
4. Click Submit
5. View the "Copy" button in the form.


### Screenshots

### English
![image](https://user-images.githubusercontent.com/2301557/93538897-1e31ff80-f904-11ea-8b82-5bc19ece1171.png)

-------------------

### Polish
![image](https://user-images.githubusercontent.com/2301557/93538689-977d2280-f903-11ea-9db3-7131954a23c1.png)


-------------------

### Swahili
![image](https://user-images.githubusercontent.com/2301557/93538786-d90dcd80-f903-11ea-8729-f1c3e29a4a43.png)

-------------------

### Random long string
![image](https://user-images.githubusercontent.com/2301557/93538605-5c7aef00-f903-11ea-8518-69ac5b14fb1a.png)

