### PR TITLE
Add the build of the AppImage

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,7 +344,8 @@
         "node_modules/libsignal-client/build/*.node"
       ],
       "target": [
-        "deb"
+        "deb",
+        "AppImage"
       ],
       "icon": "build/icons/png"
     },


### PR DESCRIPTION
This closes the issue https://github.com/signalapp/Signal-Desktop/issues/1758.

See the comment https://github.com/signalapp/Signal-Desktop/issues/1758#issuecomment-823178974 and comments after for more details on the modifications done in the related fork to build the AppImage.

Note that the build is sucessfull on my side and I have, as far as I know, no way to test the build with the github actions.
