### PR TITLE
Fix several race conditions in react-contextmenu

### DIFF
--- a/patches/react-contextmenu+2.11.0.patch
+++ b/patches/react-contextmenu+2.11.0.patch
@@ -1,15 +1,15 @@
 diff --git a/node_modules/react-contextmenu/modules/ContextMenu.js b/node_modules/react-contextmenu/modules/ContextMenu.js
-index 622a1f9..9fc87ea 100644
+index 622a1f9..fa5f3b6 100644
 --- a/node_modules/react-contextmenu/modules/ContextMenu.js
 +++ b/node_modules/react-contextmenu/modules/ContextMenu.js
 @@ -226,6 +226,9 @@ var ContextMenu = function (_AbstractMenu) {
-
+ 
              if (this.state.isVisible) {
                  var wrapper = window.requestAnimationFrame || setTimeout;
 +                if (!this.previousFocus) {
 +                    this.previousFocus = document.activeElement;
 +                }
-
+ 
                  wrapper(function () {
                      var _state = _this2.state,
 @@ -241,13 +244,21 @@ var ContextMenu = function (_AbstractMenu) {
@@ -34,3 +34,92 @@ index 622a1f9..9fc87ea 100644
              }
          }
      }, {
+diff --git a/node_modules/react-contextmenu/modules/SubMenu.js b/node_modules/react-contextmenu/modules/SubMenu.js
+index 3eb1d4e..0734b63 100644
+--- a/node_modules/react-contextmenu/modules/SubMenu.js
++++ b/node_modules/react-contextmenu/modules/SubMenu.js
+@@ -123,6 +123,7 @@ var SubMenu = function (_AbstractMenu) {
+ 
+             if (_this.props.disabled || _this.state.visible) return;
+ 
++            if (_this.opentimer) clearTimeout(_this.opentimer);
+             _this.opentimer = setTimeout(function () {
+                 return _this.setState({
+                     visible: true,
+@@ -136,6 +137,7 @@ var SubMenu = function (_AbstractMenu) {
+ 
+             if (!_this.state.visible) return;
+ 
++            if (_this.closetimer) clearTimeout(_this.closetimer);
+             _this.closetimer = setTimeout(function () {
+                 return _this.setState({
+                     visible: false,
+@@ -164,6 +166,15 @@ var SubMenu = function (_AbstractMenu) {
+             }
+         };
+ 
++        _this.cleanup = function () {
++            _this.subMenu.removeEventListener('transitionend', _this.cleanup);
++            _this.subMenu.style.removeProperty('bottom');
++            _this.subMenu.style.removeProperty('right');
++            _this.subMenu.style.top = 0;
++            _this.subMenu.style.left = '100%';
++            _this.unregisterHandlers();
++        };
++
+         _this.state = (0, _objectAssign2.default)({}, _this.state, {
+             visible: false
+         });
+@@ -196,32 +207,28 @@ var SubMenu = function (_AbstractMenu) {
+             if (this.props.forceOpen || this.state.visible) {
+                 var wrapper = window.requestAnimationFrame || setTimeout;
+                 wrapper(function () {
+-                    var styles = _this2.props.rtl ? _this2.getRTLMenuPosition() : _this2.getMenuPosition();
+-
+-                    _this2.subMenu.style.removeProperty('top');
+-                    _this2.subMenu.style.removeProperty('bottom');
+-                    _this2.subMenu.style.removeProperty('left');
+-                    _this2.subMenu.style.removeProperty('right');
+-
+-                    if ((0, _helpers.hasOwnProp)(styles, 'top')) _this2.subMenu.style.top = styles.top;
+-                    if ((0, _helpers.hasOwnProp)(styles, 'left')) _this2.subMenu.style.left = styles.left;
+-                    if ((0, _helpers.hasOwnProp)(styles, 'bottom')) _this2.subMenu.style.bottom = styles.bottom;
+-                    if ((0, _helpers.hasOwnProp)(styles, 'right')) _this2.subMenu.style.right = styles.right;
+-                    _this2.subMenu.classList.add(_helpers.cssClasses.menuVisible);
+-
+-                    _this2.registerHandlers();
+-                    _this2.setState({ selectedItem: null });
++                    if (_this2.props.forceOpen || _this2.state.visible) {
++                        _this2.subMenu.removeEventListener('transitionend', _this2.cleanup);
++                        var styles = _this2.props.rtl ? _this2.getRTLMenuPosition() : _this2.getMenuPosition();
++
++                        _this2.subMenu.style.removeProperty('top');
++                        _this2.subMenu.style.removeProperty('bottom');
++                        _this2.subMenu.style.removeProperty('left');
++                        _this2.subMenu.style.removeProperty('right');
++
++                        if ((0, _helpers.hasOwnProp)(styles, 'top')) _this2.subMenu.style.top = styles.top;
++                        if ((0, _helpers.hasOwnProp)(styles, 'left')) _this2.subMenu.style.left = styles.left;
++                        if ((0, _helpers.hasOwnProp)(styles, 'bottom')) _this2.subMenu.style.bottom = styles.bottom;
++                        if ((0, _helpers.hasOwnProp)(styles, 'right')) _this2.subMenu.style.right = styles.right;
++                        _this2.subMenu.classList.add(_helpers.cssClasses.menuVisible);
++
++                        _this2.registerHandlers();
++                        _this2.setState({ selectedItem: null });
++                    }
+                 });
+             } else {
+-                var cleanup = function cleanup() {
+-                    _this2.subMenu.removeEventListener('transitionend', cleanup);
+-                    _this2.subMenu.style.removeProperty('bottom');
+-                    _this2.subMenu.style.removeProperty('right');
+-                    _this2.subMenu.style.top = 0;
+-                    _this2.subMenu.style.left = '100%';
+-                    _this2.unregisterHandlers();
+-                };
+-                this.subMenu.addEventListener('transitionend', cleanup);
++                this.subMenu.removeEventListener('transitionend', this.cleanup);
++                this.subMenu.addEventListener('transitionend', this.cleanup);
+                 this.subMenu.classList.remove(_helpers.cssClasses.menuVisible);
+             }
+         }

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -460,11 +460,11 @@ export class ConversationHeader extends React.Component<PropsType, StateType> {
     return (
       <ContextMenu id={triggerId}>
         {disableTimerChanges ? null : (
-          <SubMenu hoverDelay={1} title={disappearingTitle}>
+          <SubMenu hoverDelay={1} title={disappearingTitle} rtl>
             {expireDurations}
           </SubMenu>
         )}
-        <SubMenu hoverDelay={1} title={muteTitle}>
+        <SubMenu hoverDelay={1} title={muteTitle} rtl>
           {muteOptions.map(item => (
             <MenuItem
               key={item.name}


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

This PR fixes several race conditions in `react-contextmenu`. Since that project is no longer maintained, the fixes won't be upstreamed.

It can be easier to reproduce some of these race conditions by enabling CPU throttling in the DevTools, under Performance -> Capture settings (gear icon).

The several fixes here can be summed up as ensuring things only happen once. In the unpatched code there are places where timeouts and event listeners are set without considering the possibility that they are already set, so these fixes ensure anything previously set is cleared first. There's also a fix that checks the submenu is still visible when a callback is run, since that may have changed after the callback was scheduled.

With the fixes I can no longer reproduce the issues shown below, but it would be good for others to try hammering on it as well.

Note that this changes the same patch file as #5609, so there will be a merge conflict depending on the order the two PRs are merged.

### Issues Fixed

#### Multiple submenus open at once

![Multiple submenus open at once](https://user-images.githubusercontent.com/5820654/139503587-645e40ad-7aca-42c1-a70d-49ade0313a29.gif)

#### Submenu stuck open

![Submenu stuck open](https://user-images.githubusercontent.com/5820654/139503710-459cc56d-666e-4568-95e3-c3b1ddd05628.gif)

#### Submenu opens on wrong side

![Submenu opens on wrong side](https://user-images.githubusercontent.com/5820654/139503755-4b12bd38-bd9e-49bb-9e54-b46fccc56350.gif)

Same issue as #5403. This issue is easiest to reproduce with CPU throttling and using the keyboard (right and left arrows) to repeatedly open and close a submenu.

The fix for this issue is to mark the submenus as right-to-left so that they always open on the left side. They sometimes open on the right due to a race condition when determining the position of the submenu, which appears to sometimes get a bounding rectangle for the submenu which isn't in the correct X position yet, which makes it seem like it won't run off the window. I didn't track that race condition down and fix it, since using the right-to-left functionality sidesteps the issue.