### PR TITLE
load CAPTCHA to enable phone number verification

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -715,6 +715,10 @@
     "message": "Sharing screen",
     "description": "Title for screen sharing window"
   },
+  "captchaResponseRequired": {
+    "message": "CAPTCHA Response Required",
+    "description": "Title of the window that pops up when a CAPTCHA response is required"
+  },
   "speech": {
     "message": "Speech",
     "description": "Item under the Edit menu, with 'start/stop speaking' items below it"

--- a/config/default.json
+++ b/config/default.json
@@ -8,6 +8,8 @@
     "0": "https://cdn-staging.signal.org",
     "2": "https://cdn2-staging.signal.org"
   },
+  "captchaUrl": "https://signalcaptchas.org/registration/generate.html",
+  "captchaScheme": "signalcaptcha://",
   "contentProxyUrl": "http://contentproxy.signal.org:443",
   "updatesUrl": "https://updates2.signal.org/desktop",
   "updatesPublicKey": "05fd7dd3de7149dc0a127909fee7de0f7620ddd0de061b37a2c303e37de802a401",

--- a/js/views/standalone_registration_view.js
+++ b/js/views/standalone_registration_view.js
@@ -17,6 +17,9 @@
 
       this.accountManager = getAccountManager();
 
+      this.pendingVoiceVerification = false;
+      this.pendingSMSVerification = false;
+
       this.render();
 
       const number = textsecure.storage.user.getNumber();
@@ -77,29 +80,60 @@
       }
     },
     requestVoice() {
+      this.pendingVoiceVerification = true;
+      this.pendingSMSVerification = false;
       window.removeSetupMenuItems();
       this.$('#error').hide();
       const number = this.phoneView.validateNumber();
+      const token = window.textsecure.storage.get('captchaToken');
       if (number) {
         this.accountManager
-          .requestVoiceVerification(number)
-          .catch(this.displayError.bind(this));
+          .requestVoiceVerification(number, token)
+          .then(() => {
+            this.pendingVoiceVerification = false;
+          })
+          .catch(e => {
+            if (e.code === 402) {
+              window.captchaRequired();
+            } else {
+              this.displayError(e);
+            }
+          });
         this.$('#step2').addClass('in').fadeIn();
       } else {
         this.$('#number-container').addClass('invalid');
       }
     },
     requestSMSVerification() {
+      this.pendingSMSVerification = true;
+      this.pendingVoiceVerification = false;
       window.removeSetupMenuItems();
       $('#error').hide();
       const number = this.phoneView.validateNumber();
+      const token = window.textsecure.storage.get('captchaToken');
       if (number) {
         this.accountManager
-          .requestSMSVerification(number)
-          .catch(this.displayError.bind(this));
+          .requestSMSVerification(number, token)
+          .then(() => {
+            this.pendingSMSVerification = false;
+          })
+          .catch(e => {
+            if (e.code === 402) {
+              window.captchaRequired();
+            } else {
+              this.displayError(e);
+            }
+          });
         this.$('#step2').addClass('in').fadeIn();
       } else {
         this.$('#number-container').addClass('invalid');
+      }
+    },
+    requestPendingVerification() {
+      if (this.pendingVoiceVerification) {
+        this.requestVoice();
+      } else if (this.pendingSMSVerification) {
+        this.requestSMSVerification();
       }
     },
   });

--- a/main.js
+++ b/main.js
@@ -294,6 +294,14 @@ async function handleUrl(event, target) {
     return;
   }
 
+  if (target.startsWith(config.get('captchaScheme'))) {
+    if (captchaWindow) {
+      captchaWindow.close();
+    }
+    const token = target.slice(config.get('captchaScheme').length);
+    mainWindow.webContents.send('captcha-response', token);
+  }
+
   if ((protocol === 'http:' || protocol === 'https:') && !isDevServer) {
     try {
       await shell.openExternal(target);
@@ -1112,6 +1120,47 @@ function showPermissionsPopupWindow(forCalling, forCamera) {
     });
   });
 }
+
+let captchaWindow;
+function showCaptchaWindow() {
+  if (captchaWindow) {
+    captchaWindow.show();
+    return;
+  }
+
+  const options = {
+    resizable: false,
+    title: locale.messages.captchaResponseRequired.message,
+    autoHideMenuBar: true,
+    show: false,
+    webPreferences: {
+      ...defaultWebPrefs,
+      nodeIntegration: false,
+      nodeIntegrationInWorker: false,
+      contextIsolation: false,
+      nativeWindowOpen: true,
+    },
+  };
+
+  captchaWindow = new BrowserWindow(options);
+
+  handleCommonWindowEvents(captchaWindow);
+
+  captchaWindow.loadURL(prepareUrl(new URL(config.get('captchaUrl'))));
+
+  captchaWindow.on('closed', () => {
+    captchaWindow = null;
+  });
+
+  captchaWindow.once('ready-to-show', () => {
+    captchaWindow.show();
+  });
+}
+
+// IPC call to load CAPTCHA
+ipc.on('captcha-required', () => {
+  showCaptchaWindow();
+});
 
 async function initializeSQL() {
   const userDataPath = await getRealPath(app.getPath('userData'));

--- a/preload.js
+++ b/preload.js
@@ -124,6 +124,11 @@ try {
   // eslint-disable-next-line no-eval, no-multi-assign
   window.eval = global.eval = () => null;
 
+  window.captchaRequired = () => {
+    window.log.info('CAPTCHA required');
+    ipc.send('captcha-required');
+  };
+
   window.drawAttention = () => {
     window.log.info('draw attention');
     ipc.send('draw-attention');
@@ -198,6 +203,11 @@ try {
         conversationId: ourConversation && ourConversation.id,
       },
     });
+  });
+
+  ipc.on('captcha-response', (_event, token) => {
+    window.textsecure.storage.put('captchaToken', token);
+    window.owsDesktopApp.appView.standaloneView.requestPendingVerification();
   });
 
   ipc.on('set-up-as-new-device', () => {

--- a/ts/textsecure/AccountManager.ts
+++ b/ts/textsecure/AccountManager.ts
@@ -81,12 +81,12 @@ export default class AccountManager extends EventTarget {
     this.pending = Promise.resolve();
   }
 
-  async requestVoiceVerification(number: string) {
-    return this.server.requestVerificationVoice(number);
+  async requestVoiceVerification(number: string, captchaToken?: string) {
+    return this.server.requestVerificationVoice(number, captchaToken);
   }
 
-  async requestSMSVerification(number: string) {
-    return this.server.requestVerificationSMS(number);
+  async requestSMSVerification(number: string, captchaToken?: string) {
+    return this.server.requestVerificationSMS(number, captchaToken);
   }
 
   async encryptDeviceName(name: string, providedIdentityKey?: KeyPairType) {

--- a/ts/textsecure/WebAPI.ts
+++ b/ts/textsecure/WebAPI.ts
@@ -924,8 +924,14 @@ export type WebAPIType = {
   registerKeys: (genKeys: KeysType) => Promise<void>;
   registerSupportForUnauthenticatedDelivery: () => Promise<any>;
   reportMessage: (senderE164: string, serverGuid: string) => Promise<void>;
-  requestVerificationSMS: (number: string) => Promise<any>;
-  requestVerificationVoice: (number: string) => Promise<any>;
+  requestVerificationSMS: (
+    number: string,
+    captchaToken?: string
+  ) => Promise<any>;
+  requestVerificationVoice: (
+    number: string,
+    captchaToken?: string
+  ) => Promise<any>;
   sendMessages: (
     destination: string,
     messageArray: Array<MessageType>,
@@ -1476,19 +1482,33 @@ export function initialize({
       });
     }
 
-    async function requestVerificationSMS(number: string) {
+    async function requestVerificationSMS(
+      number: string,
+      captchaToken?: string
+    ) {
+      let urlParameters = `/sms/code/${number}?client=desktop`;
+      if (captchaToken) {
+        urlParameters += `&captcha=${captchaToken}`;
+      }
       return _ajax({
         call: 'accounts',
         httpType: 'GET',
-        urlParameters: `/sms/code/${number}`,
+        urlParameters,
       });
     }
 
-    async function requestVerificationVoice(number: string) {
+    async function requestVerificationVoice(
+      number: string,
+      captchaToken?: string
+    ) {
+      let urlParameters = `/voice/code/${number}?client=desktop`;
+      if (captchaToken) {
+        urlParameters += `&captcha=${captchaToken}`;
+      }
       return _ajax({
         call: 'accounts',
         httpType: 'GET',
-        urlParameters: `/voice/code/${number}`,
+        urlParameters,
       });
     }
 

--- a/ts/window.d.ts
+++ b/ts/window.d.ts
@@ -200,6 +200,7 @@ declare global {
     baseAttachmentsPath: string;
     baseStickersPath: string;
     baseTempPath: string;
+    captchaRequired: () => void;
     enterKeyboardMode: () => void;
     enterMouseMode: () => void;
     getAccountManager: () => AccountManager;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-[re]base-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

### Description

This PR fixes merge conflicts in @kevinsung 's fix for #5006 at https://github.com/signalapp/Signal-Desktop/pull/5121. I tested manually that this works and that it allowed me to successfully register a phone number. I tested this on MacOS 10.15.7.

**Kevin's PR notes:**
Loads the CAPTCHA that is required for verification to register a phone number with the desktop app as a standalone device for development. I adapted this from Signal-Android. When a request for SMS or voice verification is rejected with error code 402, a new window with a CAPTCHA appears, and upon successful completion of the CAPTCHA, the window closes and the request is sent again with the newly acquired credentials.

This requires the SIGNAL_ENABLE_HTTP environment variable to be set, e.g. on Linux,

`SIGNAL_ENABLE_HTTP=1 yarn start`

I tested manually that this works and that it allowed me to successfully register a phone number. I tested this on Arch Linux (kernel version 5.11.8-arch1-1).

### Screenshots

![Screen Shot 2021-08-20 at 4 20 41 PM](https://user-images.githubusercontent.com/1291473/130302303-438ca856-0051-46d7-a128-558caa806fe4.png)

![Screen Shot 2021-08-20 at 4 20 57 PM](https://user-images.githubusercontent.com/1291473/130302383-8869b950-78bc-4ab7-a8dd-53b504dfefb7.png)

![Screen Shot 2021-08-20 at 4 22 45 PM](https://user-images.githubusercontent.com/1291473/130302391-70c30e67-baa2-4a3b-aae6-e733ba62de9a.png)