### PR TITLE
Make emoji/text match case insensitive (alternative implementation)

### DIFF
--- a/ts/quill/emoji/completion.tsx
+++ b/ts/quill/emoji/completion.tsx
@@ -103,7 +103,7 @@ export class EmojiCompletion {
     const range = this.quill.getSelection();
     const [blot, index] = this.quill.getLeaf(range ? range.index : -1);
 
-    return getBlotTextPartitions(blot, index);
+    return getBlotTextPartitions(blot.text, index);
   }
 
   onSelectionChange(): void {

--- a/ts/quill/util.ts
+++ b/ts/quill/util.ts
@@ -93,17 +93,14 @@ export const getTextAndMentionsFromOps = (
 };
 
 export const getBlotTextPartitions = (
-  blot: LeafBlot,
+  blotText: string | undefined,
   index: number
 ): [string, string] => {
-  if (blot !== undefined && blot.text !== undefined) {
-    const leftLeafText = blot.text.substr(0, index);
-    const rightLeafText = blot.text.substr(index);
+  const lowerCaseBlotText = blotText?.toLowerCase();
+  const leftLeafText = lowerCaseBlotText?.substr(0, index);
+  const rightLeafText = lowerCaseBlotText?.substr(index);
 
-    return [leftLeafText, rightLeafText];
-  }
-
-  return ['', ''];
+  return [leftLeafText || '', rightLeafText || ''];
 };
 
 export const matchBlotTextPartitions = (
@@ -112,7 +109,7 @@ export const matchBlotTextPartitions = (
   leftRegExp: RegExp,
   rightRegExp?: RegExp
 ): Array<RegExpMatchArray | null> => {
-  const [leftText, rightText] = getBlotTextPartitions(blot, index);
+  const [leftText, rightText] = getBlotTextPartitions(blot.text, index);
 
   const leftMatch = leftRegExp.exec(leftText);
   let rightMatch = null;


### PR DESCRIPTION
Fixes #5018.

Alternative to #5156.

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

See issue.