### PR TITLE
Fix race condition which often prevented sending group call started message

### DIFF
--- a/ts/services/calling.ts
+++ b/ts/services/calling.ts
@@ -478,6 +478,18 @@ export class CallingClass {
         this.syncGroupCallToRedux(conversationId, groupCall);
       },
       onPeekChanged: groupCall => {
+        const localDeviceState = groupCall.getLocalDeviceState();
+        const { eraId } = groupCall.getPeekInfo() || {};
+        if (
+          updateMessageState === GroupCallUpdateMessageState.SentNothing &&
+          localDeviceState.connectionState !== ConnectionState.NotConnected &&
+          localDeviceState.joinState === JoinState.Joined &&
+          eraId
+        ) {
+          updateMessageState = GroupCallUpdateMessageState.SentJoin;
+          this.sendGroupCallUpdateMessage(conversationId, eraId);
+        }
+
         this.updateCallHistoryForGroupCall(
           conversationId,
           groupCall.getPeekInfo()


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

The group call update message after starting a group call is currently only
sent in the `onLocalDeviceStateChanged` callback. But often the peekInfo is
not available yet when the connection state changes to Joined, effectively
preventing the group call update message to be sent.

This commit also sends the message in the `onPeekChanged` callback. It is still
only sent at most once, which is ensured by the updateMessageState check.

I'm not sure if ringrtc is behaving correctly here or if the peek info should always be available if the connection state is Joined.
Then this PR would be just a workaround for an underlying problem in ringrtc ...

Fixes #4915

Manually tested with Signal-Desktop on Linux (x86_64) and the Android app.