### PR TITLE
remove backslash from search queries.

### DIFF
--- a/ts/test-both/util/cleanSearchTerm_test.ts
+++ b/ts/test-both/util/cleanSearchTerm_test.ts
@@ -1,0 +1,13 @@
+// Copyright 2020-2021 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+import { cleanSearchTerm } from '../../util/cleanSearchTerm';
+
+describe('cleanSearchTerm', () => {
+  it('should remove \\ from a search term', () => {
+    const searchTerm = '\\search\\term';
+    const sanitizedSearchTerm = cleanSearchTerm(searchTerm);
+    assert.strictEqual(sanitizedSearchTerm, 'search* term*');
+  });
+});

--- a/ts/test-both/util/cleanSearchTerm_test.ts
+++ b/ts/test-both/util/cleanSearchTerm_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Signal Messenger, LLC
+// Copyright 2021 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { assert } from 'chai';

--- a/ts/util/cleanSearchTerm.ts
+++ b/ts/util/cleanSearchTerm.ts
@@ -4,7 +4,7 @@
 export function cleanSearchTerm(searchTerm: string): string {
   const lowercase = searchTerm.toLowerCase();
   const withoutSpecialCharacters = lowercase.replace(
-    /([!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~])/g,
+    /([-!"#$%&'()*+,./\\:;<=>?@[\]^_`{|}~])/g,
     ' '
   );
   const whiteSpaceNormalized = withoutSpecialCharacters.replace(/\s+/g, ' ');


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

This addresses the bug reported in this issue  #5015 where a backslash entered in the search box along with another non-whitespace character caused the loading to never terminate.

I added '\\' to the regex that filters out special characters from search terms and added a test for this case.
