### PR TITLE
Remove Debian dependency libappindicator1

### DIFF
--- a/package.json
+++ b/package.json
@@ -340,7 +340,6 @@
     "deb": {
       "depends": [
         "libnotify4",
-        "libappindicator1",
         "libxtst6",
         "libnss3",
         "libasound2",


### PR DESCRIPTION
libappindicator1 has been deprecated by Debian\[0\] and will not be shipped from
Debian Bullseye on.

Fixes #4761.

[[0]](): https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

See https://github.com/signalapp/Signal-Desktop/issues/4761#issuecomment-780178017 for more details.

~~I'm still trying thing out and see if there's anything missing.~~

Update:

Everything is working (including tray icon) on a Debian with no package containing 'libappindicator' or 'libayatana' (supposed to be the replacement) installed. There might be a dependency required to make this work which was just preinstalled on the system I used (a fresh VM on Xfce), but it's hard to guess like this.

According to https://www.electronjs.org/docs/api/tray:
```
On Linux distributions that only have app indicator support, you have to install libappindicator1 to make the tray icon work.
```
This seems to indicate that, at the worst case, only the tray icon feature should fail.