### PR TITLE
Allow search within words: use LIKE instead of MATCH to search for messages

### DIFF
--- a/ts/sql/Server.ts
+++ b/ts/sql/Server.ts
@@ -2648,9 +2648,9 @@ async function searchMessages(
         FROM
           messages_fts
         WHERE
-          messages_fts.body MATCH $query;
+          messages_fts.body LIKE $query;
       `
-    ).run({ query });
+    ).run({ query: `%${query}%` });
 
     if (conversationId === undefined) {
       db.prepare<Query>(
@@ -2701,11 +2701,11 @@ async function searchMessages(
         INNER JOIN messages
           ON messages.rowid = tmp_filtered_results.rowid
         WHERE
-          messages_fts.body MATCH $query
+          messages_fts.body LIKE $query
         ORDER BY messages.received_at DESC, messages.sent_at DESC;
         `
       )
-      .all({ query });
+      .all({ query: `%${query}%` });
 
     db.exec(
       `
@@ -2713,6 +2713,14 @@ async function searchMessages(
       DROP TABLE tmp_filtered_results;
       `
     );
+
+    const re = new RegExp(query, 'gi');
+    for (let index = 0; index < result.length; index += 1) {
+      result[index].snippet = result[index].snippet.replace(
+        re,
+        '<<left>>$&<<right>>'
+      );
+    }
 
     return result;
   })();

--- a/ts/test-both/util/cleanSearchTerm_test.ts
+++ b/ts/test-both/util/cleanSearchTerm_test.ts
@@ -8,6 +8,6 @@ describe('cleanSearchTerm', () => {
   it('should remove \\ from a search term', () => {
     const searchTerm = '\\search\\term';
     const sanitizedSearchTerm = cleanSearchTerm(searchTerm);
-    assert.strictEqual(sanitizedSearchTerm, 'search* term*');
+    assert.strictEqual(sanitizedSearchTerm, 'search term');
   });
 });

--- a/ts/util/cleanSearchTerm.ts
+++ b/ts/util/cleanSearchTerm.ts
@@ -21,7 +21,6 @@ export function cleanSearchTerm(searchTerm: string): string {
       token !== ',' &&
       token !== 'near'
   );
-  const withWildcards = withoutSpecialTokens.map(token => `${token}*`);
 
-  return withWildcards.join(' ').trim();
+  return withoutSpecialTokens.join(' ').trim();
 }


### PR DESCRIPTION
Fixes #5149.

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

### Description

See #5149.

Right now the matched part is not highlighted anymore (no bold characters), @indutny-signal can you guide me there?

If we do use `LIKE` instead of `MATCH`, we might want to update the comment referring to `MATCH`.