### PR TITLE
Make emoji/text match case insensitive

### DIFF
--- a/ts/quill/emoji/completion.tsx
+++ b/ts/quill/emoji/completion.tsx
@@ -120,11 +120,12 @@ export class EmojiCompletion {
     if (!range) return PASS_THROUGH;
 
     const [blot, index] = this.quill.getLeaf(range.index);
+    blot.text = blot.text?.toLowerCase();
     const [leftTokenTextMatch, rightTokenTextMatch] = matchBlotTextPartitions(
       blot,
       index,
-      /(?<=^|\s):([-+0-9a-zA-Z_]*)(:?)$/,
-      /^([-+0-9a-zA-Z_]*):/
+      /(?<=^|\s):([-+0-9a-z_]*)(:?)$/,
+      /^([-+0-9a-z_]*):/
     );
 
     if (leftTokenTextMatch) {


### PR DESCRIPTION
Fixes #5018.

Supersedes #5076.

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->


### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

See other issue and other PR.

Tested with `:wave:`, `:Wave:`, `:waVE:`.