### PR TITLE
Do not search if normalized query is empty

### DIFF
--- a/ts/state/ducks/search.ts
+++ b/ts/state/ducks/search.ts
@@ -247,6 +247,9 @@ function updateSearchTerm(query: string): UpdateSearchTermActionType {
 async function queryMessages(query: string, searchConversationId?: string) {
   try {
     const normalized = cleanSearchTerm(query);
+    if (normalized.length === 0) {
+      return [];
+    }
 
     if (searchConversationId) {
       return searchMessagesInConversation(normalized, searchConversationId);


### PR DESCRIPTION
Fixes #5137

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

See issue.

Sanitizing the query can lead to an empty query, which hangs the search. We return early if the query is empty after sanitization.