### PR TITLE
Fix cropped message reaction icons

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -11475,16 +11475,16 @@ $contact-modal-padding: 18px;
   }
 }
 
-/* Spec: container < 437px */
-@media (min-width: 0px) and (max-width: 799px) {
+/* Spec: container < 515px */
+@media (min-width: 0px) and (max-width: 834px) {
   .module-message {
     // Add 2px for 1px border
     max-width: 302px;
   }
 }
 
-/* Spec: container > 438px and container < 593px */
-@media (min-width: 800px) and (max-width: 925px) {
+/* Spec: container > 514px and container < 606px */
+@media (min-width: 835px) and (max-width: 925px) {
   .module-message {
     // Add 2px for 1px border
     max-width: 376px;


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Reduced the min-width/increased the max-width of media queries to switch sooner from reaction icons for messages to a "more" menu.

Smallest media query
![image](https://user-images.githubusercontent.com/28270981/114395146-58af0280-9b9c-11eb-9c5e-ed257e0aadd0.png)

next smallest media query
![image](https://user-images.githubusercontent.com/28270981/114394776-dfafab00-9b9b-11eb-9ff3-c2c15392af19.png)


