### PR TITLE
Ignore case while matching emoji

### DIFF
--- a/ts/quill/emoji/completion.tsx
+++ b/ts/quill/emoji/completion.tsx
@@ -127,6 +127,7 @@ export class EmojiCompletion {
 
     if (leftTokenTextMatch) {
       const [, leftTokenText, isSelfClosing] = leftTokenTextMatch;
+      leftTokenText = leftTokenText.toLowerCase();
 
       if (isSelfClosing || justPressedColon) {
         if (isShortName(leftTokenText)) {


### PR DESCRIPTION
This is a very small change. All I want is to be able to type `:SMILE:` just as I can type `:smile:` today to get the emoji. I hope that it's at the correct place.

No need for CLAs please. I provide it as public domain (silly to say this for one line, but I've been nagged before).