### PR TITLE
Fix pip sliding down on click

### DIFF
--- a/ts/components/CallingPip.tsx
+++ b/ts/components/CallingPip.tsx
@@ -202,7 +202,7 @@ export const CallingPip = ({
         return [
           PIP_PADDING,
           Math.min(
-            PIP_TOP_MARGIN + positionState.offsetY,
+            positionState.offsetY,
             windowHeight - PIP_PADDING - PIP_HEIGHT
           ),
         ];
@@ -210,7 +210,7 @@ export const CallingPip = ({
         return [
           windowWidth - PIP_PADDING - PIP_WIDTH,
           Math.min(
-            PIP_TOP_MARGIN + positionState.offsetY,
+            positionState.offsetY,
             windowHeight - PIP_PADDING - PIP_HEIGHT
           ),
         ];

--- a/ts/components/CallingPip.tsx
+++ b/ts/components/CallingPip.tsx
@@ -86,7 +86,7 @@ export const CallingPip = ({
   const [windowHeight, setWindowHeight] = React.useState(window.innerHeight);
   const [positionState, setPositionState] = React.useState<PositionState>({
     mode: PositionMode.SnapToRight,
-    offsetY: 0,
+    offsetY: PIP_TOP_MARGIN,
   });
 
   React.useEffect(() => {


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Fixes PiP sliding down on click when snapping to left or right side during call

The PiP's top margin was added to the translate y position which resulted in moving it down by that margin on every mouse up, when snapping to the left or right side of the window.