### PR TITLE
Add guard: stop attachment during audio record

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -620,6 +620,9 @@
   "fileSizeWarning": {
     "message": "Sorry, the selected file exceeds message size restrictions."
   },
+  "unableToAttachFileWhileRecording": {
+    "message": "Unable to attach a file while recording."
+  },
   "unableToLoadAttachment": {
     "message": "Unable to load selected attachment."
   },

--- a/js/views/recorder_view.js
+++ b/js/views/recorder_view.js
@@ -120,6 +120,9 @@
       );
       this.recorder.startRecording();
     },
+    isRecording() {
+      return this.recorder.isRecording();
+    },
     onTimeout() {
       this.recorder.finishRecording();
       this.close();

--- a/ts/views/conversation_view.ts
+++ b/ts/views/conversation_view.ts
@@ -298,6 +298,10 @@ Whisper.AlreadyRequestedToJoinToast = Whisper.ToastView.extend({
   template: () => window.i18n('GroupV2--join--already-awaiting-approval'),
 });
 
+Whisper.UnableToAttachFileWhileRecording = Whisper.ToastView.extend({
+  template: () => window.i18n('unableToAttachFileWhileRecording'),
+});
+
 Whisper.ConversationLoadingScreen = Whisper.View.extend({
   template: () => $('#conversation-loading-screen').html(),
   className: 'conversation-loading-screen',
@@ -1252,6 +1256,11 @@ Whisper.ConversationView = Whisper.View.extend({
   },
 
   onChooseAttachment() {
+    if (this.captureAudioView.isRecording()) {
+      this.showToast(Whisper.UnableToAttachFileWhileRecording);
+      return;
+    }
+
     this.$('input.file-input').click();
   },
   async onChoseAttachment() {

--- a/ts/window.d.ts
+++ b/ts/window.d.ts
@@ -793,6 +793,7 @@ export type WhisperType = {
   TapToViewExpiredIncomingToast: typeof window.Whisper.ToastView;
   TapToViewExpiredOutgoingToast: typeof window.Whisper.ToastView;
   TimerConflictToast: typeof window.Whisper.ToastView;
+  UnableToAttachFileWhileRecording: typeof window.Whisper.ToastView;
   UnableToLoadToast: typeof window.Whisper.ToastView;
   VoiceNoteLimit: typeof window.Whisper.ToastView;
   VoiceNoteMustBeOnlyAttachmentToast: typeof window.Whisper.ToastView;


### PR DESCRIPTION
Fixes #5205

Sends a toast when the user clicks the "+" attach file during an audio
recording. The file chooser doesn't appear anymore.

The toast may overlap the existing toast that is sent at the beginning of the
audio recording.

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [ ] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
  - This is only a translation issue as far as I need to translate the label I wrote into every language. How would  go about doing this?
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users
  - They aren't ready because I need translations of my label.

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"
-->

Please write a summary of your test approach:
  - What kind of manual testing did you do?
    - Started an audio recording in a conversation
    - Clicked the "+" add attachment button.
    - Verified that the toast appeared.
  - Did you write any new tests?
    - I did not. How can I write UI tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
    - OS X 10.15.7
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
    - I don't have any other Desktop devices.