### PR TITLE
Bug fix escape 'about page' is breaking on fullscreen mode [macOS] (Issue #4540)

### DIFF
--- a/main.js
+++ b/main.js
@@ -613,6 +613,7 @@ function showAbout() {
   aboutWindow.loadURL(prepareURL([__dirname, 'about.html']));
 
   aboutWindow.on('closed', () => {
+    // mainWindow.show();
     aboutWindow = null;
   });
 
@@ -1192,6 +1193,13 @@ ipc.on('set-menu-bar-visibility', (event, visibility) => {
 
 ipc.on('close-about', () => {
   if (aboutWindow) {
+    // Exiting child window when on full screen mode (MacOs only) hides the main window
+    // Fix to issue #4540
+    if (mainWindow.isFullScreen() && process.platform === 'darwin') {
+      mainWindow.setFullScreen(false);
+      mainWindow.show();
+      mainWindow.setFullScreen(true);
+    }
     aboutWindow.close();
   }
 });

--- a/main.js
+++ b/main.js
@@ -613,7 +613,6 @@ function showAbout() {
   aboutWindow.loadURL(prepareURL([__dirname, 'about.html']));
 
   aboutWindow.on('closed', () => {
-    // mainWindow.show();
     aboutWindow = null;
   });
 


### PR DESCRIPTION
 * on macOS, in fullscreen mode, closing the about window caused the main window to remain in visibility hidden.

 * The solution - set fullscreen off, show main window and set fullscreen on again (just showing main window wouldn't work).

 Resolves: #4540

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This commit solves the about page closing bug on macOS fullscreen mode:
Upon closing about page event, check if it's on full screen mode AND macOS (to avoid unnecessary results in other platforms) - and if so, perform exit of full screen mode, show the main window, and re-enter full screen mode.

Tested on OS Catalina 10.15.6 on both states (full screen, regular).


<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
