### PR TITLE
feat(message): show menu on right-click

### DIFF
--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -2037,6 +2037,10 @@ export class Message extends React.PureComponent<Props, State> {
 
     this.handleOpen(event);
   };
+  
+  public handleContextMenu = (event: React.MouseEvent<HTMLDivElement>): void => {
+    this.showMenu(event);
+  };
 
   public renderContainer(): JSX.Element {
     const {
@@ -2149,6 +2153,7 @@ export class Message extends React.PureComponent<Props, State> {
         role="button"
         onKeyDown={this.handleKeyDown}
         onClick={this.handleClick}
+        onContextMenu={this.handleContextMenu}
         onFocus={this.handleFocus}
         ref={this.focusRef}
       >


### PR DESCRIPTION
see the issue for details

Refs #4549

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Show the menu when right-clicking on a message.

See #4549

No new unit tests were added. This has been tested on Windows 10. 