### PR TITLE
Bug fix escape 'about page' is breaking on fullscreen mode [macOS] (Issue #4540)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1191,13 +1191,6 @@ ipc.on('set-menu-bar-visibility', (event, visibility) => {
 
 ipc.on('close-about', () => {
   if (aboutWindow) {
-    // Exiting child window when on full screen mode (MacOs only) hides the main window
-    // Fix to issue #4540
-    if (mainWindow.isFullScreen() && process.platform === 'darwin') {
-      mainWindow.setFullScreen(false);
-      mainWindow.show();
-      mainWindow.setFullScreen(true);
-    }
     aboutWindow.close();
   }
 });

--- a/main.js
+++ b/main.js
@@ -772,7 +772,6 @@ async function showDebugLogWindow() {
       preload: path.join(__dirname, 'debug_log_preload.js'),
       nativeWindowOpen: true,
     },
-    parent: mainWindow,
   };
 
   debugLogWindow = new BrowserWindow(options);


### PR DESCRIPTION
### First time contributor checklist:

- [x ] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [ x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x ] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x ] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x ] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x ] My changes are ready to be shipped to users

### Description

This pull request fixes #4540 and removes a previous attempt at fixing the same issue.

For testing I was able to reproduce the issue locally. After adding my code change I performed the same steps and the issue did not occur. I reproduced the issue and then found this it did not occur on a 2020 MacBook Air running macOS Catalina 10.15.7.

