### PR TITLE
Fixed Preferences header and close button ( Issue #4926)

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -40,8 +40,11 @@
 </script>
 <script type='text/x-tmpl-mustache' id='settings'>
   <div class='content'>
-    <a class='x close' alt='close settings' href='#'></a>
-    <h2>{{ settings }}</h2>
+    
+    <div class="settings-header">
+        <h2>{{ settings }}</h2>
+         <a class="x close" alt="close settings" href="#"></a>
+    </div>
     <div class='device-name-settings'>
       <b>{{ deviceNameLabel }}:</b> {{ deviceName }}
     </div>

--- a/stylesheets/_settings.scss
+++ b/stylesheets/_settings.scss
@@ -26,6 +26,21 @@
       border-color: $color-gray-45;
     }
   }
+  .settings-header{
+    margin: 0 auto;
+    position: fixed;
+    top: 0;
+    background-color: inherit;
+    width: 85%;
+    height: 60px;
+    padding: 30px 0;
+}
+
+.settings-header h2{
+    display:inline-block;
+    margin:0;
+}
+
   .device-name-settings {
     text-align: center;
     margin-bottom: 1em;


### PR DESCRIPTION
 
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X ] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X ] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X ] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

### Description

 
I fixed this issue #4926
The "Preferences" title string and "X" close button are now aligned horizontally in the After screenshot.
Before :
![befor](https://user-images.githubusercontent.com/55016909/108523107-8f327480-72f3-11eb-8f37-48288aa95a28.jpg)
After:
![after](https://user-images.githubusercontent.com/55016909/108523158-9bb6cd00-72f3-11eb-934d-8713e8d5d7c4.jpg)

