### PR TITLE
Show avatar in search conversation pill

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -4157,6 +4157,7 @@ button.module-conversation-details__action-button {
       }
 
       &__avatar-container {
+        display: flex;
         margin-left: 4px;
         height: 16px;
         width: 16px;
@@ -4165,7 +4166,7 @@ button.module-conversation-details__action-button {
         background-color: $ultramarine-ui-light;
       }
 
-      &__avatar {
+      &__avatar-placeholder {
         height: 16px;
         width: 16px;
 

--- a/ts/components/MainHeader.tsx
+++ b/ts/components/MainHeader.tsx
@@ -18,6 +18,7 @@ export type PropsType = {
   searchTerm: string;
   searchConversationName?: string;
   searchConversationId?: string;
+  searchConversationAvatarPath?: string;
   startSearchCounter: number;
   selectedConversation: undefined | ConversationType;
 
@@ -42,7 +43,7 @@ export type PropsType = {
 
   updateSearchTerm: (searchTerm: string) => void;
   startSearch: () => void;
-  searchInConversation: (id: string, name: string) => void;
+  searchInConversation: (id: string, name: string, avatarPath?: string) => void;
   searchMessages: (
     query: string,
     options: {
@@ -301,7 +302,11 @@ export class MainHeader extends React.Component<PropsType, StateType> {
       const name = selectedConversation.isMe
         ? i18n('noteToSelf')
         : selectedConversation.title;
-      searchInConversation(selectedConversation.id, name);
+      searchInConversation(
+        selectedConversation.id,
+        name,
+        selectedConversation.avatarPath
+      );
 
       event.preventDefault();
       event.stopPropagation();
@@ -349,6 +354,7 @@ export class MainHeader extends React.Component<PropsType, StateType> {
       title,
       searchConversationId,
       searchConversationName,
+      searchConversationAvatarPath,
       searchTerm,
       showArchivedConversations,
     } = this.props;
@@ -433,7 +439,21 @@ export class MainHeader extends React.Component<PropsType, StateType> {
               aria-label={i18n('clearSearch')}
             >
               <div className="module-main-header__search__in-conversation-pill__avatar-container">
-                <div className="module-main-header__search__in-conversation-pill__avatar" />
+                {searchConversationAvatarPath ? (
+                  <Avatar
+                    acceptedMessageRequest
+                    avatarPath={searchConversationAvatarPath}
+                    className="module-main-header__search__in-conversation-pill__avatar"
+                    conversationType="direct"
+                    i18n={i18n}
+                    isMe={false}
+                    title=""
+                    sharedGroupNames={[]}
+                    size={16}
+                  />
+                ) : (
+                  <div className="module-main-header__search__in-conversation-pill__avatar-placeholder" />
+                )}
               </div>
               <div className="module-main-header__search__in-conversation-pill__x-button" />
             </button>

--- a/ts/state/ducks/search.ts
+++ b/ts/state/ducks/search.ts
@@ -45,6 +45,7 @@ export type SearchStateType = {
   startSearchCounter: number;
   searchConversationId?: string;
   searchConversationName?: string;
+  searchConversationAvatarPath?: string;
   contactIds: Array<string>;
   conversationIds: Array<string>;
   query: string;
@@ -111,6 +112,7 @@ type SearchInConversationActionType = {
   payload: {
     searchConversationId: string;
     searchConversationName: string;
+    searchConversationAvatarPath?: string;
   };
 };
 
@@ -228,13 +230,15 @@ function clearConversationSearch(): ClearConversationSearchActionType {
 }
 function searchInConversation(
   searchConversationId: string,
-  searchConversationName: string
+  searchConversationName: string,
+  searchConversationAvatarPath?: string
 ): SearchInConversationActionType {
   return {
     type: 'SEARCH_IN_CONVERSATION',
     payload: {
       searchConversationId,
       searchConversationName,
+      searchConversationAvatarPath,
     },
   };
 }
@@ -379,7 +383,11 @@ export function reducer(
 
   if (action.type === 'SEARCH_IN_CONVERSATION') {
     const { payload } = action;
-    const { searchConversationId, searchConversationName } = payload;
+    const {
+      searchConversationId,
+      searchConversationName,
+      searchConversationAvatarPath,
+    } = payload;
 
     if (searchConversationId === state.searchConversationId) {
       return {
@@ -392,6 +400,7 @@ export function reducer(
       ...getEmptyState(),
       searchConversationId,
       searchConversationName,
+      searchConversationAvatarPath,
       startSearchCounter: state.startSearchCounter + 1,
     };
   }

--- a/ts/state/selectors/search.ts
+++ b/ts/state/selectors/search.ts
@@ -52,6 +52,12 @@ export const getSearchConversationName = createSelector(
   (state: SearchStateType): string | undefined => state.searchConversationName
 );
 
+export const getSearchConversationAvatarPath = createSelector(
+  getSearch,
+  (state: SearchStateType): string | undefined =>
+    state.searchConversationAvatarPath
+);
+
 export const getStartSearchCounter = createSelector(
   getSearch,
   (state: SearchStateType): number => state.startSearchCounter

--- a/ts/state/smart/MainHeader.tsx
+++ b/ts/state/smart/MainHeader.tsx
@@ -11,6 +11,7 @@ import {
   getQuery,
   getSearchConversationId,
   getSearchConversationName,
+  getSearchConversationAvatarPath,
   getStartSearchCounter,
 } from '../selectors/search';
 import {
@@ -28,6 +29,7 @@ const mapStateToProps = (state: StateType) => {
     searchTerm: getQuery(state),
     searchConversationId: getSearchConversationId(state),
     searchConversationName: getSearchConversationName(state),
+    searchConversationAvatarPath: getSearchConversationAvatarPath(state),
     selectedConversation: getSelectedConversation(state),
     startSearchCounter: getStartSearchCounter(state),
     regionCode: getRegionCode(state),

--- a/ts/views/conversation_view.ts
+++ b/ts/views/conversation_view.ts
@@ -491,7 +491,11 @@ Whisper.ConversationView = Whisper.View.extend({
             const name = this.model.isMe()
               ? window.i18n('noteToSelf')
               : this.model.getTitle();
-            searchInConversation(this.model.id, name);
+            searchInConversation(
+              this.model.id,
+              name,
+              this.model.getAbsoluteAvatarPath()
+            );
           },
           onSetMuteNotifications: (ms: number) =>
             this.model.setMuteExpiration(


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Currently, when you're searching in a conversation, a generic blue avatar icon is shown in the search bar. With this PR the avatar for the conversation is shown. Here's what it currently looks like (on top) and with PR changes (on bottom):

![image](https://user-images.githubusercontent.com/28270981/118356000-755fa100-b573-11eb-8b1b-5454607e4dce.png)

As it stands the generic blue avatar is shown for group conversations, the "me" conversation and conversation without an avatar image. We could change that to show the corresponding placeholders.