### PR TITLE
Allow emojis to be inserted with 'Enter' (resolves #5434)

### DIFF
--- a/ts/components/emoji/EmojiPicker.tsx
+++ b/ts/components/emoji/EmojiPicker.tsx
@@ -130,19 +130,23 @@ export const EmojiPicker = React.memo(
             | React.MouseEvent<HTMLButtonElement>
             | React.KeyboardEvent<HTMLButtonElement>
         ) => {
-          if ('key' in e) {
-            if (e.key === 'Enter' && doSend) {
-              e.stopPropagation();
-              e.preventDefault();
-              doSend();
-            }
-          } else {
             const { shortName } = e.currentTarget.dataset;
-            if (shortName) {
+            if ('key' in e) {
+                if (e.key === 'Enter') {
+                    if (shortName) {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        onPickEmoji({ skinTone: selectedTone, shortName });
+                    } else if (doSend) {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        doSend();
+                    }
+                }
+            } else if (shortName) {
               e.stopPropagation();
               e.preventDefault();
               onPickEmoji({ skinTone: selectedTone, shortName });
-            }
           }
         },
         [doSend, onPickEmoji, selectedTone]
@@ -248,6 +252,7 @@ export const EmojiPicker = React.memo(
       const cellRenderer = React.useCallback<GridCellRenderer>(
         ({ key, style: cellStyle, rowIndex, columnIndex }) => {
           const shortName = emojiGrid[rowIndex][columnIndex];
+          const isFirstItem = rowIndex === 0 && columnIndex === 0;
 
           return shortName ? (
             <div
@@ -262,13 +267,14 @@ export const EmojiPicker = React.memo(
                 onKeyDown={handlePickEmoji}
                 data-short-name={shortName}
                 title={shortName}
+                ref={(isFirstItem && !searchMode) ? focusOnRender : null}
               >
                 <Emoji shortName={shortName} skinTone={selectedTone} />
               </button>
             </div>
           ) : null;
         },
-        [emojiGrid, handlePickEmoji, selectedTone]
+        [emojiGrid, handlePickEmoji, selectedTone, searchMode]
       );
 
       const getRowHeight = React.useCallback(


### PR DESCRIPTION
### Contributor checklist:
- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
As described in #5434 , this pull request resolves two issues:
- It sets keyboard focus on a logical element on opening the emoji picker (= the first emoji)
- When an emoticon has keyboard focus, pressing 'Enter' will insert the emoticon into the message

Tested on Windows 10* 64-bit, manually by using the emoji picker both before and after the changes to test if the change indeed fixes the issues whilst not causing any new issues. 

Resolves #5434.