### PR TITLE
High resolution link preview images

### DIFF
--- a/ts/linkPreviews/linkPreviewFetch.ts
+++ b/ts/linkPreviews/linkPreviewFetch.ts
@@ -354,9 +354,10 @@ const parseMetadata = (
   const rawImageHref =
     getOpenGraphContent(document, ['og:image', 'og:image:url']) ||
     getLinkHrefAttribute(document, [
+      'apple-touch-icon',
+      'apple-touch-icon-precomposed',
       'shortcut icon',
       'icon',
-      'apple-touch-icon',
     ]);
   const imageUrl = rawImageHref ? maybeParseUrl(rawImageHref, href) : null;
   const imageHref = imageUrl ? imageUrl.href : null;

--- a/ts/test-electron/linkPreviews/linkPreviewFetch_test.ts
+++ b/ts/test-electron/linkPreviews/linkPreviewFetch_test.ts
@@ -122,6 +122,63 @@ describe('link preview fetching', () => {
       );
     });
 
+    const orderedImageHrefSources = [
+      {
+        tag:
+          '<meta property="og:image" content="https://example.com/og-image.jpg">',
+        expectedHref: 'https://example.com/og-image.jpg',
+      },
+      {
+        tag:
+          '<meta property="og:image:url" content="https://example.com/og-image-url.jpg">',
+        expectedHref: 'https://example.com/og-image-url.jpg',
+      },
+      {
+        tag:
+          '<link rel="shortcut icon" href="https://example.com/shortcut-icon.jpg">',
+        expectedHref: 'https://example.com/shortcut-icon.jpg',
+      },
+      {
+        tag: '<link rel="icon" href="https://example.com/icon.jpg">',
+        expectedHref: 'https://example.com/icon.jpg',
+      },
+      {
+        tag:
+          '<link rel="apple-touch-icon" href="https://example.com/apple-touch-icon.jpg">',
+        expectedHref: 'https://example.com/apple-touch-icon.jpg',
+      },
+    ];
+    it('handles image href sources in the correct order', async () => {
+      for (let i = orderedImageHrefSources.length - 1; i >= 0; i -= 1) {
+        const imageTags = orderedImageHrefSources
+          .slice(i)
+          .map(({ tag }) => tag)
+          // Reverse the array to make sure that we're prioritizing properly,
+          //   instead of just using whichever comes first.
+          .reverse();
+        const fakeFetch = stub().resolves(
+          makeResponse({
+            body: makeHtml([
+              '<meta property="og:title" content="test title">',
+              ...imageTags,
+            ]),
+          })
+        );
+
+        // eslint-disable-next-line no-await-in-loop
+        const val = await fetchLinkPreviewMetadata(
+          fakeFetch,
+          'https://example.com',
+          new AbortController().signal
+        );
+        assert.propertyVal(
+          val,
+          'imageHref',
+          orderedImageHrefSources[i].expectedHref
+        );
+      }
+    });
+
     it('logs no warnings if everything goes smoothly', async () => {
       const fakeFetch = stub().resolves(
         makeResponse({

--- a/ts/test-electron/linkPreviews/linkPreviewFetch_test.ts
+++ b/ts/test-electron/linkPreviews/linkPreviewFetch_test.ts
@@ -135,17 +135,22 @@ describe('link preview fetching', () => {
       },
       {
         tag:
+          '<link rel="apple-touch-icon" href="https://example.com/apple-touch-icon.jpg">',
+        expectedHref: 'https://example.com/apple-touch-icon.jpg',
+      },
+      {
+        tag:
+          '<link rel="apple-touch-icon-precomposed" href="https://example.com/apple-touch-icon-precomposed.jpg">',
+        expectedHref: 'https://example.com/apple-touch-icon-precomposed.jpg',
+      },
+      {
+        tag:
           '<link rel="shortcut icon" href="https://example.com/shortcut-icon.jpg">',
         expectedHref: 'https://example.com/shortcut-icon.jpg',
       },
       {
         tag: '<link rel="icon" href="https://example.com/icon.jpg">',
         expectedHref: 'https://example.com/icon.jpg',
-      },
-      {
-        tag:
-          '<link rel="apple-touch-icon" href="https://example.com/apple-touch-icon.jpg">',
-        expectedHref: 'https://example.com/apple-touch-icon.jpg',
       },
     ];
     it('handles image href sources in the correct order', async () => {

--- a/ts/test-electron/linkPreviews/linkPreviewFetch_test.ts
+++ b/ts/test-electron/linkPreviews/linkPreviewFetch_test.ts
@@ -122,38 +122,38 @@ describe('link preview fetching', () => {
       );
     });
 
-    const orderedImageHrefSources = [
-      {
-        tag:
-          '<meta property="og:image" content="https://example.com/og-image.jpg">',
-        expectedHref: 'https://example.com/og-image.jpg',
-      },
-      {
-        tag:
-          '<meta property="og:image:url" content="https://example.com/og-image-url.jpg">',
-        expectedHref: 'https://example.com/og-image-url.jpg',
-      },
-      {
-        tag:
-          '<link rel="apple-touch-icon" href="https://example.com/apple-touch-icon.jpg">',
-        expectedHref: 'https://example.com/apple-touch-icon.jpg',
-      },
-      {
-        tag:
-          '<link rel="apple-touch-icon-precomposed" href="https://example.com/apple-touch-icon-precomposed.jpg">',
-        expectedHref: 'https://example.com/apple-touch-icon-precomposed.jpg',
-      },
-      {
-        tag:
-          '<link rel="shortcut icon" href="https://example.com/shortcut-icon.jpg">',
-        expectedHref: 'https://example.com/shortcut-icon.jpg',
-      },
-      {
-        tag: '<link rel="icon" href="https://example.com/icon.jpg">',
-        expectedHref: 'https://example.com/icon.jpg',
-      },
-    ];
     it('handles image href sources in the correct order', async () => {
+      const orderedImageHrefSources = [
+        {
+          tag:
+            '<meta property="og:image" content="https://example.com/og-image.jpg">',
+          expectedHref: 'https://example.com/og-image.jpg',
+        },
+        {
+          tag:
+            '<meta property="og:image:url" content="https://example.com/og-image-url.jpg">',
+          expectedHref: 'https://example.com/og-image-url.jpg',
+        },
+        {
+          tag:
+            '<link rel="apple-touch-icon" href="https://example.com/apple-touch-icon.jpg">',
+          expectedHref: 'https://example.com/apple-touch-icon.jpg',
+        },
+        {
+          tag:
+            '<link rel="apple-touch-icon-precomposed" href="https://example.com/apple-touch-icon-precomposed.jpg">',
+          expectedHref: 'https://example.com/apple-touch-icon-precomposed.jpg',
+        },
+        {
+          tag:
+            '<link rel="shortcut icon" href="https://example.com/shortcut-icon.jpg">',
+          expectedHref: 'https://example.com/shortcut-icon.jpg',
+        },
+        {
+          tag: '<link rel="icon" href="https://example.com/icon.jpg">',
+          expectedHref: 'https://example.com/icon.jpg',
+        },
+      ];
       for (let i = orderedImageHrefSources.length - 1; i >= 0; i -= 1) {
         const imageTags = orderedImageHrefSources
           .slice(i)


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #4977. I added a new test since none existed that tested the order in which preview images are prioritized. I only tested on Arch Linux.

I'm open to any and all feedback!

Before:
![image](https://user-images.githubusercontent.com/1589155/107137289-09103a00-68c0-11eb-96c4-bc1bb63b52b6.png)
After:
![image](https://user-images.githubusercontent.com/1589155/107137292-14636580-68c0-11eb-9892-e5e9cefaa125.png)