### PR TITLE
Allow hyphenated query on conversations and contacts search

### DIFF
--- a/ts/state/ducks/search.ts
+++ b/ts/state/ducks/search.ts
@@ -282,7 +282,7 @@ async function queryConversationsAndContacts(
   }
 ) {
   const { ourConversationId, noteToSelf } = options;
-  const query = providedQuery.replace(/[+-.()]*/g, '');
+  const query = providedQuery.replace(/[+.()]*/g, '');
 
   const searchResults: Array<DBConversationType> = await dataSearchConversations(
     query


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Allow hyphenated query (query including hyphen "-") on conversations and contacts search.

Fixes: #4707

Tested on macOS (Big Sur).