### PR TITLE
Use LIKE instead of MATCH to search for messages (allow search within words)

### DIFF
--- a/ts/sql/Server.ts
+++ b/ts/sql/Server.ts
@@ -2528,15 +2528,15 @@ async function searchMessages(
   const rows = await db.all(
     `SELECT
       messages.json,
-      snippet(messages_fts, -1, '<<left>>', '<<right>>', '...', 10) as snippet
+      snippet(messages_fts, 1, '<<left>>', '<<right>>', '...', 10) as snippet
     FROM messages_fts
     INNER JOIN messages on messages_fts.id = messages.id
     WHERE
-      messages_fts match $query
+      messages_fts.body like $query
     ORDER BY messages.received_at DESC, messages.sent_at DESC
     LIMIT $limit;`,
     {
-      $query: query,
+      $query: `%${query}%`,
       $limit: limit || 500,
     }
   );
@@ -2556,16 +2556,16 @@ async function searchMessagesInConversation(
   const rows = await db.all(
     `SELECT
       messages.json,
-      snippet(messages_fts, -1, '<<left>>', '<<right>>', '...', 10) as snippet
+      snippet(messages_fts, 1, '<<left>>', '<<right>>', '...', 10) as snippet
     FROM messages_fts
     INNER JOIN messages on messages_fts.id = messages.id
     WHERE
-      messages_fts match $query AND
+      messages_fts.body like $query AND
       messages.conversationId = $conversationId
     ORDER BY messages.received_at DESC, messages.sent_at DESC
     LIMIT $limit;`,
     {
-      $query: query,
+      $query: `%${query}%`,
       $conversationId: conversationId,
       $limit: limit || 100,
     }

--- a/ts/test-both/util/cleanSearchTerm_test.ts
+++ b/ts/test-both/util/cleanSearchTerm_test.ts
@@ -8,6 +8,6 @@ describe('cleanSearchTerm', () => {
   it('should remove \\ from a search term', () => {
     const searchTerm = '\\search\\term';
     const sanitizedSearchTerm = cleanSearchTerm(searchTerm);
-    assert.strictEqual(sanitizedSearchTerm, 'search* term*');
+    assert.strictEqual(sanitizedSearchTerm, 'search term');
   });
 });

--- a/ts/util/cleanSearchTerm.ts
+++ b/ts/util/cleanSearchTerm.ts
@@ -21,7 +21,6 @@ export function cleanSearchTerm(searchTerm: string): string {
       token !== ',' &&
       token !== 'near'
   );
-  const withWildcards = withoutSpecialTokens.map(token => `${token}*`);
 
-  return withWildcards.join(' ').trim();
+  return withoutSpecialTokens.join(' ').trim();
 }


### PR DESCRIPTION
Fixes #5149.

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

See #5149.

Not clear to me why I had to change the `snippet` column argument from -1 to 1. Without this, the preview is the UUID of the message. The answer is probably in the source of sqlite, the doc doesn't say much.

~~I still have to properly address the '*' character, I couldn't find where it comes from in the few minutes I spent. If you have a hint off the top of your head, I could save some time.~~

**Edit**: done