### PR TITLE
Fix 1:1 message to/from in search results

### DIFF
--- a/ts/state/selectors/search.ts
+++ b/ts/state/selectors/search.ts
@@ -200,6 +200,9 @@ export const getMessageSearchResultSelector = createSelector(
       if (type === 'incoming') {
         from = conversationSelector(sourceUuid || source);
         to = conversationSelector(conversationId);
+        if (from === to) {
+          to = conversationSelector(ourConversationId);
+        }
       } else if (type === 'outgoing') {
         from = conversationSelector(ourConversationId);
         to = conversationSelector(conversationId);

--- a/ts/test-both/state/selectors/search_test.ts
+++ b/ts/test-both/state/selectors/search_test.ts
@@ -186,8 +186,8 @@ describe('both/state/selectors/search', () => {
       const selector = getMessageSearchResultSelector(state);
 
       const actual = selector(searchId);
-      assert.deepEqual(actual.from, from);
-      assert.deepEqual(action.to, meAsRecipient);
+      assert.deepEqual(actual?.from, from);
+      assert.deepEqual(actual?.to, meAsRecipient);
     });
 
     it('returns outgoing message and caches appropriately', () => {

--- a/ts/test-both/state/selectors/search_test.ts
+++ b/ts/test-both/state/selectors/search_test.ts
@@ -144,6 +144,66 @@ describe('both/state/selectors/search', () => {
 
       assert.deepEqual(actual, expected);
     });
+
+    it('returns incoming message and has the correct "to" when sent to me', () => {
+      const searchId = 'search-id';
+      const fromId = 'from-id';
+      const toId = fromId;
+      const myId = 'my-id';
+
+      const from = getDefaultConversation(fromId);
+      const meAsRecipient = getDefaultConversation(myId);
+
+      const state = {
+        ...getEmptyRootState(),
+        conversations: {
+          ...getEmptyConversationState(),
+          conversationLookup: {
+            [fromId]: from,
+            [myId]: meAsRecipient,
+          },
+        },
+        ourConversationId: myId,
+        search: {
+          ...getEmptySearchState(),
+          messageLookup: {
+            [searchId]: {
+              ...getDefaultMessage(searchId),
+              type: 'incoming' as const,
+              sourceUuid: fromId,
+              conversationId: toId,
+              snippet: 'snippet',
+              body: 'snippet',
+              bodyRanges: [],
+            },
+          },
+        },
+        user: {
+          ...getEmptyUserState(),
+          ourConversationId: myId,
+        },
+      };
+      const selector = getMessageSearchResultSelector(state);
+
+      const actual = selector(searchId);
+      const expected = {
+        from,
+        to: meAsRecipient,
+
+        id: searchId,
+        conversationId: toId,
+        sentAt: undefined,
+        snippet: 'snippet',
+        body: 'snippet',
+        bodyRanges: [],
+
+        isSelected: false,
+        isSearchingInConversation: false,
+      };
+
+      assert.deepEqual(actual, expected);
+    });
+
     it('returns outgoing message and caches appropriately', () => {
       const searchId = 'search-id';
       const fromId = 'from-id';

--- a/ts/test-both/state/selectors/search_test.ts
+++ b/ts/test-both/state/selectors/search_test.ts
@@ -145,7 +145,7 @@ describe('both/state/selectors/search', () => {
       assert.deepEqual(actual, expected);
     });
 
-    it('returns incoming message and has the correct "to" when sent to me', () => {
+    it('returns the correct "from" and "to" when sent to me', () => {
       const searchId = 'search-id';
       const fromId = 'from-id';
       const toId = fromId;

--- a/ts/test-both/state/selectors/search_test.ts
+++ b/ts/test-both/state/selectors/search_test.ts
@@ -186,22 +186,8 @@ describe('both/state/selectors/search', () => {
       const selector = getMessageSearchResultSelector(state);
 
       const actual = selector(searchId);
-      const expected = {
-        from,
-        to: meAsRecipient,
-
-        id: searchId,
-        conversationId: toId,
-        sentAt: undefined,
-        snippet: 'snippet',
-        body: 'snippet',
-        bodyRanges: [],
-
-        isSelected: false,
-        isSearchingInConversation: false,
-      };
-
-      assert.deepEqual(actual, expected);
+      assert.deepEqual(actual.from, from);
+      assert.deepEqual(action.to, meAsRecipient);
     });
 
     it('returns outgoing message and caches appropriately', () => {


### PR DESCRIPTION
Fixes #5158.

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

See issue.

I don't think that's the proper way to address this issue, but it seems to work in practice. Feel free to close this PR in favor of a better fix.

If I note:

M(e)
G(roup)
O(ther)

I have tested these cases and the header seems correct (message sent from - to):
O - G
O - M
M - G
M - O
M - M (notes to self)