### PR TITLE
Fix developer setup section for windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,8 @@ Install the [Xcode Command-Line Tools](http://osxdaily.com/2014/02/12/install-co
     - Install Microsoft .NET Framework 4.5.1:
       https://www.microsoft.com/en-us/download/details.aspx?id=40773
     - Install Windows SDK version 8.1: https://developer.microsoft.com/en-us/windows/downloads/sdk-archive
-1.  Install _Windows Build Tools_: Open the [Command Prompt (`cmd.exe`) as Administrator](<https://technet.microsoft.com/en-us/library/cc947813(v=ws.10).aspx>)
-    and run: `npm install --vs2015 --global --production --add-python-to-path windows-build-tools`
+2.  Download _Build Tools for Visual Studio_ from the [Visual Studio download page](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019) and install it including the "Desktop development with C++" option.
+3.  Download and install the latest Python 3 release from https://www.python.org/downloads/windows/ (3.6 or later required).
 
 ### Linux
 


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
This PR references a post ([Building with vs2015 fails](https://community.signalusers.org/t/building-with-vs2015-fails/32182)) on the community forum. While researching the issue i found multiple people having problems with https://github.com/felixrieseberg/windows-build-tools (e.g. https://github.com/felixrieseberg/windows-build-tools/issues/252, https://github.com/felixrieseberg/windows-build-tools/issues/251, https://github.com/felixrieseberg/windows-build-tools/issues/172). According to the commits the project switched to Python 3, but it seems like there has not been a release since and the project seems to be unmaintained. The workaround mentioned in my community forum post (partially sourced from https://github.com/felixrieseberg/windows-build-tools/issues/172) seems overly complicated and installing the two dependencies manually more reasonable to me.

Removes reference to https://github.com/felixrieseberg/windows-build-tools.

Added "Download Build Tools for Visual Studio" and "Download Python 3" as steps.

*The PR might also fix/ would have prevented some of the issues that holahila is having on the community forum ([I get an error when I run the command “yarn install –frozen-lockfile”](https://community.signalusers.org/t/i-get-an-error-when-i-run-the-command-yarn-install-frozen-lockfile/33148)), but I'm not sure.*

The old setup instructions failed on multiple Windows 10 machines, I verified the new procedure on a fresh installation.

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
