### PR TITLE
Conversation View improvements

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -7818,6 +7818,62 @@ button.module-image__border-overlay:focus {
 .module-timeline__message-container {
   padding-top: 4px;
   padding-bottom: 4px;
+
+  &--same-author-before {
+    padding-top: 1px;
+
+    .module-message__container--outgoing {
+      border-top-right-radius: 4px;
+
+      .module-quote,
+      .module-image--curved-top-right,
+      .module-message__attachment-container,
+      .module-message__link-preview,
+      .module-message__link-preview__content {
+        border-top-right-radius: 4px;
+      }
+    }
+
+    .module-message__container--incoming {
+      border-top-left-radius: 4px;
+
+      .module-quote,
+      .module-image--curved-top-left,
+      .module-message__attachment-container,
+      .module-message__link-preview,
+      .module-message__link-preview__content {
+        border-top-left-radius: 4px;
+      }
+    }
+  }
+
+  &--same-author-after {
+    padding-bottom: 1px;
+
+    .module-message__container--outgoing {
+      border-bottom-right-radius: 4px;
+
+      .module-quote,
+      .module-image--curved-bottom-right,
+      .module-message__attachment-container {
+        border-bottom-right-radius: 4px;
+      }
+    }
+
+    .module-message__container--incoming {
+      border-bottom-left-radius: 4px;
+
+      .module-quote,
+      .module-image--curved-bottom-left,
+      .module-message__attachment-container {
+        border-bottom-left-radius: 4px;
+      }
+
+      .module-message__author-avatar {
+        display: none;
+      }
+    }
+  }
 }
 
 .ReactVirtualized__List {

--- a/ts/components/conversation/Timeline.tsx
+++ b/ts/components/conversation/Timeline.tsx
@@ -18,6 +18,7 @@ import { LocalizerType } from '../../types/Util';
 
 import { PropsActions as MessageActionsType } from './Message';
 import { PropsActions as SafetyNumberActionsType } from './SafetyNumberNotification';
+import { MessageModel } from '../../models/messages';
 
 const AT_BOTTOM_THRESHOLD = 15;
 const NEAR_BOTTOM_THRESHOLD = 15;
@@ -595,11 +596,42 @@ export class Timeline extends React.PureComponent<PropsType, StateType> {
         );
       }
       const messageId = items[itemIndex];
+      const conversation = window.getConversations().get(id);
+      const messages = conversation.messageCollection?.models;
+
+      let beforeSame = false;
+      let afterSame = false;
+
+      if (messages) {
+        const messageIdx = messages.findIndex(msg => msg.id === messageId);
+        const msg = messages[messageIdx];
+
+        const fromSameAuthor = (msg1: MessageModel, msg2: MessageModel) =>
+          msg1 &&
+          msg1.attributes &&
+          msg2 &&
+          msg2.attributes &&
+          (msg1.attributes.sourceUuid === msg2.attributes.sourceUuid ||
+            (msg1.attributes.type === 'outgoing' &&
+              msg2.attributes.type === 'outgoing'));
+
+        beforeSame = fromSameAuthor(messages[messageIdx - 1], msg);
+        afterSame = fromSameAuthor(messages[messageIdx + 1], msg);
+      }
+
       rowContents = (
         <div
           id={messageId}
           data-row={row}
-          className="module-timeline__message-container"
+          className={classNames(
+            'module-timeline__message-container',
+            beforeSame
+              ? 'module-timeline__message-container--same-author-before'
+              : null,
+            afterSame
+              ? 'module-timeline__message-container--same-author-after'
+              : null
+          )}
           style={styleWithWidth}
           role="row"
         >

--- a/ts/components/conversation/Timeline.tsx
+++ b/ts/components/conversation/Timeline.tsx
@@ -960,7 +960,16 @@ export class Timeline extends React.PureComponent<PropsType, StateType> {
 
     if (isNumber(messageHeightChangeIndex)) {
       const rowIndex = this.fromItemIndexToRow(messageHeightChangeIndex);
+      const rowCount = this.getRowCount();
       this.resize(rowIndex);
+      // The height of the previous and message may change as well since
+      // we have different paddings depending on the author.
+      if (rowIndex > 0) {
+        this.resize(rowIndex - 1);
+      }
+      if (rowIndex < rowCount - 1) {
+        this.resize(rowIndex + 1);
+      }
       clearChangedMessages(id);
 
       return;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
This PR intends to realize the intended changes by #4829. Thanks, @misterPaul0 for your great starting point.
I opened this PR because I think it is a neater implementation with less bug potential. However, a more experienced developer may correct me.
![image](https://user-images.githubusercontent.com/9084670/106984694-5b3e4780-6768-11eb-8230-f2cd049a8988.png)
![image](https://user-images.githubusercontent.com/9084670/106984816-8cb71300-6768-11eb-915d-94c36cfeae88.png)


These are the changes:
* Consecutive messages from the same author have less space in between and corner radii are adjusted to group them.
* Only a single profile picture is shown per group of messages (in a group chat)

Compared to the original PR (#4829) I did not include any changes to the timestamps. Also, all attachments should work just fine.

A question to the core team would still be whether there is a neater way to access the previous and next message than accessing the conversation via `window.getConversations`.
<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
