### PR TITLE
Add menu option for copying supported images in lightbox

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -163,6 +163,10 @@
     "message": "Copy Link",
     "description": "Shown in the context menu for a link to indicate that the user can copy the link"
   },
+  "contextMenuCopyImage": {
+    "message": "Copy Image",
+    "description": "Shown in the context menu for an image to indicate that the user can copy the image"
+  },
   "contextMenuNoSuggestions": {
     "message": "No Suggestions",
     "description": "Shown in the context menu for a misspelled word to indicate that there are no suggestions to replace the misspelled word"

--- a/app/spell_check.js
+++ b/app/spell_check.js
@@ -93,7 +93,7 @@ exports.setup = (browserWindow, messages) => {
           };
           label = messages.contextMenuCopyLink.message;
         } else if (isImage) {
-          click = async () => {
+          click = () => {
             if (url.parse(params.srcURL).protocol !== 'file:') {
               return;
             }

--- a/app/spell_check.js
+++ b/app/spell_check.js
@@ -1,8 +1,9 @@
 /* eslint-disable strict */
 
-const { Menu, clipboard } = require('electron');
+const { Menu, clipboard, nativeImage } = require('electron');
 const osLocale = require('os-locale');
 const { uniq } = require('lodash');
+const url = require('url');
 
 function getLanguages(userLocale, availableLocales) {
   const baseLocale = userLocale.split('-')[0];
@@ -37,7 +38,10 @@ exports.setup = (browserWindow, messages) => {
     const { editFlags } = params;
     const isMisspelled = Boolean(params.misspelledWord);
     const isLink = Boolean(params.linkURL);
-    const showMenu = params.isEditable || editFlags.canCopy || isLink;
+    const isImage =
+      params.mediaType === 'image' && params.hasImageContents && params.srcURL;
+    const showMenu =
+      params.isEditable || editFlags.canCopy || isLink || isImage;
 
     // Popup editor menu
     if (showMenu) {
@@ -79,25 +83,43 @@ exports.setup = (browserWindow, messages) => {
         }
       }
 
-      if (editFlags.canCopy || isLink) {
+      if (editFlags.canCopy || isLink || isImage) {
+        let click;
+        let label;
+
+        if (isLink) {
+          click = () => {
+            clipboard.writeText(params.linkURL);
+          };
+          label = messages.contextMenuCopyLink.message;
+        } else if (isImage) {
+          click = async () => {
+            if (url.parse(params.srcURL).protocol !== 'file:') {
+              return;
+            }
+
+            const image = nativeImage.createFromPath(
+              url.fileURLToPath(params.srcURL)
+            );
+            clipboard.writeImage(image);
+          };
+          label = messages.contextMenuCopyImage.message;
+        } else {
+          label = messages.editMenuCopy.message;
+        }
+
         template.push({
-          label: isLink
-            ? messages.contextMenuCopyLink.message
-            : messages.editMenuCopy.message,
-          role: isLink ? undefined : 'copy',
-          click: isLink
-            ? () => {
-                clipboard.writeText(params.linkURL);
-              }
-            : undefined,
+          label,
+          role: isLink || isImage ? undefined : 'copy',
+          click,
         });
       }
 
-      if (editFlags.canPaste) {
+      if (editFlags.canPaste && !isImage) {
         template.push({ label: messages.editMenuPaste.message, role: 'paste' });
       }
 
-      if (editFlags.canPaste) {
+      if (editFlags.canPaste && !isImage) {
         template.push({
           label: messages.editMenuPasteAndMatchStyle.message,
           role: 'pasteAndMatchStyle',

--- a/preload.js
+++ b/preload.js
@@ -544,7 +544,8 @@ try {
     );
     const link = e.target.closest('a');
     const selection = Boolean(window.getSelection().toString());
-    if (!editable && !selection && !link) {
+    const image = e.target.closest('.module-lightbox img');
+    if (!editable && !selection && !link && !image) {
       e.preventDefault();
     }
   });

--- a/ts/components/Lightbox.tsx
+++ b/ts/components/Lightbox.tsx
@@ -376,6 +376,7 @@ export class Lightbox extends React.Component<Props, State> {
             alt={i18n('lightboxImageAlt')}
             style={styles.img}
             src={objectURL}
+            onContextMenu={this.onContextMenu}
           />
         </button>
       );
@@ -414,6 +415,15 @@ export class Lightbox extends React.Component<Props, State> {
       <Icon i18n={i18n} onClick={this.onObjectClick} url="images/file.svg" />
     );
   };
+
+  private readonly onContextMenu = (event: React.MouseEvent<HTMLImageElement>) => {
+    const { contentType } = this.props;
+
+    // These are the only image types supported by Electron's NativeImage
+    if (contentType !== "image/png" && contentType !== "image/jpg") {
+      event?.preventDefault();
+    }
+  }
 
   private readonly onClose = () => {
     const { close } = this.props;


### PR DESCRIPTION

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Wire up context menu handlers to support copying attachment images to clipboard from lightbox view. This follows the behavior of Slack's desktop app pretty closely, except that I intentionally didn't include an option to copy the image URL.

This scratches a personal itch. I often use the Note to Self feature to send images between computers, and copying is usually a lot easier than downloading. Should go a long way toward addressing #3350.

- I didn't write any unit tests. I'm not sure how to automate this.
- I tested manually on Ubuntu 19.10. I verified that:
  - No context menu appears for GIF images (NativeImage and Electron's clipboard API only supports PNG and JPEG).
  - No context menu appears for videos.
  - Messages with multiple attachments are handled correctly.
  - Non-attachment images like profile pictures and emoji do NOT produce a context menu.