### PR TITLE
Unescape HTML encoded entities in link preview

### DIFF
--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import ReactDOM, { createPortal } from 'react-dom';
 import classNames from 'classnames';
-import { drop, groupBy, orderBy, take } from 'lodash';
+import { drop, groupBy, orderBy, take, unescape } from 'lodash';
 import { ContextMenu, ContextMenuTrigger, MenuItem } from 'react-contextmenu';
 import { Manager, Popper, Reference } from 'react-popper';
 
@@ -957,7 +957,7 @@ export class Message extends React.Component<Props, State> {
             </div>
             {first.description && (
               <div className="module-message__link-preview__description">
-                {first.description}
+                {unescape(first.description)}
               </div>
             )}
             <div className="module-message__link-preview__footer">


### PR DESCRIPTION
 
<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
Fixes #5397 
I have fixed the issue of HTML encoded entities not being unescaped in description link preview. 
I have used unescape method of lodash.

Before:
![image](https://user-images.githubusercontent.com/55016909/126085266-a40c9cc8-8d0d-4c35-ae68-461c0762b80d.png)
After:
![fixed](https://user-images.githubusercontent.com/55016909/126085271-2512073e-6771-42fe-bda7-a686a4d2795d.JPG)

I have tested if the same issue happens with the title also. But it seems like it happens only for the description of the preview.