### PR TITLE
Add support for all TLDs when rendering links

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -2580,6 +2580,30 @@ Signal Desktop makes use of the following open source projects.
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+## tlds
+
+    MIT License
+
+    Copyright (c) 2013 Stephen Mathieson and 2020 Richie Bendall
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
 ## tmp
 
     The MIT License (MIT)

--- a/js/modules/link_previews.js
+++ b/js/modules/link_previews.js
@@ -4,8 +4,7 @@ const { isNumber, compact, isEmpty } = require('lodash');
 const he = require('he');
 const nodeUrl = require('url');
 const LinkifyIt = require('linkify-it');
-
-const linkify = LinkifyIt();
+const linkify = LinkifyIt().tlds(require('tlds'));
 const { concatenateBytes, getViewOfArrayBuffer } = require('../../ts/Crypto');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "sharp": "0.23.0",
     "tar": "4.4.8",
     "testcheck": "1.0.0-rc.2",
+    "tlds": "^1.211.0",
     "tmp": "0.0.33",
     "to-arraybuffer": "1.0.1",
     "typeface-inter": "3.10.0",

--- a/ts/components/conversation/Linkify.tsx
+++ b/ts/components/conversation/Linkify.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import LinkifyIt from 'linkify-it';
-
+import tlds from 'tlds';
 import { RenderTextCallbackType } from '../../types/Util';
 import { isLinkSneaky } from '../../../js/modules/link_previews';
 
-const linkify = LinkifyIt();
+const linkify = LinkifyIt().tlds(tlds);
 
 export interface Props {
   text: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15882,6 +15882,11 @@ tinycolor2@^1.4.1:
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
   integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
+tlds@^1.211.0:
+  version "1.211.0"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.211.0.tgz#86ccefed98538f867cee431e22f57fad87dcc8fc"
+  integrity sha512-xo3HkJ8cmluINOK9ziKNeDcNjQibPNeVAlGfwgyhvxrBv1ZFqs74DcnffKaemHcOI8tNgQ+pB7G8GbcmZENKoA==
+
 tmp@0.0.28:
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.28.tgz#172735b7f614ea7af39664fa84cf0de4e515d120"


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This pull request adds support for all ICANN-registered TLDs when rendering links. This means that when sending a link with an obscure TLD and no protocol to someone - for example, `example.services` it will become hyperlinked instead of remaining as text. This is consistent with the behavior exhibited by links with more common TLDs such as `example.com`. It adds a new dependency, `tlds`, to achieve this.

This pull request fixes #4538.

I tested this on my MacBook (OS X 10.15.7) by sending links with various TLDs in a Note To Self. I did not write any new tests. I did not test on any other desktop devices.