### PR TITLE
Don't close emoji picker when Ctrl key is pressed (resolves #5062)

### DIFF
--- a/ts/components/emoji/EmojiPicker.tsx
+++ b/ts/components/emoji/EmojiPicker.tsx
@@ -160,6 +160,7 @@ export const EmojiPicker = React.memo(
             event.stopPropagation();
           } else if (
             !searchMode &&
+            !event.ctrlKey &&
             ![
               'ArrowUp',
               'ArrowDown',


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
When the emoji picker was opened, pressing the Ctrl-key would close it. Because of that, the zoom in/out accessibility features couldn't be used at that time. With this commit, the Ctrl-key will no longer trigger the closing of the emoji picker.

Tested on Windows 10* 64-bit, manually by using the emoji picker both before and after the changes to test if the change indeed fixes the issue whilst not causing any new issues.

Fixes #5062.
