### PR TITLE
Fix emoji style

### DIFF
--- a/ts/components/CompositionInput.tsx
+++ b/ts/components/CompositionInput.tsx
@@ -163,29 +163,15 @@ const compositeDecorator = new CompositeDecorator([
     },
     component: ({
       children,
-      contentState,
       decoratedText,
-      entityKey,
     }: {
       children: React.ReactNode;
-      contentState: ContentState;
       decoratedText: string;
-      entityKey: string;
-    }) =>
-      entityKey ? (
-        <Emoji
-          shortName={contentState.getEntity(entityKey).getData().shortName}
-          skinTone={contentState.getEntity(entityKey).getData().skinTone}
-          inline
-          size={20}
-        >
-          {children}
-        </Emoji>
-      ) : (
-        <Emoji inline size={20} emoji={decoratedText}>
-          {children}
-        </Emoji>
-      ),
+    }) => (
+      <Emoji inline size={20} emoji={decoratedText}>
+        {children}
+      </Emoji>
+    ),
   },
 ]);
 
@@ -373,12 +359,6 @@ export const CompositionInput = ({
         const selection = state.getSelection();
         const word = getWordAtCaret(state);
         const emojiContent = convertShortName(shortName, skinTone);
-        const emojiEntityKey = content
-          .createEntity('emoji', 'IMMUTABLE', {
-            shortName,
-            skinTone,
-          })
-          .getLastCreatedEntityKey();
 
         const replaceSelection = selection.merge({
           anchorOffset: word.start,
@@ -388,9 +368,7 @@ export const CompositionInput = ({
         let newContent = Modifier.replaceText(
           content,
           replaceSelection as SelectionState,
-          emojiContent,
-          undefined,
-          emojiEntityKey
+          emojiContent
         );
 
         const afterSelection = newContent.getSelectionAfter();
@@ -581,12 +559,6 @@ export const CompositionInput = ({
       const selection = state.getSelection();
       const oldContent = state.getCurrentContent();
       const emojiContent = convertShortName(e.shortName, e.skinTone);
-      const emojiEntityKey = oldContent
-        .createEntity('emoji', 'IMMUTABLE', {
-          shortName: e.shortName,
-          skinTone: e.skinTone,
-        })
-        .getLastCreatedEntityKey();
       const word = getWordAtCaret();
 
       let newContent = Modifier.replaceText(
@@ -597,9 +569,7 @@ export const CompositionInput = ({
               focusOffset: word.end,
             }) as SelectionState)
           : selection,
-        emojiContent,
-        undefined,
-        emojiEntityKey
+        emojiContent
       );
 
       const afterSelection = newContent.getSelectionAfter();

--- a/ts/components/CompositionInput.tsx
+++ b/ts/components/CompositionInput.tsx
@@ -164,10 +164,12 @@ const compositeDecorator = new CompositeDecorator([
     component: ({
       children,
       contentState,
+      decoratedText,
       entityKey,
     }: {
       children: React.ReactNode;
       contentState: ContentState;
+      decoratedText: string;
       entityKey: string;
     }) =>
       entityKey ? (
@@ -180,7 +182,9 @@ const compositeDecorator = new CompositeDecorator([
           {children}
         </Emoji>
       ) : (
-        children
+        <Emoji inline size={20} emoji={decoratedText}>
+          {children}
+        </Emoji>
       ),
   },
 ]);


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes most of #4612. Emojis now render properly after pasting into the composer or switching between conversations. The selection issue still remains, as I couldn't find any CSS tricks that would let me clean that up.

The issue was that Draft.js state was being used to track the type of each emoji, but that only works for emojis inserted by the picker, not for pasted emojis or emojis loaded from a draft. The fix was to move the information about the emoji out of the Draft.js state and to instead just determine its identity by looking at its text.

I've verified both the pasting and conversation switching cases, and I've checked that skin tone is preserved. Tested on Ubuntu 20.04.1 LTS.
