### PR TITLE
GUI: Open settings window centered above mainwindow

### DIFF
--- a/main.js
+++ b/main.js
@@ -635,9 +635,16 @@ function showSettingsWindow() {
   addDarkOverlay();
 
   const size = mainWindow.getSize();
+  // center settings window over main window
+  const settingwidth = Math.min(500, size[0]);
+  const settingheight = Math.max(size[1] - 100, MIN_HEIGHT);
+  const mainPos = mainWindow.getPosition();
+  const mainSize = mainWindow.getSize();
   const options = {
-    width: Math.min(500, size[0]),
-    height: Math.max(size[1] - 100, MIN_HEIGHT),
+    x: Math.round(mainPos[0] + mainSize[0] / 2 - settingwidth / 2),
+    y: Math.round(mainPos[1] + mainSize[1] / 2 - settingheight / 2),
+    width: settingwidth,
+    height: settingheight,
     frame: false,
     resizable: false,
     title: locale.messages.signalDesktopPreferences.message,


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

When I open the settings menu the position will be fixed, independant where I moved the app window. On my multi screen layout this can be confusing when the settings open on the main screen although the main window is on another monitor − on big monitors this might be also strange. My change sets the position of the settings window right in the middle above the main window.