### PR TITLE
Submit logs with proper .gz extension

### DIFF
--- a/ts/logging/debuglogs.ts
+++ b/ts/logging/debuglogs.ts
@@ -43,10 +43,11 @@ export const uploadDebugLogs = async (
 
   const signedForm = await got.get(BASE_URL, { json: true, headers });
   const { fields, url } = parseTokenBody(signedForm.body);
+  const uploadKey = `${fields.key}.gz`;
 
   const form = new FormData();
   // The API expects `key` to be the first field:
-  form.append('key', fields.key);
+  form.append('key', uploadKey);
   Object.entries(fields)
     .filter(([key]) => key !== 'key')
     .forEach(([key, value]) => {
@@ -77,5 +78,5 @@ export const uploadDebugLogs = async (
   }
   window.log.info('Debug log upload complete.');
 
-  return `${BASE_URL}/${fields.key}`;
+  return `${BASE_URL}/${uploadKey}`;
 };

--- a/ts/test-node/logging/uploadDebugLogs_test.ts
+++ b/ts/test-node/logging/uploadDebugLogs_test.ts
@@ -40,7 +40,7 @@ describe('uploadDebugLogs', () => {
   it('makes a request to get the S3 bucket, then uploads it there', async function test() {
     assert.strictEqual(
       await uploadDebugLogs('hello world', '1.2.3'),
-      'https://debuglogs.org/abc123'
+      'https://debuglogs.org/abc123.gz'
     );
 
     sinon.assert.calledOnce(this.fakeGet);

--- a/ts/util/lint/exceptions.json
+++ b/ts/util/lint/exceptions.json
@@ -16750,66 +16750,66 @@
   {
     "rule": "jQuery-append(",
     "path": "ts/logging/debuglogs.js",
-    "line": "    form.append('key', fields.key);",
-    "lineNumber": 61,
+    "line": "    form.append('key', uploadKey);",
+    "lineNumber": 62,
     "reasonCategory": "falseMatch",
-    "updated": "2020-12-17T18:08:07.752Z"
+    "updated": "2021-05-05T10:16:27.804Z"
   },
   {
     "rule": "jQuery-append(",
     "path": "ts/logging/debuglogs.js",
     "line": "        form.append(key, value);",
-    "lineNumber": 65,
+    "lineNumber": 66,
     "reasonCategory": "falseMatch",
-    "updated": "2020-12-17T18:08:07.752Z"
+    "updated": "2021-05-05T10:16:27.804Z"
   },
   {
     "rule": "jQuery-append(",
     "path": "ts/logging/debuglogs.js",
     "line": "    form.append('Content-Type', contentType);",
-    "lineNumber": 69,
+    "lineNumber": 70,
     "reasonCategory": "falseMatch",
-    "updated": "2020-12-17T18:08:07.752Z"
+    "updated": "2021-05-05T10:16:27.804Z"
   },
   {
     "rule": "jQuery-append(",
     "path": "ts/logging/debuglogs.js",
     "line": "    form.append('file', contentBuffer, {",
-    "lineNumber": 70,
+    "lineNumber": 71,
     "reasonCategory": "falseMatch",
-    "updated": "2020-12-17T18:08:07.752Z"
+    "updated": "2021-05-05T10:16:27.804Z"
   },
   {
     "rule": "jQuery-append(",
     "path": "ts/logging/debuglogs.ts",
-    "line": "  form.append('key', fields.key);",
-    "lineNumber": 49,
+    "line": "  form.append('key', uploadKey);",
+    "lineNumber": 50,
     "reasonCategory": "falseMatch",
-    "updated": "2020-12-17T18:08:07.752Z"
+    "updated": "2021-05-05T10:16:27.804Z"
   },
   {
     "rule": "jQuery-append(",
     "path": "ts/logging/debuglogs.ts",
     "line": "      form.append(key, value);",
-    "lineNumber": 53,
+    "lineNumber": 54,
     "reasonCategory": "falseMatch",
-    "updated": "2020-12-17T18:08:07.752Z"
+    "updated": "2021-05-05T10:16:27.804Z"
   },
   {
     "rule": "jQuery-append(",
     "path": "ts/logging/debuglogs.ts",
     "line": "  form.append('Content-Type', contentType);",
-    "lineNumber": 58,
+    "lineNumber": 59,
     "reasonCategory": "falseMatch",
-    "updated": "2020-12-17T18:08:07.752Z"
+    "updated": "2021-05-05T10:16:27.804Z"
   },
   {
     "rule": "jQuery-append(",
     "path": "ts/logging/debuglogs.ts",
     "line": "  form.append('file', contentBuffer, {",
-    "lineNumber": 59,
+    "lineNumber": 60,
     "reasonCategory": "falseMatch",
-    "updated": "2020-12-17T18:08:07.752Z"
+    "updated": "2021-05-05T10:16:27.804Z"
   },
   {
     "rule": "jQuery-$(",
@@ -17088,3 +17088,4 @@
     "reasonDetail": "Doesn't manipulate the DOM. This is just a function."
   }
 ]
+


### PR DESCRIPTION
### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Currently, debug logs are submitted without extension. This makes Firefox (tested on 88.0) download the debug logs with a filename `afa5018e70cfcb84e9572cbdb6ba1f06ac3f9497d923ec2a9c45fab9fd7a4454` for the link https://debuglogs.org/afa5018e70cfcb84e9572cbdb6ba1f06ac3f9497d923ec2a9c45fab9fd7a4454. Since `gunzip` does not work without a `.gz` extension, this means I have to rename the file before peeking at the logs.

As a quick test, I submitted a Desktop debug log, which you can find there, with the correct extension:

https://debuglogs.org/a29e18ea70eb287b17eccb695d4ecf67e9b450cf9a1b38b0077874b8b043c2cb.gz

This is also how they seem to do it in the iOS repository: 

https://github.com/signalapp/Signal-iOS/blob/962369b2676a10da9cf130aa27c87f7c45c325cb/Signal/src/util/Pastelog.m#L131-L141

P.S.: Chrome apparently does some magic there and appends a .gz at the end of the downloaded file, so this change is a no-op for Chrome.