### PR TITLE
Add option to mute conversations indefinitely

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3183,9 +3183,17 @@
     "message": "Mute for one year",
     "description": "Label for muting the conversation"
   },
+  "muteIndefinite": {
+    "message": "Mute until I unmute",
+    "description": "Label for muting the conversation"
+  },
   "unmute": {
     "message": "Unmute",
     "description": "Label for unmuting the conversation"
+  },
+  "indefiniteMuteLabel": {
+    "message": "Muted until you unmute",
+    "description": "Shown in the mute notifications submenu whenever a conversation has been muted indefinitely"
   },
   "muteExpirationLabel": {
     "message": "Muted until $duration$",

--- a/ts/ConversationController.ts
+++ b/ts/ConversationController.ts
@@ -59,15 +59,16 @@ export function start(): void {
     // we can reset the mute state on the model. If the mute has already expired
     // then we reset the state right away.
     initMuteExpirationTimer(model: ConversationModel): void {
-      if (model.isMuted()) {
+      const muteExpiresAt = model.get('muteExpiresAt');
+      if (model.isMuted() && muteExpiresAt !== -1) {
         window.Signal.Services.onTimeout(
-          model.get('muteExpiresAt'),
+          muteExpiresAt,
           () => {
             model.set({ muteExpiresAt: undefined });
           },
           model.getMuteTimeoutId()
         );
-      } else if (model.get('muteExpiresAt')) {
+      } else if (muteExpiresAt !== -1) {
         model.set({ muteExpiresAt: undefined });
       }
     },

--- a/ts/components/ConversationListItem.tsx
+++ b/ts/components/ConversationListItem.tsx
@@ -14,6 +14,7 @@ import { cleanId } from './_util';
 
 import { LocalizerType } from '../types/Util';
 import { ColorType } from '../types/Colors';
+import { isMuted } from '../util/isMuted';
 
 export const MessageStatuses = [
   'sending',
@@ -202,7 +203,7 @@ export class ConversationListItem extends React.PureComponent<Props> {
               : null
           )}
         >
-          {muteExpiresAt && Date.now() < muteExpiresAt && (
+          {isMuted(muteExpiresAt) && (
             <span className="module-conversation-list-item__muted" />
           )}
           {!acceptedMessageRequest ? (

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -366,25 +366,31 @@ export class ConversationHeader extends React.Component<PropsType> {
 
     const muteOptions = [];
     if (isMuted(muteExpiresAt)) {
-      const expires = moment(muteExpiresAt);
-      const muteExpirationLabel = moment().isSame(expires, 'day')
-        ? expires.format('hh:mm A')
-        : expires.format('M/D/YY, hh:mm A');
+      if (muteExpiresAt === -1) {
+        muteOptions.push({
+          name: i18n('indefiniteMuteLabel'),
+          disabled: true,
+          value: 0,
+        });
+      } else {
+        const expires = moment(muteExpiresAt);
+        const muteExpirationLabel = moment().isSame(expires, 'day')
+          ? expires.format('hh:mm A')
+          : expires.format('M/D/YY, hh:mm A');
 
-      muteOptions.push(
-        ...[
-          {
-            name: i18n('muteExpirationLabel', [muteExpirationLabel]),
-            disabled: true,
-            value: 0,
-          },
-          {
-            name: i18n('unmute'),
-            value: 0,
-          },
-        ]
-      );
+        muteOptions.push({
+          name: i18n('muteExpirationLabel', [muteExpirationLabel]),
+          disabled: true,
+          value: 0,
+        });
+      }
+
+      muteOptions.push({
+        name: i18n('unmute'),
+        value: 0,
+      });
     }
+
     muteOptions.push(...getMuteOptions(i18n));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ts/test-node/util/isMuted_test.ts
+++ b/ts/test-node/util/isMuted_test.ts
@@ -15,8 +15,16 @@ describe('isMuted', () => {
     assert.isFalse(isMuted(Date.now() - 123));
   });
 
-  it('returns false if passed a date in the future', () => {
+  it('returns false if passed a negative number less than -1', () => {
+    assert.isFalse(isMuted(-2));
+  });
+
+  it('returns true if passed a date in the future', () => {
     assert.isTrue(isMuted(Date.now() + 123));
     assert.isTrue(isMuted(Date.now() + 123456));
+  });
+
+  it('returns true if passed -1', () => {
+    assert.isTrue(isMuted(-1));
   });
 });

--- a/ts/util/getMuteOptions.ts
+++ b/ts/util/getMuteOptions.ts
@@ -28,5 +28,9 @@ export function getMuteOptions(i18n: LocalizerType): Array<MuteOption> {
       name: i18n('muteYear'),
       value: moment.duration(1, 'year').as('milliseconds'),
     },
+    {
+      name: i18n('muteIndefinite'),
+      value: -1,
+    },
   ];
 }

--- a/ts/util/isMuted.ts
+++ b/ts/util/isMuted.ts
@@ -2,5 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 export function isMuted(muteExpiresAt: undefined | number): boolean {
-  return Boolean(muteExpiresAt && Date.now() < muteExpiresAt);
+  return Boolean(
+    muteExpiresAt && (muteExpiresAt === -1 || Date.now() < muteExpiresAt)
+  );
 }

--- a/ts/views/conversation_view.ts
+++ b/ts/views/conversation_view.ts
@@ -417,7 +417,7 @@ Whisper.ConversationView = Whisper.View.extend({
 
   getMuteExpirationLabel() {
     const muteExpiresAt = this.model.get('muteExpiresAt');
-    if (!this.model.isMuted()) {
+    if (!this.model.isMuted() || muteExpiresAt === -1) {
       return;
     }
 
@@ -2853,9 +2853,8 @@ Whisper.ConversationView = Whisper.View.extend({
   },
 
   setMuteNotifications(ms: number) {
-    const muteExpiresAt = ms > 0 ? Date.now() + ms : undefined;
-
-    if (muteExpiresAt) {
+    if (ms > 0) {
+      const muteExpiresAt = Date.now() + ms;
       // we use a timeoutId here so that we can reference the mute that was
       // potentially set in the ConversationController. Specifically for a
       // scenario where a conversation is already muted and we boot up the app,
@@ -2871,9 +2870,12 @@ Whisper.ConversationView = Whisper.View.extend({
         },
         timeoutId
       );
+
+      this.model.set({ muteExpiresAt });
+    } else if (ms !== -1) {
+      this.model.set({ muteExpiresAt: undefined });
     }
 
-    this.model.set({ muteExpiresAt });
     this.saveModel();
   },
 


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Allow setting a value of -1 for muteExpiration which is treated as indefinite.
Add new strings for mute menu
- "Mute until I unmute" to enable
- "Muted until you unmute" for mute status
Ensure existing code works correctly, e.g mute icon and labels show appropriately
Add tests for additional mute cases
Verify `yarn ready` passes.

Addresses issue #4906.

Manually tested by muting/unmuting conversations with the local app connected to a live device and verifying that the labels/menus/mute icons appear correctly and behave as expected.

Development and testing was done on MacOS Big Sur, 11.0.1.  Primary device is Android running Android 11.
