### PR TITLE
Fix typo in method name

### DIFF
--- a/ts/views/conversation_view.ts
+++ b/ts/views/conversation_view.ts
@@ -3571,7 +3571,7 @@ Whisper.ConversationView = Whisper.View.extend({
 
     const contact = this.quotedMessage.getContact();
     if (contact) {
-      this.listenTo(contact, 'change', this.renderQuotedMesage);
+      this.listenTo(contact, 'change', this.renderQuotedMessage);
     }
 
     this.quoteView = new Whisper.ReactWrapperView({


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

There was a typo in the method name which would be invoked on a change event, which would probably lead to an error at run-time, and broken functionality.

I'm new to the codebase, so not sure what this would affect, and I didn't see any tests that covered `conversation_view.ts` to extend. I ran `yarn ready` and it passes, that's all I've got for testing.

The typo was spotted with a spell checker, rather than noticing any functional problems.