### PR TITLE
Update emoji completion to be case insensitive

### DIFF
--- a/ts/quill/emoji/completion.tsx
+++ b/ts/quill/emoji/completion.tsx
@@ -121,8 +121,8 @@ export class EmojiCompletion {
     const [leftTokenTextMatch, rightTokenTextMatch] = matchBlotTextPartitions(
       blot,
       index,
-      /(?<=^|\s):([-+0-9a-z_]*)(:?)$/,
-      /^([-+0-9a-z_]*):/
+      /(?<=^|\s):([-+0-9a-zA-Z_]*)(:?)$/,
+      /^([-+0-9a-zA-Z_]*):/
     );
 
     if (leftTokenTextMatch) {


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes https://github.com/signalapp/Signal-Desktop/issues/4773

Updated the Regular Expression to also support detecting upper case combinations, This allows for users to type a capital letter after the colon key, and still get emoji results like so:

<img width="204" alt="Screen Shot 2021-01-10 at 12 13 46 pm" src="https://user-images.githubusercontent.com/13283054/104121289-edebf200-5334-11eb-9f47-e50c44fedbb4.png">

OS Information:
```
Darwin Jacobs-MacBook-Pro 20.3.0 Darwin Kernel Version 20.3.0: Mon Dec  7 22:04:02 PST 2020; root:xnu-7195.80.16.111.1~1/RELEASE_X86_64 x86_
```

<img width="698" alt="Screen Shot 2021-01-10 at 12 22 07 pm" src="https://user-images.githubusercontent.com/13283054/104121436-19bba780-5336-11eb-9235-b3e9128207c3.png">

I haven't performed any tests on any operating systems other than MacOS. I do not have access to any other machines at this time.


Signed-off-by: JPyke3 <pyke.jacob@pm.me>

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
