### PR TITLE
Add build of an AppImage to the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,6 +366,7 @@
         "node_modules/@signalapp/signal-client/build/*.node"
       ],
       "target": [
+        "AppImage",
         "deb"
       ],
       "icon": "build/icons/png"


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

I wanted to add a Linux-build of Signal-Desktop to the Linuxbrew/Homebrew build system. Homepage: https://brew.sh/

My pull request there was closed by a Dev under the assumption that having a Linux build of Signal-Desktop as something other than a Debian package is not welcomed:

https://github.com/Homebrew/homebrew-core/pull/84016

The flatpak is maintained by the Flathub community, so I guess the a brew formula would not be rejected, even if you don't endorse it explicitly.

I found that the easiest build step which I produce a fully-working application was by adding "AppImage" to the build targets.
and I saw that the extra "cost" of building an AppImage besides the .deb package is negligible. Basically, it's for free, it's just another container.

Some corporate environments, even if they use Ubuntu or Debian, don't give root credentials (or permission to use snap) to all users, so it would be nice to have some alternative which one could simply run or build in a simple way like using Linuxbrew/Homebrew.

Would my be against having a Linux-build of Signal-Desktop installable via this command?
```
brew install signal-desktop
```
Thanks for this great messenger and best regards to the team!