### PR TITLE
Fix max size for animated stickers

### DIFF
--- a/sticker-creator/preload.js
+++ b/sticker-creator/preload.js
@@ -15,6 +15,7 @@ const { nativeTheme } = remote.require('electron');
 const STICKER_SIZE = 512;
 const MIN_STICKER_DIMENSION = 10;
 const MAX_STICKER_DIMENSION = STICKER_SIZE;
+const MAX_WEBP_STICKER_BYTE_LENGTH = 100 * 1024;
 const MAX_ANIMATED_STICKER_BYTE_LENGTH = 300 * 1024;
 
 window.ROOT_PATH = window.location.href.startsWith('file') ? '../../' : '/';
@@ -128,6 +129,12 @@ window.processStickerImage = async path => {
       })
       .webp()
       .toBuffer();
+    if (processedBuffer.byteLength > MAX_WEBP_STICKER_BYTE_LENGTH) {
+      throw processStickerError(
+        'Sticker file was too large',
+        'StickerCreator--Toasts--tooLarge'
+      );
+    }
   }
 
   return {

--- a/sticker-creator/store/ducks/stickers.ts
+++ b/sticker-creator/store/ducks/stickers.ts
@@ -51,7 +51,7 @@ export const reset = createAction<void>('stickers/reset');
 
 export const minStickers = 1;
 export const maxStickers = 200;
-export const maxByteSize = 100 * 1024;
+export const maxByteSize = 300 * 1024;
 
 interface StateStickerData {
   readonly imageData?: StickerImageData;


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Animated stickers are allowed to be up to 300kB since bdd71e489859eb6c56434ad4b71663b3251b2e7c. However, a validation was still in place in `sticker-creator/store/ducks/stickers.ts`, preventing all stickers (APNG and Webp) to be above 100kB.
This commit fixes this, allowing to upload APNG stickers up to 300kB.

I'm not sure if this test can be removed altogether tho: https://github.com/signalapp/Signal-Desktop/blob/779487df017d8ff2db55cbda96f8fdf22f9415a7/sticker-creator/store/ducks/stickers.ts#L135-L138