### PR TITLE
Reply to a message by double clicking on its row

### DIFF
--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -1206,6 +1206,11 @@ export class Message extends React.Component<Props, State> {
             ? 'module-message__text--error'
             : null
         )}
+        onDoubleClick={(event: React.MouseEvent) => {
+          // Prevent double-click interefering with interactions _inside_
+          // the bubble.
+          event.stopPropagation();
+        }}
       >
         <MessageBody
           bodyRanges={bodyRanges}

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -1393,6 +1393,10 @@ export class Message extends React.Component<Props, State> {
             'module-message__buttons',
             `module-message__buttons--${direction}`
           )}
+          onDoubleClick={(event: React.MouseEvent) => {
+            // Prevent double-click interefering when clicking the invisible buttons.
+            event.stopPropagation();
+          }}
         >
           {canReply ? reactButton : null}
           {canDownload ? downloadButton : null}

--- a/ts/components/conversation/Timeline.tsx
+++ b/ts/components/conversation/Timeline.tsx
@@ -659,6 +659,7 @@ export class Timeline extends React.PureComponent<PropsType, StateType> {
       renderLoadingRow,
       renderLastSeenIndicator,
       renderTypingBubble,
+      replyToMessage,
       unblurAvatar,
       updateSharedGroups,
     } = this.props;
@@ -719,10 +720,19 @@ export class Timeline extends React.PureComponent<PropsType, StateType> {
       }
       const messageId = items[itemIndex];
       rowContents = (
+        // Double clicking on this item is meant for mouse use only
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line jsx-a11y/interactive-supports-focus, jsx-a11y/click-events-have-key-events
         <div
           id={messageId}
           data-row={row}
           className="module-timeline__message-container"
+          onDoubleClick={(event: React.MouseEvent) => {
+            event.stopPropagation();
+            event.preventDefault();
+
+            replyToMessage(messageId);
+          }}
           style={styleWithWidth}
           role="row"
         >


### PR DESCRIPTION
When a user double clicks on a message, or to the whitespace to its side, reply to that message.

This shortcut makes is very fast and handy to quickly reply to a single message and mimics what other popular messaging clients do (WhatsApp Web and Telegram Desktop are examples of this).

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users