### PR TITLE
Organize conversation menu into "commonly used" vs "single-use" sections

### DIFF
--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -466,11 +466,9 @@ export class ConversationHeader extends React.Component<PropsType, StateType> {
 
     return (
       <ContextMenu id={triggerId}>
-        {disableTimerChanges ? null : (
-          <SubMenu hoverDelay={1} title={disappearingTitle}>
-            {expireDurations}
-          </SubMenu>
-        )}
+        {!markedUnread ? (
+          <MenuItem onClick={onMarkUnread}>{i18n('markUnread')}</MenuItem>
+        ) : null}
         <SubMenu hoverDelay={1} title={muteTitle}>
           {muteOptions.map(item => (
             <MenuItem
@@ -498,17 +496,6 @@ export class ConversationHeader extends React.Component<PropsType, StateType> {
         ) : null}
         <MenuItem onClick={onShowAllMedia}>{i18n('viewRecentMedia')}</MenuItem>
         <MenuItem divider />
-        {!markedUnread ? (
-          <MenuItem onClick={onMarkUnread}>{i18n('markUnread')}</MenuItem>
-        ) : null}
-        {isArchived ? (
-          <MenuItem onClick={onMoveToInbox}>
-            {i18n('moveConversationToInbox')}
-          </MenuItem>
-        ) : (
-          <MenuItem onClick={onArchive}>{i18n('archiveConversation')}</MenuItem>
-        )}
-        <MenuItem onClick={onDeleteMessages}>{i18n('deleteMessages')}</MenuItem>
         {isPinned ? (
           <MenuItem onClick={() => onSetPin(false)}>
             {i18n('unpinConversation')}
@@ -518,6 +505,19 @@ export class ConversationHeader extends React.Component<PropsType, StateType> {
             {i18n('pinConversation')}
           </MenuItem>
         )}
+        {disableTimerChanges ? null : (
+          <SubMenu hoverDelay={1} title={disappearingTitle}>
+            {expireDurations}
+          </SubMenu>
+        )}
+        {isArchived ? (
+          <MenuItem onClick={onMoveToInbox}>
+            {i18n('moveConversationToInbox')}
+          </MenuItem>
+        ) : (
+          <MenuItem onClick={onArchive}>{i18n('archiveConversation')}</MenuItem>
+        )}
+        <MenuItem onClick={onDeleteMessages}>{i18n('deleteMessages')}</MenuItem>
       </ContextMenu>
     );
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [ ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
The conversation context menu has confused me recently: many commonly-used entries are right next to rarely-used entries, some of which can become permanent pretty fast (for example delete conversation isn't someplace where mistakes should be easily made).
I think that frequently-used options should go together and rarely-used options should also be grouped together, as this will make for some sort of intuitive ordering. It will also help prevent issues such as intending to click on "mark as unread" and archiving/deleting the conversation by mistake.

Current menu order:
- Disappearing messages > Submenu
- Mute notifications > Submenu
- Group settings
- View recent media
-[Separator]
- Mark as unread
- Archive
- Delete
- Pin conversation

Menu order after this PR:
- Mark as unread
- Mute notifications > Submenu
- Group settings
- View recent media
-[Separator]
- Pin conversation
- Disappearing messages > Submenu
- Archive
- Delete

The choice is still somewhat arbitrary, especially for "pin conversation" and "disappearing messages" which I never use but others may have a different workflow -> all actionable feedback is welcome.

### Testing
I built and ran the electron app, but was unable to connect it to either one of my android or iOS devices ("error no device found" on android, while iOS suggests retrying and can't get past that part.). I therefore wasn't able to load a conversation, so I wasn't able to open the menu and see if it worked.
`yarn ready` passes
`yarn test` all tests pass
OS: macOS 12.2.1
Device: laptop

### Additional notes
I'm happy to sign the CLA but I wanted to get some feedback first.