### PR TITLE
Add a setting to choose what contact details are shown on the chat header

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1406,6 +1406,18 @@
     "message": "New Message",
     "description": "Displayed in notifications for only 1 message"
   },
+  "nameAndNumber": {
+    "message": "Name and number",
+    "description": "Show name and number of the contact in the chat header"
+  },
+  "noNameOrNumber": {
+    "message": "No name or number",
+    "description": "Do not show name and number of the contact in the chat header"
+  },
+  "hideChatContactPersonalDetailsDialog": {
+    "message": "Chat header shows",
+    "description": "Do not show name and number of the contact in the chat header"
+  },
   "notificationSenderInGroup": {
     "message": "$sender$ in $group$",
     "description": "Displayed in notifications for messages in a group",

--- a/js/settings_start.js
+++ b/js/settings_start.js
@@ -31,6 +31,7 @@ const getInitialData = async () => ({
   hideMenuBar: await window.getHideMenuBar(),
 
   notificationSetting: await window.getNotificationSetting(),
+  chatHeaderContactSetting: await window.getChatHeaderContactSetting(),
   audioNotification: await window.getAudioNotification(),
   notificationDrawAttention: await window.getNotificationDrawAttention(),
   countMutedConversations: await window.getCountMutedConversations(),

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -152,6 +152,12 @@
           window.setSpellCheck(val);
         },
       });
+      new RadioButtonGroupView({
+        el: this.$('.chat-header-contact-setting'),
+        name: 'chat-header-contact-setting',
+        value: window.initialData.chatHeaderContactSetting,
+        setFn: window.setChatHeaderContactSetting,
+      });
       if (Settings.isHideMenuBarSupported()) {
         new CheckboxView({
           el: this.$('.menu-bar-setting'),
@@ -219,6 +225,9 @@
         nameAndMessage: i18n('nameAndMessage'),
         noNameOrMessage: i18n('noNameOrMessage'),
         nameOnly: i18n('nameOnly'),
+        hideChatContactPersonalDetailsDialog: i18n('hideChatContactPersonalDetailsDialog'),
+        nameAndNumber: i18n('nameAndNumber'),
+        noNameOrNumber: i18n('noNameOrNumber'),
         notificationDrawAttention: i18n('notificationDrawAttention'),
         audioNotificationDescription: i18n('audioNotificationDescription'),
         isAudioNotificationSupported: Settings.isAudioNotificationSupported(),

--- a/main.js
+++ b/main.js
@@ -1293,6 +1293,9 @@ installSettingsSetter('badge-count-muted-conversations');
 installSettingsGetter('spell-check');
 installSettingsSetter('spell-check');
 
+installSettingsGetter('chat-header-contact-setting');
+installSettingsSetter('chat-header-contact-setting');
+
 installSettingsGetter('always-relay-calls');
 installSettingsSetter('always-relay-calls');
 installSettingsGetter('call-ringtone-notification');

--- a/preload.js
+++ b/preload.js
@@ -189,6 +189,9 @@ try {
   installGetter('spell-check', 'getSpellCheck');
   installSetter('spell-check', 'setSpellCheck');
 
+  installGetter('chat-header-contact-setting', 'getChatHeaderContactSetting');
+  installSetter('chat-header-contact-setting', 'setChatHeaderContactSetting')
+
   installGetter('always-relay-calls', 'getAlwaysRelayCalls');
   installSetter('always-relay-calls', 'setAlwaysRelayCalls');
 

--- a/settings.html
+++ b/settings.html
@@ -118,6 +118,21 @@
           {{ spellCheckDirtyText }}
         </p>
       </div>
+      <div class='chat-header-contact-setting'>
+        <p>{{ hideChatContactPersonalDetailsDialog }}</p>
+      <div>
+        <input type='radio' name='chat-header-contact-setting' id='chat-header-contact-setting-name-and-number' value='name-and-number'>
+        <label for='chat-contact-personal-details-name-and-number'>{{ nameAndNumber }} </label>
+      </div>
+      <div>
+        <input type='radio' name='chat-header-contact-setting' id='chat-header-contact-setting-name-only'  value='name-only'/>
+        <label for='chat-contact-personal-details-name-only'>{{ nameOnly }} </label>
+      </div>
+      <div>
+        <input type='radio' name='chat-header-contact-setting' id='chat-header-contact-setting-no-name-no-number' value='no-name-no-number'/>
+        <label for='chat-contact-personal-details-no-name-no-number'>{{ noNameOrNumber }} </label>
+      </div>
+      </div>
     <hr>
     <div class='calling-setting'>
       <h3>{{ calling }}</h3>

--- a/settings_preload.js
+++ b/settings_preload.js
@@ -58,6 +58,9 @@ window.setHideMenuBar = makeSetter('hide-menu-bar');
 window.getSpellCheck = makeGetter('spell-check');
 window.setSpellCheck = makeSetter('spell-check');
 
+window.getChatHeaderContactSetting = makeGetter('chat-header-contact-setting');
+window.setChatHeaderContactSetting = makeSetter('chat-header-contact-setting');
+
 window.getAlwaysRelayCalls = makeGetter('always-relay-calls');
 window.setAlwaysRelayCalls = makeSetter('always-relay-calls');
 

--- a/ts/background.ts
+++ b/ts/background.ts
@@ -410,6 +410,9 @@ type WhatIsThis = import('./window.d').WhatIsThis;
         window.storage.put('spell-check', value);
       },
 
+      getChatHeaderContactSetting: () => window.storage.get('chat-header-contact-setting', 'name-only'),
+      setChatHeaderContactSetting: (value: WhatIsThis) => window.storage.put('chat-header-contact-setting', value),
+
       getAlwaysRelayCalls: () => window.storage.get('always-relay-calls'),
       setAlwaysRelayCalls: (value: WhatIsThis) =>
         window.storage.put('always-relay-calls', value),

--- a/ts/components/conversation/ConversationHeader.stories.tsx
+++ b/ts/components/conversation/ConversationHeader.stories.tsx
@@ -54,6 +54,7 @@ const commonProps = {
   onMarkUnread: action('onMarkUnread'),
   onMoveToInbox: action('onMoveToInbox'),
   onSetPin: action('onSetPin'),
+  contactDetailsSetting: 'name-and-number'
 };
 
 const stories: Array<ConversationHeaderStory> = [
@@ -168,6 +169,40 @@ const stories: Array<ConversationHeaderStory> = [
           id: '6',
           acceptedMessageRequest: true,
           muteExpiresAt: new Date('3000-10-18T11:11:11Z').valueOf(),
+        },
+      },
+      {
+        title: 'chat header contact details is set to name only',
+        props: {
+          ...commonProps,
+          color: 'red',
+          isVerified: true,
+          avatarPath: gifUrl,
+          title: 'Someone 🔥 Somewhere',
+          name: 'Someone 🔥 Somewhere',
+          phoneNumber: '(202) 555-0001',
+          type: 'direct',
+          id: '1',
+          profileName: '🔥Flames🔥',
+          acceptedMessageRequest: true,
+          contactDetailsSetting: 'name-only'
+        },
+      },
+      {
+        title: 'chat header contact details is set to no name and no number',
+        props: {
+          ...commonProps,
+          color: 'red',
+          isVerified: true,
+          avatarPath: gifUrl,
+          title: 'Someone 🔥 Somewhere',
+          name: 'Someone 🔥 Somewhere',
+          phoneNumber: '(202) 555-0001',
+          type: 'direct',
+          id: '1',
+          profileName: '🔥Flames🔥',
+          acceptedMessageRequest: true,
+          contactDetailsSetting: 'no-name-no-number'
         },
       },
     ],

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -32,6 +32,12 @@ export enum OutgoingCallButtonStyle {
   Join,
 }
 
+const ContactDetailsSettingNames = {
+  NAME_AND_NUMBER: 'name-and-number',
+  NAME_ONLY: 'name-only',
+  NO_NAME_AND_NUMBER: 'no-name-no-number',
+};
+
 export interface PropsDataType {
   id: string;
   name?: string;
@@ -58,6 +64,7 @@ export interface PropsDataType {
 
   showBackButton?: boolean;
   outgoingCallButtonStyle: OutgoingCallButtonStyle;
+  contactDetailsSetting: string
 }
 
 export interface PropsActionsType {
@@ -135,6 +142,7 @@ export class ConversationHeader extends React.Component<PropsType> {
       isMe,
       profileName,
       isVerified,
+      contactDetailsSetting
     } = this.props;
 
     if (isMe) {
@@ -146,11 +154,12 @@ export class ConversationHeader extends React.Component<PropsType> {
     }
 
     const shouldShowIcon = Boolean(name && type === 'direct');
-    const shouldShowNumber = Boolean(phoneNumber && (name || profileName));
+    const shouldShowName = Boolean(contactDetailsSetting == ContactDetailsSettingNames.NAME_ONLY || contactDetailsSetting == ContactDetailsSettingNames.NAME_AND_NUMBER)
+    const shouldShowNumber = Boolean(phoneNumber && (name || profileName) && contactDetailsSetting == ContactDetailsSettingNames.NAME_AND_NUMBER);
 
     return (
       <div className="module-conversation-header__title">
-        <Emojify text={title} />
+        {shouldShowName ? <Emojify text={title} /> : null}
         {shouldShowIcon ? (
           <span>
             {' '}

--- a/ts/state/smart/ConversationHeader.tsx
+++ b/ts/state/smart/ConversationHeader.tsx
@@ -75,6 +75,10 @@ const getOutgoingCallButtonStyle = (
   }
 };
 
+const getContactDetailsSetting = () => {
+  return window.Events.getChatHeaderContactSetting();
+};
+
 const mapStateToProps = (state: StateType, ownProps: OwnProps) => {
   const conversation = getConversationSelector(state)(ownProps.id);
   if (!conversation) {
@@ -105,6 +109,7 @@ const mapStateToProps = (state: StateType, ownProps: OwnProps) => {
     i18n: getIntl(state),
     showBackButton: state.conversations.selectedConversationPanelDepth > 0,
     outgoingCallButtonStyle: getOutgoingCallButtonStyle(conversation, state),
+    contactDetailsSetting: getContactDetailsSetting()
   };
 };
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Currently, name and number of the contact are shown on chat header by default
some of the users have raised a concern about it as it is too revealing and gives away privacy

Add a setting to choose what level of details are shown on the chat header
Following options are provided
- Name and number
- Name only
- No name and number

By default name only option is chose.

Users can change the settings under general header.
Manually tested on MacOS Catalina (10.15.1)

Resolves: #4669
