### PR TITLE
Clarify warning text for local message deletion #5060

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -982,7 +982,7 @@
     "description": "Label for when something is turned off"
   },
   "deleteWarning": {
-    "message": "The message will be deleted from this device only.",
+    "message": "This message will be deleted from this device.",
     "description": "Text shown in the confirmation dialog for deleting a message locally"
   },
   "deleteForEveryoneWarning": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -982,7 +982,7 @@
     "description": "Label for when something is turned off"
   },
   "deleteWarning": {
-    "message": "Clicking 'delete' will permanently remove this message from your devices only.",
+    "message": "The message will be deleted from this device only.",
     "description": "Text shown in the confirmation dialog for deleting a message locally"
   },
   "deleteForEveryoneWarning": {


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
The node tests have 5 errors in the most recent sources.
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Fixes #5060 

I changed the text of a warning message when deleting a message to clarify that it will be only deleted from the currently used device.

The change was tested on macOS 10.15.7:
![image](https://user-images.githubusercontent.com/28270981/112767420-f8a25300-9016-11eb-9b7c-3f963a657cfa.png)