### PR TITLE
Improving the UX of the conversation view.

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -1106,7 +1106,9 @@
   vertical-align: middle;
   content:"";
 }
-
+.module-message__container--with-big-metadata-gap .module-message__text:after {
+  width: 95px;
+}
 .module-message__text--incoming {
   @include light-theme {
     color: $color-white;
@@ -7076,33 +7078,40 @@ button.module-image__border-overlay:focus {
   padding-bottom: 4px;
 }
 
-
-// TODO: negative margin top is hacky here, not sure how to get the beforeSame class on the parent so we can reduce the margin there.
-.beforeSame {
+// TODO: negative margin top is hacky here, not sure how to get the module-message__container--same-author-before class on the parent so we can reduce the margin there.
+.module-message__container--same-author-before {
   margin-top:-6px;
 }
-.afterSame .module-avatar {
+
+
+.module-message__container--same-author-after .module-avatar {
   display: none;
 }
-.module-message--incoming .beforeSame {
-  border-top-left-radius: 0;
+.module-message--incoming .module-message__container--same-author-before {
+  border-top-left-radius: 4px;
 }
-.module-message--outgoing .beforeSame {
-  border-top-right-radius: 0;
+.module-message--outgoing .module-message__container--same-author-before {
+  border-top-right-radius: 4px;
 }
-.module-message--incoming .afterSame {
-  border-bottom-left-radius: 0;
+.module-message--incoming .module-message__container--same-author-after {
+  border-bottom-left-radius: 4px;
 }
-.module-message--outgoing .afterSame {
-  border-bottom-right-radius: 0;
+.module-message--outgoing .module-message__container--same-author-after {
+  border-bottom-right-radius: 4px;
 }
-.beforeSame.attachment {
+.module-message__container--same-author-before.module-message__container--with-attachment {
   padding-top: 0;
 }
-.beforeSame .module-message__author {
+.module-message__container--same-author-before .module-message__author {
   display:none;
 }
-.beforeSame .module-message__attachment-container {
+.module-message__container--same-author-before .module-message__attachment-container {
+  margin-top:0;
+}
+.module-message__container--same-author-before.module-message__container--outgoing.module-message__container--with-attachment {
+  margin-top:4px;
+}
+.module-message__container--same-author-before.module-message__container--with-attachment .module-message__link-preview--with-content-above {
   margin-top:0;
 }
 

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -1100,6 +1100,13 @@
   }
 }
 
+.module-message__text:after {
+  width: 56px;
+  display: inline-block;
+  vertical-align: middle;
+  content:"";
+}
+
 .module-message__text--incoming {
   @include light-theme {
     color: $color-white;
@@ -1161,11 +1168,15 @@
 }
 
 .module-message__metadata {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-top: 3px;
-  margin-bottom: -3px;
+
+  overflow-wrap: break-word;
+  height: 15px;
+  font-size: 11px;
+  line-height: 15px;
+  white-space: nowrap;
+  float: right;
+  margin: -10px 0 -5px 4px;
+  display: inline-block;
 
   &--outgoing {
     justify-content: flex-end;
@@ -7063,6 +7074,36 @@ button.module-image__border-overlay:focus {
 .module-timeline__message-container {
   padding-top: 4px;
   padding-bottom: 4px;
+}
+
+
+// TODO: negative margin top is hacky here, not sure how to get the beforeSame class on the parent so we can reduce the margin there.
+.beforeSame {
+  margin-top:-6px;
+}
+.afterSame .module-avatar {
+  display: none;
+}
+.module-message--incoming .beforeSame {
+  border-top-left-radius: 0;
+}
+.module-message--outgoing .beforeSame {
+  border-top-right-radius: 0;
+}
+.module-message--incoming .afterSame {
+  border-bottom-left-radius: 0;
+}
+.module-message--outgoing .afterSame {
+  border-bottom-right-radius: 0;
+}
+.beforeSame.attachment {
+  padding-top: 0;
+}
+.beforeSame .module-message__author {
+  display:none;
+}
+.beforeSame .module-message__attachment-container {
+  margin-top:0;
 }
 
 .ReactVirtualized__List {

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -673,6 +673,7 @@
 }
 
 .module-message__audio-attachment {
+  display:block;
   margin-top: 2px;
 }
 
@@ -889,13 +890,6 @@
     background-color: $color-gray-95;
     border-color: $color-gray-60;
   }
-}
-
-.module-message__link-preview__content--with-content-above {
-  border-top: none;
-  border-bottom: none;
-  border-top-left-radius: 0px;
-  border-top-right-radius: 0px;
 }
 
 .module-message__link-preview__icon_container {
@@ -1187,6 +1181,14 @@
   &--with-reactions {
     margin-bottom: -2px;
   }
+}
+
+.module-message__container--with-audio .module-message__metadata {
+  margin: 3px 0 -3px 0;
+  float:none;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 // With an image and no caption, this section needs to be on top of the image overlay
@@ -7087,33 +7089,40 @@ button.module-image__border-overlay:focus {
 .module-message__container--same-author-after .module-avatar {
   display: none;
 }
-.module-message--incoming .module-message__container--same-author-before {
-  border-top-left-radius: 4px;
-}
-.module-message--outgoing .module-message__container--same-author-before {
-  border-top-right-radius: 4px;
-}
-.module-message--incoming .module-message__container--same-author-after {
-  border-bottom-left-radius: 4px;
-}
-.module-message--outgoing .module-message__container--same-author-after {
-  border-bottom-right-radius: 4px;
-}
+.module-message--incoming .module-message__container--same-author-before,
+.module-message--incoming .module-message__container--same-author-before .module-message__link-preview,
+.module-message--incoming .module-message__container--same-author-before .module-message__link-preview__content {
+  border-top-left-radius: 4px; }
+
+.module-message--outgoing .module-message__container--same-author-before,
+.module-message--outgoing .module-message__container--same-author-before .module-message__link-preview,
+.module-message--outgoing .module-message__container--same-author-before .module-message__link-preview__content {
+  border-top-right-radius: 4px; }
+
+.module-message--incoming .module-message__container--same-author-after,
+.module-message--incoming .module-message__container--same-author-after .module-message__link-preview,
+.module-message--incoming .module-message__container--same-author-after .module-message__link-preview__content {
+  border-bottom-left-radius: 4px; }
+
+.module-message--outgoing .module-message__container--same-author-after,
+.module-message--outgoing .module-message__container--same-author-after .module-message__link-preview,
+.module-message--outgoing .module-message__container--same-author-after .module-message__link-preview__content {
+  border-bottom-right-radius: 4px; }
+
 .module-message__container--same-author-before.module-message__container--with-attachment {
-  padding-top: 0;
-}
+  padding-top: 0; }
+  
 .module-message__container--same-author-before .module-message__author {
-  display:none;
-}
+  display: none; }
+
 .module-message__container--same-author-before .module-message__attachment-container {
-  margin-top:0;
-}
+  margin-top: 0; }
+
 .module-message__container--same-author-before.module-message__container--outgoing.module-message__container--with-attachment {
-  margin-top:4px;
-}
+  margin-top: 4px; }
+
 .module-message__container--same-author-before.module-message__container--with-attachment .module-message__link-preview--with-content-above {
-  margin-top:0;
-}
+  margin-top: 0; }
 
 .ReactVirtualized__List {
   outline: none;

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -1,6 +1,7 @@
 // Copyright 2018-2020 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import moment from 'moment';
 import React from 'react';
 import ReactDOM, { createPortal } from 'react-dom';
 import classNames from 'classnames';
@@ -2101,7 +2102,11 @@ export class Message extends React.PureComponent<Props, State> {
 
   public renderContainer(): JSX.Element {
     var conversation = window.getConversations().get(this.props.conversationId);
-    var extraClasses = "";
+    var beforeSame = false;
+    var afterSame = false;
+    var attachment = false;
+    var bigMetadataGap = false;
+
     if(conversation && conversation.messageCollection && conversation.messageCollection.models) {
       var messageIndex = conversation.messageCollection.models.findIndex((element) => element.id == this.props.id);
 
@@ -2110,16 +2115,23 @@ export class Message extends React.PureComponent<Props, State> {
           conversation.messageCollection.models[messageIndex-1].attributes && 
           conversation.messageCollection.models[messageIndex-1].attributes.sourceUuid == conversation.messageCollection.models[messageIndex].attributes.sourceUuid
           ) {
-          extraClasses+=" beforeSame"
+          beforeSame = true;
       }
       if( conversation.messageCollection.models[messageIndex+1] && 
           conversation.messageCollection.models[messageIndex+1].attributes && 
           conversation.messageCollection.models[messageIndex+1].attributes.sourceUuid == conversation.messageCollection.models[messageIndex].attributes.sourceUuid
           ) {
-          extraClasses+=" afterSame"
+          afterSame = true;
       }
-      if(extraClasses && conversation.messageCollection.models[messageIndex].attributes.attachments.length>0) extraClasses+=" attachment";
+      if (conversation.messageCollection.models[messageIndex].attributes.attachments.length > 0 || conversation.messageCollection.models[messageIndex].attributes.preview.length > 0)
+        attachment = true;
+      if(conversation.messageCollection.models[messageIndex].attributes.timestamp) {
+        const sameDay = moment(conversation.messageCollection.models[messageIndex].attributes.timestamp).isSame(new Date(), "day");
+        const isError = conversation.messageCollection.models[messageIndex].attributes.lastMessageStatus == "error";
+        bigMetadataGap = isError || !sameDay;
+      }
     }
+
 
     const {
       authorColor,
@@ -2140,7 +2152,11 @@ export class Message extends React.PureComponent<Props, State> {
 
     const containerClassnames = classNames(
       'module-message__container',
-      extraClasses ? extraClasses : null,
+      beforeSame ? 'module-message__container--same-author-before' : null,
+      afterSame ? 'module-message__container--same-author-after' : null,
+      attachment ? 'module-message__container--with-attachment' : null,
+      bigMetadataGap ? 'module-message__container--with-big-metadata-gap' : null,
+      isSticker ? 'module-message__container--with-sticker' : null,
       isSelected && !isSticker ? 'module-message__container--selected' : null,
       isSticker ? 'module-message__container--with-sticker' : null,
       !isSticker ? `module-message__container--${direction}` : null,

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -2106,27 +2106,35 @@ export class Message extends React.PureComponent<Props, State> {
     var afterSame = false;
     var attachment = false;
     var bigMetadataGap = false;
+    var audio = false;
 
     if(conversation && conversation.messageCollection && conversation.messageCollection.models) {
       var messageIndex = conversation.messageCollection.models.findIndex((element) => element.id == this.props.id);
 
-      
-      if( conversation.messageCollection.models[messageIndex-1] && 
-          conversation.messageCollection.models[messageIndex-1].attributes && 
-          conversation.messageCollection.models[messageIndex-1].attributes.sourceUuid == conversation.messageCollection.models[messageIndex].attributes.sourceUuid
-          ) {
-          beforeSame = true;
-      }
-      if( conversation.messageCollection.models[messageIndex+1] && 
-          conversation.messageCollection.models[messageIndex+1].attributes && 
-          conversation.messageCollection.models[messageIndex+1].attributes.sourceUuid == conversation.messageCollection.models[messageIndex].attributes.sourceUuid
-          ) {
-          afterSame = true;
-      }
-      if (conversation.messageCollection.models[messageIndex].attributes.attachments.length > 0 || conversation.messageCollection.models[messageIndex].attributes.preview.length > 0)
+      if (conversation.messageCollection.models[messageIndex - 1] &&
+        conversation.messageCollection.models[messageIndex - 1].attributes &&
+        (
+            conversation.messageCollection.models[messageIndex - 1].attributes.sourceUuid == conversation.messageCollection.models[messageIndex].attributes.sourceUuid
+            ||
+            (conversation.messageCollection.models[messageIndex - 1].attributes.type == 'outgoing' && conversation.messageCollection.models[messageIndex].attributes.type == 'outgoing')
+        )) {
+        beforeSame = true;
+    }
+    if (conversation.messageCollection.models[messageIndex + 1] &&
+        conversation.messageCollection.models[messageIndex + 1].attributes &&
+        (
+            conversation.messageCollection.models[messageIndex + 1].attributes.sourceUuid == conversation.messageCollection.models[messageIndex].attributes.sourceUuid
+            ||
+            (conversation.messageCollection.models[messageIndex + 1].attributes.type == 'outgoing' && conversation.messageCollection.models[messageIndex].attributes.type == 'outgoing')
+        )) {
+        afterSame = true;
+    }
+      if(conversation.messageCollection.models[messageIndex].attributes.attachments[0] && conversation.messageCollection.models[messageIndex].attributes.attachments[0].contentType && conversation.messageCollection.models[messageIndex].attributes.attachments[0].contentType.indexOf("audio") > -1)
+        audio = true;
+      else if (conversation.messageCollection.models[messageIndex].attributes.attachments.length > 0 || conversation.messageCollection.models[messageIndex].attributes.preview.length > 0)
         attachment = true;
       if(conversation.messageCollection.models[messageIndex].attributes.timestamp) {
-        const sameDay = moment(conversation.messageCollection.models[messageIndex].attributes.timestamp).isSame(new Date(), "day");
+        const sameDay = moment(conversation.messageCollection.models[messageIndex].attributes.timestamp).add(12, 'hours').isBefore(/*now*/);
         const isError = conversation.messageCollection.models[messageIndex].attributes.lastMessageStatus == "error";
         bigMetadataGap = isError || !sameDay;
       }
@@ -2154,6 +2162,7 @@ export class Message extends React.PureComponent<Props, State> {
       'module-message__container',
       beforeSame ? 'module-message__container--same-author-before' : null,
       afterSame ? 'module-message__container--same-author-after' : null,
+      audio ? 'module-message__container--with-audio' : null,
       attachment ? 'module-message__container--with-attachment' : null,
       bigMetadataGap ? 'module-message__container--with-big-metadata-gap' : null,
       isSticker ? 'module-message__container--with-sticker' : null,

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -2100,6 +2100,27 @@ export class Message extends React.PureComponent<Props, State> {
   };
 
   public renderContainer(): JSX.Element {
+    var conversation = window.getConversations().get(this.props.conversationId);
+    var extraClasses = "";
+    if(conversation && conversation.messageCollection && conversation.messageCollection.models) {
+      var messageIndex = conversation.messageCollection.models.findIndex((element) => element.id == this.props.id);
+
+      
+      if( conversation.messageCollection.models[messageIndex-1] && 
+          conversation.messageCollection.models[messageIndex-1].attributes && 
+          conversation.messageCollection.models[messageIndex-1].attributes.sourceUuid == conversation.messageCollection.models[messageIndex].attributes.sourceUuid
+          ) {
+          extraClasses+=" beforeSame"
+      }
+      if( conversation.messageCollection.models[messageIndex+1] && 
+          conversation.messageCollection.models[messageIndex+1].attributes && 
+          conversation.messageCollection.models[messageIndex+1].attributes.sourceUuid == conversation.messageCollection.models[messageIndex].attributes.sourceUuid
+          ) {
+          extraClasses+=" afterSame"
+      }
+      if(extraClasses && conversation.messageCollection.models[messageIndex].attributes.attachments.length>0) extraClasses+=" attachment";
+    }
+
     const {
       authorColor,
       deletedForEveryone,
@@ -2119,6 +2140,7 @@ export class Message extends React.PureComponent<Props, State> {
 
     const containerClassnames = classNames(
       'module-message__container',
+      extraClasses ? extraClasses : null,
       isSelected && !isSticker ? 'module-message__container--selected' : null,
       isSticker ? 'module-message__container--with-sticker' : null,
       !isSticker ? `module-message__container--${direction}` : null,


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Please check this screenshot to see the changes in action:

![output](https://user-images.githubusercontent.com/2820002/104548010-fb321500-5683-11eb-8cd8-193ef30db112.png)

Consecutive messages from the same author are now
 - displayed closer together, 
 - have their border radius' changed to look more congruent,
 - only have one profile picture / username per block of messages

In addition, the timestamp for the message is now displayed on the right of each message and does not increase the vertical height of the message unless there is insufficient space for it to be displayed at the end of the message.

These changes combined make for a significantly improved viewing experience for the user.

My test approach was to generate as many combinations of message sequences as I could think of to ensure different orders of messages would look correct. 

I needed to access conversation data from each message to achieve this, a process that appears difficult under the current architecture. For this reason I've used window.getConversations to find the conversation for the message and check the messages before/after it. If you have a suggestion for a better way to achieve this, please let me know!
