### PR TITLE
Quote HTML attribute values in template

### DIFF
--- a/background.html
+++ b/background.html
@@ -309,11 +309,11 @@
           </div>
           <div class='clearfix'>
             <a class='button' id='request-sms'>Send SMS</a>
-            <a class='link' id='request-voice' tabindex=-1>Call</a>
+            <a class='link' id='request-voice' tabindex='-1'>Call</a>
           </div>
           <input class='form-control' type='text' pattern='\s*[0-9]{3}-?[0-9]{3}\s*' title='Enter your 6-digit verification code. If you did not receive a code, click Call or Send SMS to request a new one' id='code' placeholder='Verification Code' autocomplete='off'>
           <div id='error' class='collapse'></div>
-          <div id=status></div>
+          <div id='status'></div>
         </div>
         <div class='nav'>
           <a class='button' id='verifyCode' data-loading-text='Please wait...'>Register</a>

--- a/test/index.html
+++ b/test/index.html
@@ -317,11 +317,11 @@
           </div>
           <div class='clearfix'>
             <a class='button' id='request-sms'>Send SMS</a>
-            <a class='link' id='request-voice' tabindex=-1>Call</a>
+            <a class='link' id='request-voice' tabindex='-1'>Call</a>
           </div>
           <input class='form-control' type='text' pattern='\s*[0-9]{3}-?[0-9]{3}\s*' title='Enter your 6-digit verification code. If you did not receive a code, click Call or Send SMS to request a new one' id='code' placeholder='Verification Code' autocomplete='off'>
           <div id='error' class='collapse'></div>
-          <div id=status></div>
+          <div id='status'></div>
         </div>
         <div class='nav'>
           <a class='button' id='verifyCode' data-loading-text='Please wait...'>Register</a>


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

There were two unquoted attribute values in the `background.html` templates, this changes them to being quoted. I don't believe it was having any functional effect, but it was causing problems for syntax highlighting in editors, and they should be quoted to match the rest of the file.