### PR TITLE
Ascii emoji inline substitution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,8 +185,8 @@ interactive session with `NODE_ENV=test yarn run start`.
 If you want to run the `libtextsecure` tests, you can run `yarn run test-electron`,
 which also runs the unit tests.
 
-To run Node.js tests, you can run `yarn test-server` from the command line. You can get
-code coverage numbers for this kind of run via `yarn test-server-coverage`, then display
+To run Node.js tests, you can run `yarn run test-node` from the command line. You can get
+code coverage numbers for this kind of run via `yarn run test-node-coverage`, then display
 the report with `yarn open-coverage`.
 
 ## Pull requests

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1334,6 +1334,10 @@
     "message": "Enable spell check of text entered in message composition box",
     "description": "Description of the media permission description"
   },
+  "autoSubstituteAsciiEmojisDescription": {
+    "message": "Substitute ASCII emojis with their graphical version",
+    "description": "While entering ASCII emojis into a text input in chat windows, they will be replaced with graphical ones"
+  },
   "spellCheckWillBeEnabled": {
     "message": "Spell check will be enabled the next time Signal starts.",
     "description": "Shown when the user enables spellcheck to indicate that they must restart Signal."

--- a/js/settings_start.js
+++ b/js/settings_start.js
@@ -36,6 +36,7 @@ const getInitialData = async () => ({
   countMutedConversations: await window.getCountMutedConversations(),
 
   spellCheck: await window.getSpellCheck(),
+  autoSubstituteAsciiEmojis: await window.getAutoSubstituteAsciiEmojis(),
 
   incomingCallNotification: await window.getIncomingCallNotification(),
   callRingtoneNotification: await window.getCallRingtoneNotification(),

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -152,6 +152,14 @@
           window.setSpellCheck(val);
         },
       });
+      new CheckboxView({
+        el: this.$('.auto-substitute-ascii-emojis'),
+        name: 'auto-substitute-ascii-emojis',
+        value: window.initialData.autoSubstituteAsciiEmojis,
+        setFn: val => {
+          window.setAutoSubstituteAsciiEmojis(val);
+        },
+      });
       if (Settings.isHideMenuBarSupported()) {
         new CheckboxView({
           el: this.$('.menu-bar-setting'),
@@ -219,6 +227,7 @@
         nameAndMessage: i18n('nameAndMessage'),
         noNameOrMessage: i18n('noNameOrMessage'),
         nameOnly: i18n('nameOnly'),
+        autoSubstituteAsciiEmojisDescription: i18n('autoSubstituteAsciiEmojisDescription'),
         notificationDrawAttention: i18n('notificationDrawAttention'),
         audioNotificationDescription: i18n('audioNotificationDescription'),
         isAudioNotificationSupported: Settings.isAudioNotificationSupported(),
@@ -258,7 +267,7 @@
         spellCheckDisplay: spellCheckDirty ? 'inherit' : 'none',
         spellCheckDirtyText: appStartSpellCheck
           ? i18n('spellCheckWillBeDisabled')
-          : i18n('spellCheckWillBeEnabled'),
+        : i18n('spellCheckWillBeEnabled'),
       };
     },
     onClose() {

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -227,7 +227,9 @@
         nameAndMessage: i18n('nameAndMessage'),
         noNameOrMessage: i18n('noNameOrMessage'),
         nameOnly: i18n('nameOnly'),
-        autoSubstituteAsciiEmojisDescription: i18n('autoSubstituteAsciiEmojisDescription'),
+        autoSubstituteAsciiEmojisDescription: i18n(
+          'autoSubstituteAsciiEmojisDescription'
+        ),
         notificationDrawAttention: i18n('notificationDrawAttention'),
         audioNotificationDescription: i18n('audioNotificationDescription'),
         isAudioNotificationSupported: Settings.isAudioNotificationSupported(),
@@ -267,7 +269,7 @@
         spellCheckDisplay: spellCheckDirty ? 'inherit' : 'none',
         spellCheckDirtyText: appStartSpellCheck
           ? i18n('spellCheckWillBeDisabled')
-        : i18n('spellCheckWillBeEnabled'),
+          : i18n('spellCheckWillBeEnabled'),
       };
     },
     onClose() {

--- a/main.js
+++ b/main.js
@@ -1292,6 +1292,8 @@ installSettingsSetter('badge-count-muted-conversations');
 
 installSettingsGetter('spell-check');
 installSettingsSetter('spell-check');
+installSettingsGetter('auto-substitute-ascii-emojis');
+installSettingsSetter('auto-substitute-ascii-emojis');
 
 installSettingsGetter('always-relay-calls');
 installSettingsSetter('always-relay-calls');

--- a/preload.js
+++ b/preload.js
@@ -189,6 +189,9 @@ try {
   installGetter('spell-check', 'getSpellCheck');
   installSetter('spell-check', 'setSpellCheck');
 
+  installGetter('auto-substitute-ascii-emojis', 'getAutoSubstituteAsciiEmojis');
+  installSetter('auto-substitute-ascii-emojis', 'setAutoSubstituteAsciiEmojis');
+
   installGetter('always-relay-calls', 'getAlwaysRelayCalls');
   installSetter('always-relay-calls', 'setAlwaysRelayCalls');
 

--- a/settings.html
+++ b/settings.html
@@ -110,14 +110,18 @@
       <label for='badge-count-muted-conversations'>{{ countMutedConversationsDescription }}</label>
     </div>
     <hr>
-      <h3>{{ generalHeader }}</h3>
-      <div class='spell-check-setting'>
-        <input type='checkbox' name='spell-check-setting' id='spell-check-setting' />
-        <label for='spell-check-setting'>{{ spellCheckDescription }}</label>
-        <p class='spell-check-setting-message' style='display: {{ spellCheckDisplay }};' aria-hidden='{{ spellCheckHidden }}'>
-          {{ spellCheckDirtyText }}
-        </p>
-      </div>
+    <h3>{{ generalHeader }}</h3>
+    <div class='spell-check-setting'>
+      <input type='checkbox' name='spell-check-setting' id='spell-check-setting' />
+      <label for='spell-check-setting'>{{ spellCheckDescription }}</label>
+      <p class='spell-check-setting-message' style='display: {{ spellCheckDisplay }};' aria-hidden='{{ spellCheckHidden }}'>
+        {{ spellCheckDirtyText }}
+      </p>
+    </div>
+    <div class='auto-substitute-ascii-emojis'>
+      <input type='checkbox' name='auto-substitute-ascii-emojis' id='auto-substitute-ascii-emojis' />
+      <label for='auto-substitute-ascii-emojis'>{{ autoSubstituteAsciiEmojisDescription }}</label>
+    </div>
     <hr>
     <div class='calling-setting'>
       <h3>{{ calling }}</h3>

--- a/settings_preload.js
+++ b/settings_preload.js
@@ -3,34 +3,34 @@
 
 /* global window */
 
-const { ipcRenderer, remote } = require('electron');
+const {ipcRenderer, remote} = require('electron');
 
 const url = require('url');
 const i18n = require('./js/modules/i18n');
 
 const config = url.parse(window.location.toString(), true).query;
-const { locale } = config;
+const {locale} = config;
 const localeMessages = ipcRenderer.sendSync('locale-data');
 
-const { nativeTheme } = remote.require('electron');
+const {nativeTheme} = remote.require('electron');
 
 window.platform = process.platform;
 window.theme = config.theme;
 window.i18n = i18n.setup(locale, localeMessages);
 window.appStartInitialSpellcheckSetting =
-  config.appStartInitialSpellcheckSetting === 'true';
+    config.appStartInitialSpellcheckSetting === 'true';
 
 function setSystemTheme() {
-  window.systemTheme = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+    window.systemTheme = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
 }
 
 setSystemTheme();
 
 window.subscribeToSystemThemeChange = fn => {
-  nativeTheme.on('updated', () => {
-    setSystemTheme();
-    fn();
-  });
+    nativeTheme.on('updated', () => {
+        setSystemTheme();
+        fn();
+    });
 };
 
 window.getEnvironment = () => config.environment;
@@ -41,9 +41,9 @@ window.getAppInstance = () => config.appInstance;
 const Signal = require('./js/modules/signal');
 
 window.Signal = Signal.setup({
-  Attachments: null,
-  userDataPath: null,
-  getRegionCode: () => null,
+    Attachments: null,
+    userDataPath: null,
+    getRegionCode: () => null,
 });
 
 window.closeSettings = () => ipcRenderer.send('close-settings');
@@ -57,6 +57,9 @@ window.setHideMenuBar = makeSetter('hide-menu-bar');
 
 window.getSpellCheck = makeGetter('spell-check');
 window.setSpellCheck = makeSetter('spell-check');
+
+window.getAutoSubstituteAsciiEmojis = makeGetter('auto-substitute-ascii-emojis');
+window.setAutoSubstituteAsciiEmojis = makeSetter('auto-substitute-ascii-emojis');
 
 window.getAlwaysRelayCalls = makeGetter('always-relay-calls');
 window.setAlwaysRelayCalls = makeSetter('always-relay-calls');
@@ -74,10 +77,10 @@ window.setCallSystemNotification = makeSetter('call-system-notification');
 window.getIncomingCallNotification = makeGetter('incoming-call-notification');
 window.setIncomingCallNotification = makeSetter('incoming-call-notification');
 window.getCountMutedConversations = makeGetter(
-  'badge-count-muted-conversations'
+    'badge-count-muted-conversations'
 );
 window.setCountMutedConversations = makeSetter(
-  'badge-count-muted-conversations'
+    'badge-count-muted-conversations'
 );
 
 window.getMediaPermissions = makeGetter('media-permissions');
@@ -93,31 +96,32 @@ window.setLastSyncTime = makeSetter('sync-time');
 window.deleteAllData = () => ipcRenderer.send('delete-all-data');
 
 function makeGetter(name) {
-  return () =>
-    new Promise((resolve, reject) => {
-      ipcRenderer.once(`get-success-${name}`, (event, error, value) => {
-        if (error) {
-          return reject(error);
-        }
+    return () => {
+        return new Promise((resolve, reject) => {
+            ipcRenderer.once(`get-success-${name}`, (event, error, value) => {
+                if (error) {
+                    return reject(error);
+                }
 
-        return resolve(value);
-      });
-      ipcRenderer.send(`get-${name}`);
-    });
+                return resolve(value);
+            });
+            ipcRenderer.send(`get-${name}`);
+        });
+    }
 }
 
 function makeSetter(name) {
-  return value =>
-    new Promise((resolve, reject) => {
-      ipcRenderer.once(`set-success-${name}`, (event, error) => {
-        if (error) {
-          return reject(error);
-        }
+    return value =>
+        new Promise((resolve, reject) => {
+            ipcRenderer.once(`set-success-${name}`, (event, error) => {
+                if (error) {
+                    return reject(error);
+                }
 
-        return resolve();
-      });
-      ipcRenderer.send(`set-${name}`, value);
-    });
+                return resolve();
+            });
+            ipcRenderer.send(`set-${name}`, value);
+        });
 }
 
 require('./js/logging');

--- a/settings_preload.js
+++ b/settings_preload.js
@@ -3,34 +3,34 @@
 
 /* global window */
 
-const {ipcRenderer, remote} = require('electron');
+const { ipcRenderer, remote } = require('electron');
 
 const url = require('url');
 const i18n = require('./js/modules/i18n');
 
 const config = url.parse(window.location.toString(), true).query;
-const {locale} = config;
+const { locale } = config;
 const localeMessages = ipcRenderer.sendSync('locale-data');
 
-const {nativeTheme} = remote.require('electron');
+const { nativeTheme } = remote.require('electron');
 
 window.platform = process.platform;
 window.theme = config.theme;
 window.i18n = i18n.setup(locale, localeMessages);
 window.appStartInitialSpellcheckSetting =
-    config.appStartInitialSpellcheckSetting === 'true';
+  config.appStartInitialSpellcheckSetting === 'true';
 
 function setSystemTheme() {
-    window.systemTheme = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+  window.systemTheme = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
 }
 
 setSystemTheme();
 
 window.subscribeToSystemThemeChange = fn => {
-    nativeTheme.on('updated', () => {
-        setSystemTheme();
-        fn();
-    });
+  nativeTheme.on('updated', () => {
+    setSystemTheme();
+    fn();
+  });
 };
 
 window.getEnvironment = () => config.environment;
@@ -41,9 +41,9 @@ window.getAppInstance = () => config.appInstance;
 const Signal = require('./js/modules/signal');
 
 window.Signal = Signal.setup({
-    Attachments: null,
-    userDataPath: null,
-    getRegionCode: () => null,
+  Attachments: null,
+  userDataPath: null,
+  getRegionCode: () => null,
 });
 
 window.closeSettings = () => ipcRenderer.send('close-settings');
@@ -58,8 +58,12 @@ window.setHideMenuBar = makeSetter('hide-menu-bar');
 window.getSpellCheck = makeGetter('spell-check');
 window.setSpellCheck = makeSetter('spell-check');
 
-window.getAutoSubstituteAsciiEmojis = makeGetter('auto-substitute-ascii-emojis');
-window.setAutoSubstituteAsciiEmojis = makeSetter('auto-substitute-ascii-emojis');
+window.getAutoSubstituteAsciiEmojis = makeGetter(
+  'auto-substitute-ascii-emojis'
+);
+window.setAutoSubstituteAsciiEmojis = makeSetter(
+  'auto-substitute-ascii-emojis'
+);
 
 window.getAlwaysRelayCalls = makeGetter('always-relay-calls');
 window.setAlwaysRelayCalls = makeSetter('always-relay-calls');
@@ -77,10 +81,10 @@ window.setCallSystemNotification = makeSetter('call-system-notification');
 window.getIncomingCallNotification = makeGetter('incoming-call-notification');
 window.setIncomingCallNotification = makeSetter('incoming-call-notification');
 window.getCountMutedConversations = makeGetter(
-    'badge-count-muted-conversations'
+  'badge-count-muted-conversations'
 );
 window.setCountMutedConversations = makeSetter(
-    'badge-count-muted-conversations'
+  'badge-count-muted-conversations'
 );
 
 window.getMediaPermissions = makeGetter('media-permissions');
@@ -96,32 +100,32 @@ window.setLastSyncTime = makeSetter('sync-time');
 window.deleteAllData = () => ipcRenderer.send('delete-all-data');
 
 function makeGetter(name) {
-    return () => {
-        return new Promise((resolve, reject) => {
-            ipcRenderer.once(`get-success-${name}`, (event, error, value) => {
-                if (error) {
-                    return reject(error);
-                }
+  return () => {
+    return new Promise((resolve, reject) => {
+      ipcRenderer.once(`get-success-${name}`, (event, error, value) => {
+        if (error) {
+          return reject(error);
+        }
 
-                return resolve(value);
-            });
-            ipcRenderer.send(`get-${name}`);
-        });
-    }
+        return resolve(value);
+      });
+      ipcRenderer.send(`get-${name}`);
+    });
+  };
 }
 
 function makeSetter(name) {
-    return value =>
-        new Promise((resolve, reject) => {
-            ipcRenderer.once(`set-success-${name}`, (event, error) => {
-                if (error) {
-                    return reject(error);
-                }
+  return value =>
+    new Promise((resolve, reject) => {
+      ipcRenderer.once(`set-success-${name}`, (event, error) => {
+        if (error) {
+          return reject(error);
+        }
 
-                return resolve();
-            });
-            ipcRenderer.send(`set-${name}`, value);
-        });
+        return resolve();
+      });
+      ipcRenderer.send(`set-${name}`, value);
+    });
 }
 
 require('./js/logging');

--- a/ts/background.ts
+++ b/ts/background.ts
@@ -410,6 +410,12 @@ type WhatIsThis = import('./window.d').WhatIsThis;
         window.storage.put('spell-check', value);
       },
 
+      getAutoSubstituteAsciiEmojis: () =>
+        window.storage.get('auto-substitute-ascii-emojis', true),
+      setAutoSubstituteAsciiEmojis: (value: WhatIsThis) => {
+        window.storage.put('auto-substitute-ascii-emojis', value);
+      },
+
       getAlwaysRelayCalls: () => window.storage.get('always-relay-calls'),
       setAlwaysRelayCalls: (value: WhatIsThis) =>
         window.storage.put('always-relay-calls', value),

--- a/ts/components/CompositionInput.tsx
+++ b/ts/components/CompositionInput.tsx
@@ -34,11 +34,13 @@ import {
 } from '../quill/util';
 import { SignalClipboard } from '../quill/signal-clipboard';
 import { DirectionalBlot } from '../quill/block/blot';
+import { AutoSubstituteAsciiEmojis } from '../quill/auto-substitute-ascii-emojis';
 
 Quill.register('formats/emoji', EmojiBlot);
 Quill.register('formats/mention', MentionBlot);
 Quill.register('formats/block', DirectionalBlot);
 Quill.register('modules/emojiCompletion', EmojiCompletion);
+Quill.register('modules/autoSubstituteAsciiEmojis', AutoSubstituteAsciiEmojis);
 Quill.register('modules/mentionCompletion', MentionCompletion);
 Quill.register('modules/signalClipboard', SignalClipboard);
 
@@ -503,6 +505,9 @@ export const CompositionInput: React.ComponentType<Props> = props => {
                 onEscape: { key: 27, handler: onEscape }, // 27 = Escape
                 onBackspace: { key: 8, handler: onBackspace }, // 8 = Backspace
               },
+            },
+            autoSubstituteAsciiEmojis: {
+              skinTone,
             },
             emojiCompletion: {
               setEmojiPickerElement: setEmojiCompletionElement,

--- a/ts/quill/auto-substitute-ascii-emojis/index.tsx
+++ b/ts/quill/auto-substitute-ascii-emojis/index.tsx
@@ -1,0 +1,82 @@
+// Copyright 2020 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Quill from 'quill';
+import Delta from 'quill-delta';
+import _ from 'lodash';
+import {
+  convertShortName,
+  convertShortNameToData,
+  EmojiData,
+} from '../../components/emoji/lib';
+import { EmojiPickDataType } from '../../components/emoji/EmojiPicker';
+
+interface AutoSubstituteAsciiEmojisOptions {
+  onPickEmoji: (emoji: EmojiPickDataType) => void;
+  setEmojiPickerElement: (element: JSX.Element | null) => void;
+  skinTone: number;
+}
+
+const emojiMap: Record<string, string> = {
+  ':)': 'slightly_smiling_face',
+  ':(': 'slightly_frowning_face',
+  ':D': 'grinning',
+  ':-*': 'kissing',
+  ':*': 'kissing',
+};
+
+export class AutoSubstituteAsciiEmojis {
+  options: AutoSubstituteAsciiEmojisOptions;
+
+  quill: Quill;
+
+  constructor(quill: Quill, options: AutoSubstituteAsciiEmojisOptions) {
+    this.options = options;
+    this.quill = quill;
+
+    this.quill.on(
+      'text-change',
+      _.debounce(() => this.onTextChange(), 0)
+    );
+  }
+
+  onTextChange(): void {
+    if (!window.Events.getAutoSubstituteAsciiEmojis()) {
+      return;
+    }
+
+    const range = this.quill.getSelection();
+
+    if (!range) return;
+
+    const [blot, index] = this.quill.getLeaf(range.index);
+
+    if (blot !== undefined && blot.text !== undefined) {
+      const blotText: string = blot.text;
+      Object.entries(emojiMap).some(([textEmoji, emojiName]) => {
+        if (blotText.substring(0, index).endsWith(textEmoji)) {
+          const emojiData = convertShortNameToData(
+            emojiName,
+            this.options.skinTone
+          );
+          if (emojiData) {
+            this.insertEmoji(
+              emojiData,
+              range.index - textEmoji.length,
+              textEmoji.length
+            );
+            return true;
+          }
+        }
+        return false;
+      });
+    }
+  }
+
+  insertEmoji(emojiData: EmojiData, index: number, range: number): void {
+    const emoji = convertShortName(emojiData.short_name, this.options.skinTone);
+    const delta = new Delta().retain(index).delete(range).insert({emoji});
+    this.quill.updateContents(delta, 'user');
+    this.quill.setSelection(index + 1, 0);
+  }
+}

--- a/ts/quill/auto-substitute-ascii-emojis/index.tsx
+++ b/ts/quill/auto-substitute-ascii-emojis/index.tsx
@@ -9,11 +9,8 @@ import {
   convertShortNameToData,
   EmojiData,
 } from '../../components/emoji/lib';
-import { EmojiPickDataType } from '../../components/emoji/EmojiPicker';
 
 interface AutoSubstituteAsciiEmojisOptions {
-  onPickEmoji: (emoji: EmojiPickDataType) => void;
-  setEmojiPickerElement: (element: JSX.Element | null) => void;
   skinTone: number;
 }
 

--- a/ts/quill/auto-substitute-ascii-emojis/index.tsx
+++ b/ts/quill/auto-substitute-ascii-emojis/index.tsx
@@ -19,10 +19,17 @@ interface AutoSubstituteAsciiEmojisOptions {
 
 const emojiMap: Record<string, string> = {
   ':)': 'slightly_smiling_face',
+  ':-)': 'slightly_smiling_face',
   ':(': 'slightly_frowning_face',
+  ':-(': 'slightly_frowning_face',
   ':D': 'grinning',
-  ':-*': 'kissing',
+  ':-D': 'grinning',
   ':*': 'kissing',
+  ':-*': 'kissing',
+  ':P': 'stuck_out_tongue',
+  ':-P': 'stuck_out_tongue',
+  ';P': 'stuck_out_tongue_winking_eye',
+  ';-P': 'stuck_out_tongue_winking_eye',
 };
 
 export class AutoSubstituteAsciiEmojis {

--- a/ts/quill/auto-substitute-ascii-emojis/index.tsx
+++ b/ts/quill/auto-substitute-ascii-emojis/index.tsx
@@ -19,14 +19,26 @@ const emojiMap: Record<string, string> = {
   ':-)': 'slightly_smiling_face',
   ':(': 'slightly_frowning_face',
   ':-(': 'slightly_frowning_face',
-  ':D': 'grinning',
-  ':-D': 'grinning',
+  ':D': 'smiley',
+  ':-D': 'smiley',
   ':*': 'kissing',
   ':-*': 'kissing',
   ':P': 'stuck_out_tongue',
   ':-P': 'stuck_out_tongue',
   ';P': 'stuck_out_tongue_winking_eye',
   ';-P': 'stuck_out_tongue_winking_eye',
+  'D:': 'anguished',
+  "D-':": 'anguished',
+  ':O': 'open_mouth',
+  ':-O': 'open_mouth',
+  ":'(": 'cry',
+  ":'-(": 'cry',
+  ':/': 'confused',
+  ':-/': 'confused',
+  ';)': 'wink',
+  ';-)': 'wink',
+  '(Y)': '+1',
+  '(N)': '-1',
 };
 
 export class AutoSubstituteAsciiEmojis {
@@ -79,7 +91,7 @@ export class AutoSubstituteAsciiEmojis {
 
   insertEmoji(emojiData: EmojiData, index: number, range: number): void {
     const emoji = convertShortName(emojiData.short_name, this.options.skinTone);
-    const delta = new Delta().retain(index).delete(range).insert({emoji});
+    const delta = new Delta().retain(index).delete(range).insert({ emoji });
     this.quill.updateContents(delta, 'user');
     this.quill.setSelection(index + 1, 0);
   }

--- a/ts/test-electron/quill/auto-substitute-ascii-emojis_test.tsx
+++ b/ts/test-electron/quill/auto-substitute-ascii-emojis_test.tsx
@@ -1,0 +1,213 @@
+// Copyright 2020 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+import Delta from 'quill-delta';
+import sinon from 'sinon';
+
+
+import { convertShortName, EmojiData } from '../../components/emoji/lib';
+import { AutoSubstituteAsciiEmojis } from '../../quill/auto-substitute-ascii-emojis';
+
+
+describe('autoSubstituteAsciiEmojis', () => {
+  let emojiSubstitution: AutoSubstituteAsciiEmojis;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockQuill: any;
+  let options: any;
+
+  beforeEach(function beforeEach() {
+    mockQuill = {
+      getLeaf: sinon.stub(),
+      getSelection: sinon.stub(),
+      keyboard: {
+        addBinding: sinon.stub(),
+      },
+      on: sinon.stub(),
+      setSelection: sinon.stub(),
+      updateContents: sinon.stub(),
+    };
+    options = {
+      skinTone: 0,
+    };
+
+    window.Events = {
+      getAutoSubstituteAsciiEmojis: () => true
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    emojiSubstitution = new AutoSubstituteAsciiEmojis(mockQuill as any, options);
+  });
+
+  describe('onTextChange', () => {
+    let insertEmojiStub: sinon.SinonStub<
+      [EmojiData, number, number],
+      void
+    >;
+
+    beforeEach(function beforeEach() {
+      insertEmojiStub = sinon
+        .stub(emojiSubstitution, 'insertEmoji')
+        .callThrough();
+    });
+
+    afterEach(function afterEach() {
+      insertEmojiStub.restore();
+    });
+
+    describe('given an ascii-emoji is not starting (no colon or semicolon)', () => {
+      beforeEach(function beforeEach() {
+        mockQuill.getSelection.returns({
+          index: 2,
+          length: 0,
+        });
+
+        const blot = {
+          text: '-)',
+        };
+        mockQuill.getLeaf.returns([blot, 2]);
+
+        emojiSubstitution.onTextChange();
+      });
+
+      it('does not substitute with emoji', () => {
+        assert.equal(insertEmojiStub.notCalled, true);
+      });
+    });
+
+    describe('given a colon in a string (but not an emoji)', () => {
+      beforeEach(function beforeEach() {
+        mockQuill.getSelection.returns({
+          index: 5,
+          length: 0,
+        });
+
+        const blot = {
+          text: '10:Z)',
+        };
+        mockQuill.getLeaf.returns([blot, 5]);
+
+        emojiSubstitution.onTextChange();
+      });
+
+      it('does not substitute', () => {
+        assert.equal(insertEmojiStub.notCalled, true);
+      });
+    });
+
+    describe('given an emoji is starting but does not have 3 characters', () => {
+      beforeEach(function beforeEach() {
+        mockQuill.getSelection.returns({
+          index: 2,
+          length: 0,
+        });
+
+        const blot = {
+          text: ':-',
+        };
+        mockQuill.getLeaf.returns([blot, 2]);
+
+        emojiSubstitution.onTextChange();
+      });
+
+      it('does not show results', () => {
+        assert.equal(insertEmojiStub.notCalled, true);
+      });
+    });
+
+    describe('given an emoji is starting but does not match a known ascii emoji', () => {
+      beforeEach(function beforeEach() {
+        mockQuill.getSelection.returns({
+          index: 3,
+          length: 0,
+        });
+
+        const blot = {
+          text: ':-Q',
+        };
+        mockQuill.getLeaf.returns([blot, 3]);
+
+        emojiSubstitution.onTextChange();
+      });
+
+      it('does not show results', () => {
+        assert.equal(insertEmojiStub.notCalled, true);
+      });
+    });
+
+    describe('given a entered text matches a known 3-char ascii emoji', () => {
+      beforeEach(function beforeEach() {
+        mockQuill.getSelection.returns({
+          index: 3,
+          length: 0,
+        });
+
+        const blot = {
+          text: ':-)',
+        };
+        mockQuill.getLeaf.returns([blot, 3]);
+
+        emojiSubstitution.onTextChange();
+      });
+
+      it('replaces the ascii-text with the emoji', () => {
+        assert.equal(insertEmojiStub.called, true);
+        const emoji = convertShortName('slightly_smiling_face', options.skinTone);
+        const delta = new Delta().delete(3).insert({emoji});
+        sinon.assert.calledOnceWithMatch(mockQuill.updateContents, delta);
+      });
+    });
+
+    describe('given a entered text matches a known 2-char ascii emoji', () => {
+      beforeEach(function beforeEach() {
+        mockQuill.getSelection.returns({
+          index: 2,
+          length: 0,
+        });
+
+        const blot = {
+          text: ':)',
+        };
+        mockQuill.getLeaf.returns([blot, 2]);
+
+        emojiSubstitution.onTextChange();
+      });
+
+      it('replaces the ascii-text with the emoji', () => {
+        assert.equal(insertEmojiStub.called, true);
+        const emoji = convertShortName('slightly_smiling_face', options.skinTone);
+        const delta = new Delta().delete(2).insert({emoji});
+        sinon.assert.calledOnceWithMatch(mockQuill.updateContents, delta);
+      });
+    });
+
+
+    describe('given it matches a ascii emoji inside a larger string', () => {
+      const text = 'have a :-) nice day';
+
+      beforeEach(function beforeEach() {
+        const blot = {
+          text: ':-)'
+        };
+        mockQuill.getSelection.returns({
+          index: 10,
+          length: 0,
+        });
+        mockQuill.getLeaf.returns([blot, 3]);
+
+        emojiSubstitution.onTextChange();
+      });
+
+      it('inserts the emoji at the current cursor position', () => {
+        assert.equal(insertEmojiStub.called, true);
+        const emoji = convertShortName('slightly_smiling_face', options.skinTone);
+        const delta = new Delta().retain(7).delete(3).insert({emoji});
+        sinon.assert.calledOnceWithMatch(mockQuill.updateContents, delta);
+      });
+
+      it('sets the quill selection to the right cursor position', () => {
+        sinon.assert.calledOnceWithMatch(mockQuill.setSelection, 8, 0);
+      });
+    });
+  });
+});

--- a/ts/test-electron/quill/auto-substitute-ascii-emojis_test.tsx
+++ b/ts/test-electron/quill/auto-substitute-ascii-emojis_test.tsx
@@ -5,10 +5,8 @@ import { assert } from 'chai';
 import Delta from 'quill-delta';
 import sinon from 'sinon';
 
-
 import { convertShortName, EmojiData } from '../../components/emoji/lib';
 import { AutoSubstituteAsciiEmojis } from '../../quill/auto-substitute-ascii-emojis';
-
 
 describe('autoSubstituteAsciiEmojis', () => {
   let emojiSubstitution: AutoSubstituteAsciiEmojis;
@@ -32,18 +30,18 @@ describe('autoSubstituteAsciiEmojis', () => {
     };
 
     window.Events = {
-      getAutoSubstituteAsciiEmojis: () => true
-    }
+      getAutoSubstituteAsciiEmojis: () => true,
+    };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    emojiSubstitution = new AutoSubstituteAsciiEmojis(mockQuill as any, options);
+    emojiSubstitution = new AutoSubstituteAsciiEmojis(
+      mockQuill as any,
+      options
+    );
   });
 
   describe('onTextChange', () => {
-    let insertEmojiStub: sinon.SinonStub<
-      [EmojiData, number, number],
-      void
-    >;
+    let insertEmojiStub: sinon.SinonStub<[EmojiData, number, number], void>;
 
     beforeEach(function beforeEach() {
       insertEmojiStub = sinon
@@ -55,7 +53,7 @@ describe('autoSubstituteAsciiEmojis', () => {
       insertEmojiStub.restore();
     });
 
-    describe('given an ascii-emoji is not starting (no colon or semicolon)', () => {
+    describe('given there is no valid ascii emoji', () => {
       beforeEach(function beforeEach() {
         mockQuill.getSelection.returns({
           index: 2,
@@ -110,7 +108,7 @@ describe('autoSubstituteAsciiEmojis', () => {
         emojiSubstitution.onTextChange();
       });
 
-      it('does not show results', () => {
+      it('does not substitute', () => {
         assert.equal(insertEmojiStub.notCalled, true);
       });
     });
@@ -130,7 +128,7 @@ describe('autoSubstituteAsciiEmojis', () => {
         emojiSubstitution.onTextChange();
       });
 
-      it('does not show results', () => {
+      it('does not substitute', () => {
         assert.equal(insertEmojiStub.notCalled, true);
       });
     });
@@ -152,8 +150,11 @@ describe('autoSubstituteAsciiEmojis', () => {
 
       it('replaces the ascii-text with the emoji', () => {
         assert.equal(insertEmojiStub.called, true);
-        const emoji = convertShortName('slightly_smiling_face', options.skinTone);
-        const delta = new Delta().delete(3).insert({emoji});
+        const emoji = convertShortName(
+          'slightly_smiling_face',
+          options.skinTone
+        );
+        const delta = new Delta().delete(3).insert({ emoji });
         sinon.assert.calledOnceWithMatch(mockQuill.updateContents, delta);
       });
     });
@@ -175,19 +176,19 @@ describe('autoSubstituteAsciiEmojis', () => {
 
       it('replaces the ascii-text with the emoji', () => {
         assert.equal(insertEmojiStub.called, true);
-        const emoji = convertShortName('slightly_smiling_face', options.skinTone);
-        const delta = new Delta().delete(2).insert({emoji});
+        const emoji = convertShortName(
+          'slightly_smiling_face',
+          options.skinTone
+        );
+        const delta = new Delta().delete(2).insert({ emoji });
         sinon.assert.calledOnceWithMatch(mockQuill.updateContents, delta);
       });
     });
 
-
     describe('given it matches a ascii emoji inside a larger string', () => {
-      const text = 'have a :-) nice day';
-
       beforeEach(function beforeEach() {
         const blot = {
-          text: ':-)'
+          text: ':-)',
         };
         mockQuill.getSelection.returns({
           index: 10,
@@ -200,8 +201,11 @@ describe('autoSubstituteAsciiEmojis', () => {
 
       it('inserts the emoji at the current cursor position', () => {
         assert.equal(insertEmojiStub.called, true);
-        const emoji = convertShortName('slightly_smiling_face', options.skinTone);
-        const delta = new Delta().retain(7).delete(3).insert({emoji});
+        const emoji = convertShortName(
+          'slightly_smiling_face',
+          options.skinTone
+        );
+        const delta = new Delta().retain(7).delete(3).insert({ emoji });
         sinon.assert.calledOnceWithMatch(mockQuill.updateContents, delta);
       });
 

--- a/ts/util/lint/exceptions.json
+++ b/ts/util/lint/exceptions.json
@@ -317,7 +317,7 @@
     "rule": "jQuery-appendTo(",
     "path": "js/settings_start.js",
     "line": "    window.view.$el.appendTo($body);",
-    "lineNumber": 59,
+    "lineNumber": 60,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Interacting with already-existing DOM nodes"
@@ -1030,8 +1030,17 @@
   {
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
+    "line": "        el: this.$('.auto-substitute-ascii-emojis'),",
+    "lineNumber": 156,
+    "reasonCategory": "usageTrusted",
+    "updated": "2021-01-24T09:56:29.636Z",
+    "reasonDetail": "Protected from arbitrary input"
+  },
+  {
+    "rule": "jQuery-$(",
+    "path": "js/views/settings_view.js",
     "line": "          el: this.$('.menu-bar-setting'),",
-    "lineNumber": 157,
+    "lineNumber": 165,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1040,7 +1049,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.always-relay-calls-setting'),",
-    "lineNumber": 164,
+    "lineNumber": 172,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1049,7 +1058,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.call-ringtone-notification-setting'),",
-    "lineNumber": 170,
+    "lineNumber": 178,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1058,7 +1067,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.call-system-notification-setting'),",
-    "lineNumber": 176,
+    "lineNumber": 184,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1067,7 +1076,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.incoming-call-notification-setting'),",
-    "lineNumber": 182,
+    "lineNumber": 190,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1076,7 +1085,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.media-permissions'),",
-    "lineNumber": 188,
+    "lineNumber": 196,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1085,7 +1094,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        el: this.$('.media-camera-permissions'),",
-    "lineNumber": 193,
+    "lineNumber": 201,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1094,7 +1103,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "        this.$('.sync-setting').append(syncView.el);",
-    "lineNumber": 199,
+    "lineNumber": 207,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1103,7 +1112,7 @@
     "rule": "jQuery-append(",
     "path": "js/views/settings_view.js",
     "line": "        this.$('.sync-setting').append(syncView.el);",
-    "lineNumber": 199,
+    "lineNumber": 207,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Interacting with already-existing DOM nodes"
@@ -1112,7 +1121,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.sync').text(i18n('syncNow'));",
-    "lineNumber": 283,
+    "lineNumber": 294,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1121,7 +1130,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.sync').removeAttr('disabled');",
-    "lineNumber": 284,
+    "lineNumber": 295,
     "reasonCategory": "usageTrusted",
     "updated": "2020-09-11T17:24:56.124Z",
     "reasonDetail": "Static selector argument"
@@ -1130,7 +1139,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.sync').attr('disabled', 'disabled');",
-    "lineNumber": 287,
+    "lineNumber": 298,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1139,7 +1148,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.sync').text(i18n('syncing'));",
-    "lineNumber": 288,
+    "lineNumber": 299,
     "reasonCategory": "usageTrusted",
     "updated": "2020-09-11T17:24:56.124Z",
     "reasonDetail": "Static selector argument"
@@ -1148,7 +1157,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.synced_at').hide();",
-    "lineNumber": 299,
+    "lineNumber": 310,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -1157,7 +1166,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.sync_failed').show();",
-    "lineNumber": 300,
+    "lineNumber": 311,
     "reasonCategory": "usageTrusted",
     "updated": "2020-09-11T17:24:56.124Z",
     "reasonDetail": "Static selector argument"
@@ -1166,7 +1175,7 @@
     "rule": "jQuery-$(",
     "path": "js/views/settings_view.js",
     "line": "      this.$('.sync_failed').hide();",
-    "lineNumber": 304,
+    "lineNumber": 315,
     "reasonCategory": "usageTrusted",
     "updated": "2020-08-21T11:29:29.636Z",
     "reasonDetail": "Protected from arbitrary input"
@@ -14490,24 +14499,6 @@
     "rule": "React-useRef",
     "path": "ts/components/CompositionInput.js",
     "line": "    const emojiCompletionRef = React.useRef();",
-    "lineNumber": 43,
-    "reasonCategory": "falseMatch",
-    "updated": "2020-10-26T19:12:24.410Z",
-    "reasonDetail": "Doesn't refer to a DOM element."
-  },
-  {
-    "rule": "React-useRef",
-    "path": "ts/components/CompositionInput.js",
-    "line": "    const mentionCompletionRef = React.useRef();",
-    "lineNumber": 44,
-    "reasonCategory": "falseMatch",
-    "updated": "2020-10-26T23:54:34.273Z",
-    "reasonDetail": "Doesn't refer to a DOM element."
-  },
-  {
-    "rule": "React-useRef",
-    "path": "ts/components/CompositionInput.js",
-    "line": "    const quillRef = React.useRef();",
     "lineNumber": 45,
     "reasonCategory": "falseMatch",
     "updated": "2020-10-26T19:12:24.410Z",
@@ -14516,16 +14507,16 @@
   {
     "rule": "React-useRef",
     "path": "ts/components/CompositionInput.js",
-    "line": "    const scrollerRef = React.useRef(null);",
+    "line": "    const mentionCompletionRef = React.useRef();",
     "lineNumber": 46,
-    "reasonCategory": "usageTrusted",
-    "updated": "2020-10-26T19:12:24.410Z",
-    "reasonDetail": "Used with Quill for scrolling."
+    "reasonCategory": "falseMatch",
+    "updated": "2020-10-26T23:54:34.273Z",
+    "reasonDetail": "Doesn't refer to a DOM element."
   },
   {
     "rule": "React-useRef",
     "path": "ts/components/CompositionInput.js",
-    "line": "    const propsRef = React.useRef(props);",
+    "line": "    const quillRef = React.useRef();",
     "lineNumber": 47,
     "reasonCategory": "falseMatch",
     "updated": "2020-10-26T19:12:24.410Z",
@@ -14534,8 +14525,26 @@
   {
     "rule": "React-useRef",
     "path": "ts/components/CompositionInput.js",
-    "line": "    const memberRepositoryRef = React.useRef(new memberRepository_1.MemberRepository());",
+    "line": "    const scrollerRef = React.useRef(null);",
     "lineNumber": 48,
+    "reasonCategory": "usageTrusted",
+    "updated": "2020-10-26T19:12:24.410Z",
+    "reasonDetail": "Used with Quill for scrolling."
+  },
+  {
+    "rule": "React-useRef",
+    "path": "ts/components/CompositionInput.js",
+    "line": "    const propsRef = React.useRef(props);",
+    "lineNumber": 49,
+    "reasonCategory": "falseMatch",
+    "updated": "2020-10-26T19:12:24.410Z",
+    "reasonDetail": "Doesn't refer to a DOM element."
+  },
+  {
+    "rule": "React-useRef",
+    "path": "ts/components/CompositionInput.js",
+    "line": "    const memberRepositoryRef = React.useRef(new memberRepository_1.MemberRepository());",
+    "lineNumber": 50,
     "reasonCategory": "falseMatch",
     "updated": "2020-10-26T23:56:13.482Z",
     "reasonDetail": "Doesn't refer to a DOM element."


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Enables inline substitution of ascii emojis like ':-)' to the corresponding emoji like discussed in #1389.
I based my work on top of @stinarf 's work in order to finish what he started. 
The feature can be disabled via settings. I added tests similar to the tests of the emoji picker.