### PR TITLE
WebAPI.initialize: add missing validity check for proxyUrl

### DIFF
--- a/ts/textsecure/WebAPI.ts
+++ b/ts/textsecure/WebAPI.ts
@@ -895,7 +895,7 @@ export function initialize({
   if (!is.string(contentProxyUrl)) {
     throw new Error('WebAPI.initialize: Invalid contentProxyUrl');
   }
-  if (!is.string(proxyUrl)) {
+  if (proxyUrl && !is.string(proxyUrl)) {
     throw new Error('WebAPI.initialize: Invalid proxyUrl');
   }
   if (!is.string(version)) {

--- a/ts/textsecure/WebAPI.ts
+++ b/ts/textsecure/WebAPI.ts
@@ -895,6 +895,9 @@ export function initialize({
   if (!is.string(contentProxyUrl)) {
     throw new Error('WebAPI.initialize: Invalid contentProxyUrl');
   }
+  if (!is.string(proxyUrl)) {
+    throw new Error('WebAPI.initialize: Invalid proxyUrl');
+  }
   if (!is.string(version)) {
     throw new Error('WebAPI.initialize: Invalid version');
   }


### PR DESCRIPTION
## Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

## Description

Not sure if the omission of this argument sanity check is intentional, but if it is, it sure is inconsistent, and should be documented as such.
