### PR TITLE
Toggle window visibility on tray icon click

### DIFF
--- a/app/SystemTrayService.ts
+++ b/app/SystemTrayService.ts
@@ -181,10 +181,12 @@ export class SystemTrayService {
       if (!browserWindow) {
         return;
       }
-      if (!browserWindow.isVisible()) {
+      if (browserWindow.isVisible()) {
+        browserWindow.hide();
+      } else {
         browserWindow.show();
+        forceOnTop(browserWindow);
       }
-      forceOnTop(browserWindow);
     });
 
     result.setToolTip(this.messages.signalDesktop.message);


### PR DESCRIPTION
Fixes #3045.

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Currently, (left) clicking the tray icon shows the window, but clicking again does not hide it. This change allows users to click again to hide the window.