### PR TITLE
Fix #5843: Ignore release directory when running prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@ js/components.js
 js/util_worker.js
 libtextsecure/components.js
 libtextsecure/test/test.js
+release/**
 stylesheets/*.css
 test/test.js
 ts/**/*.js

--- a/ts/util/timestamp.ts
+++ b/ts/util/timestamp.ts
@@ -116,10 +116,7 @@ export function formatTime(
     return i18n('minutesAgo', [Math.floor(diff / MINUTE).toString()]);
   }
 
-  return new Date(timestamp).toLocaleTimeString([], {
-    hour: 'numeric',
-    minute: '2-digit',
-  });
+  return moment(timestamp).format('LT');
 }
 
 export function formatDate(


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This PR fixes #5843 by adding the `release` folder generated via `yarn build` into the `.prettierignore` file. This prevent's files in `release` from being linted by prettier and thus erroring out. This is a minor quality of life change for developers.

I've had to change a `formatTime` to use moment as the tests were failing with my locale of `en-AU`.
Please let me know if there is another way I should be running the tests in order to fix this without a code change. However, this feels like an oversight in the test cases unless I have missed some instruction.

OS Info: macOS Monterey 12.2.1 (21D62)