### PR TITLE
Allow keyboard navigation trough search results

### DIFF
--- a/ts/components/LeftPane.tsx
+++ b/ts/components/LeftPane.tsx
@@ -146,6 +146,8 @@ export const LeftPane: React.FC<PropsType> = ({
     modeSpecificProps
   );
 
+  const previousMessageId = usePrevious(selectedMessageId, selectedMessageId);
+
   // The left pane can be in various modes: the inbox, the archive, the composer, etc.
   //   Ideally, this would render subcomponents such as `<LeftPaneInbox>` or
   //   `<LeftPaneArchive>` (and if there's a way to do that cleanly, we should refactor
@@ -286,7 +288,7 @@ export const LeftPane: React.FC<PropsType> = ({
           conversationToOpen = helper.getConversationAndMessageInDirection(
             toFind,
             selectedConversationId,
-            selectedMessageId
+            selectedMessageId || previousMessageId
           );
         }
       }
@@ -309,6 +311,7 @@ export const LeftPane: React.FC<PropsType> = ({
     selectedConversationId,
     selectedMessageId,
     startComposing,
+    previousMessageId,
   ]);
 
   const preRowsNode = helper.getPreRowsNode({


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Closes #5176.

Implement `getConversationAndMessageInDirection` for the search helper to allow users to browse search results with keyboard. 

Couple things to note:

1. When browsing trough unreads (alt + shift + arrow), messages will be ignored, because given the message search result data structure it's not possible to tell if it's unread or not. I went for the simple solution but suppose we could update the data, just let me know!

2. When a message is selected, the focus changes to that message for about a second before coming back to the left panel, breaking the browsing flow if they press the navigation button too quickly while the message is still outlined. I think it would be preferable to still have the message highlighted somehow but keeping the focus on the results list, so the user can quickly browse trough messages but wanted to keep it simple for now but open to suggestions if/how that should be achieved.

3. There is no visual indication of which item is active in the search left bar, so adding the selected state to the result items is probably the next step for the UX to be complete.

![signal-nav-2](https://user-images.githubusercontent.com/28638133/117559872-5f2b7f80-b05f-11eb-833a-39e8439ba8b1.gif)
