### PR TITLE
Don't enable webcam on audio call startup

### DIFF
--- a/ts/services/calling.ts
+++ b/ts/services/calling.ts
@@ -137,7 +137,10 @@ export class CallingClass {
     });
 
     await this.startDeviceReselectionTimer();
-    this.enableLocalCamera();
+
+    if (isVideoCall) {
+      this.enableLocalCamera();
+    }
   }
 
   stopCallingLobby(): void {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes #4599. Straightforward fix, the video call flag just wasn't being checked. I verified after making the fix that audio call lobbies no longer automatically activate my webcam on startup, and that video call lobbies still activate it as expected. Tested on Ubuntu 20.04.1 LTS.
