### PR TITLE
Add rotation buttons to lightbox

### DIFF
--- a/ts/components/Lightbox.tsx
+++ b/ts/components/Lightbox.tsx
@@ -162,7 +162,7 @@ type IconButtonProps = {
   i18n: LocalizerType;
   onClick?: () => void;
   style?: React.CSSProperties;
-  type: 'save' | 'close' | 'previous' | 'next';
+  type: 'save' | 'close' | 'previous' | 'next' | 'rotateLeft' | 'rotateRight';
 };
 
 const IconButton = ({ i18n, onClick, style, type }: IconButtonProps) => {
@@ -217,6 +217,10 @@ export class Lightbox extends React.Component<Props, State> {
   public readonly videoRef = React.createRef<HTMLVideoElement>();
 
   public readonly focusRef = React.createRef<HTMLDivElement>();
+
+  public imageRef = React.createRef<HTMLImageElement>();
+
+  public imageRotation = 0;
 
   public previousFocus: HTMLElement | null = null;
 
@@ -323,6 +327,16 @@ export class Lightbox extends React.Component<Props, State> {
             {caption ? <div style={styles.caption}>{caption}</div> : null}
           </div>
           <div style={styles.controls}>
+            <IconButton
+              i18n={i18n}
+              type="rotateLeft"
+              onClick={this.onRotateLeft}
+            />
+            <IconButton
+              i18n={i18n}
+              type="rotateRight"
+              onClick={this.onRotateRight}
+            />
             <IconButton i18n={i18n} type="close" onClick={this.onClose} />
             {onSave ? (
               <IconButton
@@ -376,6 +390,7 @@ export class Lightbox extends React.Component<Props, State> {
           onClick={this.onObjectClick}
         >
           <img
+            ref={this.imageRef}
             alt={i18n('lightboxImageAlt')}
             style={styles.img}
             src={objectURL}
@@ -431,6 +446,24 @@ export class Lightbox extends React.Component<Props, State> {
       !/image\/jpe?g/g.test(contentType)
     ) {
       event.preventDefault();
+    }
+  };
+
+  private readonly onRotateRight = () => {
+    const t = this.imageRef.current?.style;
+    if (t !== undefined) {
+      this.imageRotation += 90;
+      t.transform = `translate(-50%, -50%) rotate(${this.imageRotation}deg)`;
+      this.imageRef.current?.setAttribute('style', t.cssText);
+    }
+  };
+
+  private readonly onRotateLeft = () => {
+    const t = this.imageRef.current?.style;
+    if (t !== undefined) {
+      this.imageRotation += 90;
+      t.transform = `translate(-50%, -50%) rotate(${this.imageRotation}deg)`;
+      this.imageRef.current?.setAttribute('style', t.cssText);
     }
   };
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [ ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [ ] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully (It is failing at the moment, and i don't know why. I am not fluent in React/Typescript, help is appreciated)
- [ ] My changes are ready to be shipped to users

### Description
Fixes #3709
This adds two buttons on top of the close button in the imageview. rotateLeft and rotateRight.
They rotate an image, so that it can be viewed more easily if a mobile user sent an image in the wrong rotation. 
- [ ] Add icons to buttons
Where are the icon's sourced from? I would like to add two new icons for the corresponding buttons since signal-desktop does not already include fitting ones.