### PR TITLE
Add mapping for gd locale

### DIFF
--- a/ts/util/mapToSupportLocale.ts
+++ b/ts/util/mapToSupportLocale.ts
@@ -7,7 +7,6 @@ export type SupportLocaleType =
   | 'en-us'
   | 'es'
   | 'fr'
-  | 'gd'
   | 'it'
   | 'ja'
   | 'pl'
@@ -36,7 +35,7 @@ export type ElectronLocaleType =
   | 'fa'
   | 'fi'
   | 'fr'
-  | 'gd_GB'
+  | 'gd'
   | 'he'
   | 'hi'
   | 'hr'
@@ -91,8 +90,8 @@ export function mapToSupportLocale(
   if (ourLocale === 'fr') {
     return ourLocale;
   }
-  if (ourLocale === 'gd_GB') {
-    return 'gd';
+  if (ourLocale === 'gd') {
+    return 'en-us';
   }
   if (ourLocale === 'it') {
     return ourLocale;

--- a/ts/util/mapToSupportLocale.ts
+++ b/ts/util/mapToSupportLocale.ts
@@ -7,6 +7,7 @@ export type SupportLocaleType =
   | 'en-us'
   | 'es'
   | 'fr'
+  | 'gd'
   | 'it'
   | 'ja'
   | 'pl'
@@ -35,6 +36,7 @@ export type ElectronLocaleType =
   | 'fa'
   | 'fi'
   | 'fr'
+  | 'gd_GB'
   | 'he'
   | 'hi'
   | 'hr'
@@ -88,6 +90,9 @@ export function mapToSupportLocale(
   }
   if (ourLocale === 'fr') {
     return ourLocale;
+  }
+  if (ourLocale === 'gd_GB') {
+    return 'gd';
   }
   if (ourLocale === 'it') {
     return ourLocale;


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

### Description

For the gd locale, some operating systems use `gd` and some use `gd_GB`.

I'm a translator and don't expect to be able to find the time to contribute further code to this project, so I haven't done any testing for this. I hope it's OK.