### PR TITLE
Allow media grid item images to fill container

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -3822,7 +3822,7 @@ button.module-conversation-details__action-button {
 
 .module-media-grid-item__image {
   height: 94px;
-  width: 94px;
+  width: 100%;
   object-fit: cover;
 }
 
@@ -3839,9 +3839,6 @@ button.module-conversation-details__action-button {
 }
 
 .module-media-grid-item__image-container {
-  height: 94px;
-  width: 94px;
-  object-fit: cover;
   position: relative;
 }
 

--- a/ts/components/conversation/media-gallery/MediaGridItem.tsx
+++ b/ts/components/conversation/media-gallery/MediaGridItem.tsx
@@ -73,6 +73,7 @@ export class MediaGridItem extends React.Component<Props, State> {
         />
       );
     }
+
     if (contentType && isVideoTypeSupported(contentType)) {
       if (imageBroken || !mediaItem.thumbnailObjectUrl) {
         return (


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Fixes #5241

#### Root Cause
The Conversation Media List and the Media Gallery lay out their items slightly differently:
* In the Conversation Media List, the available width is divided into 6 equally sized containers for thumbnails
* In the Media Gallery, each thumbnail is a fixed width (94px)

The existing styling fixed the width of the media grid item to 94px as well, but this no longer works for the Conversation Media List as the width of its thumbnails can exceed 94px as the viewport is made wider.

#### Fix
A simple change to the media grid item image styling to go from a fixed with to 100% instead.

Also removes some duplicative styling to help make maintenance of this simpler.

#### Testing
Environment: WSL
Standard tests run as per guidelines:
```
[test-node    ]   841 passing (4s)
[test-node    ]   4 pending
[test-node    ]
[test-electron] App started. Now waiting for test results...
[test-electron] >> 849 tests passed.
[test-electron]
[test-electron] Running "lib-unit-tests" task
[test-electron] Starting path /home/jonathan/code/Signal-Desktop/node_modules/.bin/electron with args [ '/home/jonathan/code/Signal-Desktop/main.js' ]
[lint-deps    ] 30085 files scanned. 0 questionable lines, 0 unused exceptions, 1954 total exceptions.
[test-electron] App started. Now waiting for test results...
[test-electron] >> 126 tests passed.
[test-electron]
[test-electron] Done.
[lint         ] $ eslint --cache .
Done in 209.73s.
```

__Visual Testing via Electron container__

![5241-1](https://user-images.githubusercontent.com/16733034/119259398-b41dd880-bbbd-11eb-8562-03309ed19f6a.png)
![5241-2](https://user-images.githubusercontent.com/16733034/119259403-b6803280-bbbd-11eb-87e7-e3514abb9648.png)
![5241-3](https://user-images.githubusercontent.com/16733034/119259406-b97b2300-bbbd-11eb-8c6e-94c3ff4a4c7f.png)
![5241-4](https://user-images.githubusercontent.com/16733034/119259407-baac5000-bbbd-11eb-9592-9c83d8cde366.png)

__Visual Testing via Storybook__

![5241-5](https://user-images.githubusercontent.com/16733034/119259409-be3fd700-bbbd-11eb-88f2-c44527e94139.png)
![5241-6](https://user-images.githubusercontent.com/16733034/119259412-c0099a80-bbbd-11eb-8dad-e4876b19f69f.png)
