### PR TITLE
Allow one-character search queries

### DIFF
--- a/ts/components/MainHeader.tsx
+++ b/ts/components/MainHeader.tsx
@@ -205,7 +205,7 @@ export class MainHeader extends React.Component<PropsType, StateType> {
       updateSearchTerm(searchTerm);
     }
 
-    if (searchTerm.length < 2) {
+    if (searchTerm.length < 1) {
       return;
     }
 

--- a/ts/state/ducks/search.ts
+++ b/ts/state/ducks/search.ts
@@ -348,7 +348,7 @@ export function reducer(
     const { payload } = action;
     const { query } = payload;
 
-    const hasQuery = Boolean(query && query.length >= 2);
+    const hasQuery = Boolean(query);
     const isWithinConversation = Boolean(state.searchConversationId);
 
     return {

--- a/ts/state/selectors/search.ts
+++ b/ts/state/selectors/search.ts
@@ -59,7 +59,7 @@ export const getStartSearchCounter = createSelector(
 
 export const isSearching = createSelector(
   getQuery,
-  (query: string): boolean => query.trim().length > 1
+  (query: string): boolean => query.trim().length > 0
 );
 
 export const getMessageSearchResultLookup = createSelector(


### PR DESCRIPTION
Related: #5180.

Closes #5184.


### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

One-character searches don't make sense most of the time in Western languages, but in languages using Chinese characters for instance, it could be really limitating. There's no real downside in removing the limit altogether.

The limit was first introduced in e39c6e532.

Tested on both conversation search and global search.