### PR TITLE
Fix MIME check for JPEG in lightbox copy handler

### DIFF
--- a/ts/components/Lightbox.tsx
+++ b/ts/components/Lightbox.tsx
@@ -425,7 +425,11 @@ export class Lightbox extends React.Component<Props, State> {
     const { contentType } = this.props;
 
     // These are the only image types supported by Electron's NativeImage
-    if (event && contentType !== 'image/png' && contentType !== 'image/jpeg') {
+    if (
+      event &&
+      contentType !== 'image/png' &&
+      !contentType?.match(/image\/jpe?g/g)
+    ) {
       event.preventDefault();
     }
   };

--- a/ts/components/Lightbox.tsx
+++ b/ts/components/Lightbox.tsx
@@ -425,7 +425,7 @@ export class Lightbox extends React.Component<Props, State> {
     const { contentType } = this.props;
 
     // These are the only image types supported by Electron's NativeImage
-    if (event && contentType !== 'image/png' && contentType !== 'image/jpg') {
+    if (event && contentType !== 'image/png' && contentType !== 'image/jpeg') {
       event.preventDefault();
     }
   };


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Reference: https://www.w3.org/Graphics/JPEG/

The lightbox copy menu wasn't showing for JPEG images because #4614 was checking incorrectly for "image/jpg". I've verified that this fixes the issue in my own testing.