### PR TITLE
fix attachment filename being truncated when zoomed in

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -789,8 +789,8 @@
 .module-message__generic-attachment__text {
   flex-grow: 1;
   margin-left: 8px;
-  // The width of the icon plus our 8px margin
-  max-width: calc(100% - 37px);
+  // The width of the icon plus our 8px margin plus 1px leeway
+  max-width: calc(100% - 36px);
 }
 
 .module-message__generic-attachment__file-name {


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Fixes #5090 .

I needed to adjust a width calculation by one pixel because fractional values were causing the filename to truncated even when it was short.

I tested this on Arch Linux (kernel version 5.11.8-arch1-1).

### Screenshots
Before:
![Screenshot from 2021-03-29 14-21-48](https://user-images.githubusercontent.com/4296166/112883544-6e043700-909c-11eb-9f1c-c96f4bb59f5b.png)
After:
![Screenshot from 2021-03-29 14-22-55](https://user-images.githubusercontent.com/4296166/112883619-8411f780-909c-11eb-9095-cd8c7bb37f27.png)
