### PR TITLE
getInitials: handle more cases to reduce cross-platform inconsistencies

### DIFF
--- a/ts/test-both/util/getInitials_test.ts
+++ b/ts/test-both/util/getInitials_test.ts
@@ -1,0 +1,62 @@
+// Copyright 2021 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+
+import { getInitials } from '../../util/getInitials';
+
+describe('getInitials', () => {
+  it('returns undefined when passed undefined', () => {
+    assert.isUndefined(getInitials(undefined));
+  });
+
+  it('returns undefined when passed an empty string', () => {
+    assert.isUndefined(getInitials(''));
+  });
+
+  it('returns undefined when passed a string with no letters', () => {
+    assert.isUndefined(getInitials('123 !@#$%'));
+  });
+
+  it('returns the first letter of a name that is one ASCII word', () => {
+    assert.strictEqual(getInitials('Foo'), 'F');
+    assert.strictEqual(getInitials('Bo'), 'B');
+  });
+
+  [
+    'Foo Bar',
+    'foo bar',
+    'F Bar',
+    'Foo B',
+    'FB',
+    'F.B.',
+    '0Foo 1Bar',
+    "Foo B'Ar",
+    'Foo Q Bar',
+    'Foo Q. Bar',
+    'Foo Qux Bar',
+    'Foo "Qux" Bar',
+    'Foo-Qux Bar',
+    'Foo Bar-Qux',
+    "Foo b'Arr",
+  ].forEach(name => {
+    it(`returns 'FB' for '${name}'`, () => {
+      assert.strictEqual(getInitials(name), 'FB');
+    });
+  });
+
+  it('returns initials for languages with non-Latin alphabets', () => {
+    assert.strictEqual(getInitials('Иван Иванов'), 'ИИ');
+    assert.strictEqual(getInitials('山田 太郎'), '山太');
+    assert.strictEqual(getInitials('王五'), '王五');
+  });
+
+  it('returns initials for right-to-left languages', () => {
+    assert.strictEqual(getInitials('فلانة الفلانية'), 'فا');
+    assert.strictEqual(getInitials('ישראלה ישראלי'), 'יי');
+  });
+
+  it('returns initials with diacritical marks', () => {
+    assert.strictEqual(getInitials('Ḟoo Ḅar'), 'ḞḄ');
+  });
+});

--- a/ts/util/getInitials.ts
+++ b/ts/util/getInitials.ts
@@ -1,24 +1,31 @@
 // Copyright 2018-2020 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-const BAD_CHARACTERS = /[^A-Za-z\s]+/g;
-const WHITESPACE = /\s+/g;
-
-function removeNonInitials(name: string) {
-  return name.replace(BAD_CHARACTERS, '').replace(WHITESPACE, ' ');
-}
-
 export function getInitials(name?: string): string | undefined {
   if (!name) {
     return undefined;
   }
 
-  const cleaned = removeNonInitials(name);
-  const parts = cleaned.split(' ');
-  const initials = parts.map(part => part.trim()[0]);
-  if (!initials.length) {
+  const parsedName = name
+    // remove all chars that are not letters or separators
+    .replace(/[^\p{L}\p{Z}]+/gu, '')
+    // replace all chars that are separators with a single ASCII space
+    .replace(/\p{Z}+/gu, ' ')
+    .trim();
+
+  if (!parsedName) {
     return undefined;
   }
 
-  return initials.slice(0, 2).join('');
+  // check if chars in the parsed string are initials
+  if (parsedName.length === 2 && parsedName === parsedName.toUpperCase()) {
+    return parsedName;
+  }
+
+  const parts = parsedName.toUpperCase().split(' ');
+  const partsLen = parts.length;
+
+  return partsLen === 1
+    ? parts[0].charAt(0)
+    : parts[0].charAt(0) + parts[partsLen - 1].charAt(0);
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

https://github.com/signalapp/Signal-Desktop/issues/4172

I made changes to the `getInitials` method to handle more cases. The first letter of the first and the last word in a passed string will form the initials. Any non-letters, suffixes such as "Jr", "Sr" or Roman numerals will be omitted.
I added tests and tried to cover multiple edge cases.

OS X 10.15.6.
