### PR TITLE
Limit opening media gallery to a single instance (Fixes #5266)

### DIFF
--- a/ts/views/conversation_view.ts
+++ b/ts/views/conversation_view.ts
@@ -42,6 +42,7 @@ import {
 } from '../state/selectors/message';
 import { getMessagesByConversation } from '../state/selectors/conversations';
 import { ConversationDetailsMembershipList } from '../components/conversation/conversation-details/ConversationDetailsMembershipList';
+import { MediaGallery } from '../components/conversation/media-gallery/MediaGallery';
 import { showSafetyNumberChangeDialog } from '../shims/showSafetyNumberChangeDialog';
 import {
   LinkPreviewImage,
@@ -2398,6 +2399,14 @@ Whisper.ConversationView = Whisper.View.extend({
   },
 
   async showAllMedia() {
+    if (
+      this.panels &&
+      this.panels.length > 0 &&
+      this.panels[0].Component === MediaGallery
+    ) {
+      return;
+    }
+
     // We fetch more documents than media as they don’t require to be loaded
     // into memory right away. Revisit this once we have infinite scrolling:
     const DEFAULT_MEDIA_FETCH_COUNT = 50;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

It was possible to open a media gallery inside a conversation multiple times using a keyboard shortcut CMD+Shift+M. Now, it can be opened only once.

Tested on OS X 11.5. I've pressed CMD+Shift+M twice and a media gallery panel has been opened only once. The issue seems to be properly addressed.

Fixes #5266 
