### PR TITLE
Fix message input emoji focus close

### DIFF
--- a/ts/components/CompositionArea.tsx
+++ b/ts/components/CompositionArea.tsx
@@ -249,6 +249,7 @@ export const CompositionArea = ({
         i18n={i18n}
         doSend={handleForceSend}
         onPickEmoji={insertEmoji}
+        onClose={focusInput}
         recentEmojis={recentEmojis}
         skinTone={skinTone}
         onSetSkinTone={onSetSkinTone}

--- a/ts/components/emoji/EmojiButton.tsx
+++ b/ts/components/emoji/EmojiButton.tsx
@@ -11,6 +11,7 @@ import { LocalizerType } from '../../types/Util';
 
 export type OwnProps = {
   readonly i18n: LocalizerType;
+  readonly onClose?: () => unknown;
 };
 
 export type Props = OwnProps &
@@ -23,6 +24,7 @@ export const EmojiButton = React.memo(
   ({
     i18n,
     doSend,
+    onClose,
     onPickEmoji,
     skinTone,
     onSetSkinTone,
@@ -43,7 +45,10 @@ export const EmojiButton = React.memo(
 
     const handleClose = React.useCallback(() => {
       setOpen(false);
-    }, [setOpen]);
+      if (onClose) {
+        onClose();
+      }
+    }, [setOpen, onClose]);
 
     // Create popper root and handle outside clicks
     React.useEffect(() => {
@@ -51,9 +56,11 @@ export const EmojiButton = React.memo(
         const root = document.createElement('div');
         setPopperRoot(root);
         document.body.appendChild(root);
-        const handleOutsideClick = ({ target }: MouseEvent) => {
-          if (!root.contains(target as Node)) {
-            setOpen(false);
+        const handleOutsideClick = (event: MouseEvent) => {
+          if (!root.contains(event.target as Node)) {
+            handleClose();
+            event.stopPropagation();
+            event.preventDefault();
           }
         };
         document.addEventListener('click', handleOutsideClick);
@@ -66,7 +73,7 @@ export const EmojiButton = React.memo(
       }
 
       return noop;
-    }, [open, setOpen, setPopperRoot]);
+    }, [open, setOpen, setPopperRoot, handleClose]);
 
     // Install keyboard shortcut to open emoji picker
     React.useEffect(() => {

--- a/ts/components/emoji/EmojiPicker.tsx
+++ b/ts/components/emoji/EmojiPicker.tsx
@@ -20,7 +20,6 @@ import {
 } from 'lodash';
 import { Emoji } from './Emoji';
 import { dataByCategory, search } from './lib';
-import { useRestoreFocus } from '../../util/hooks';
 import { LocalizerType } from '../../types/Util';
 
 export type EmojiPickDataType = {
@@ -75,7 +74,6 @@ export const EmojiPicker = React.memo(
       }: Props,
       ref
     ) => {
-      const focusRef = React.useRef<HTMLButtonElement>(null);
       const [firstRecent] = React.useState(recentEmojis);
       const [selectedCategory, setSelectedCategory] = React.useState(
         categories[0]
@@ -187,9 +185,6 @@ export const EmojiPicker = React.memo(
           document.removeEventListener('keydown', handler);
         };
       }, [onClose, searchMode]);
-
-      // Focus after initial render, restore focus on teardown
-      useRestoreFocus(focusRef);
 
       const [, ...renderableCategories] = categories;
 
@@ -307,7 +302,6 @@ export const EmojiPicker = React.memo(
           <header className="module-emoji-picker__header">
             <button
               type="button"
-              ref={focusRef}
               onClick={handleToggleSearch}
               title={i18n('EmojiPicker--search-placeholder')}
               className={classNames(


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Added a new optional property to `EmojiButton`, this property (`onClose`) allows providing a callback which will be executed on emoji picker close, for example, for focusing back the `CompositionInput` after closing the emoji picker.

Also, removed the old focus approach (that worked only on `keypress`)

Fixes #4723, #4708

Tested on macOS (Big Sur), also tested the changes on storybook using chrome, brave and firefox.
