### PR TITLE
Fix dark mode for call settings (#5759)

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -7291,6 +7291,8 @@ button.module-image__border-overlay:focus {
 
   select {
     @include font-body-1;
+    background: $color-gray-75;
+    color: $color-gray-02;
     -webkit-appearance: none;
     border-radius: 4px;
     border: 1px solid $color-gray-45;


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
![Screenshot_2022-04-20_22-07-18](https://user-images.githubusercontent.com/59527089/164376561-67f8350a-3827-4854-a5c0-38a1d3d7a40e.png)

- [X] My changes are ready to be shipped to users

### Description

Does it address any outstanding issues in this project?
  Yes, fixes #5759 

Please write a summary of your test approach:
  - What kind of manual testing did you do?
Ran locally against staging:
![Screenshot_2022-04-20_21-49-45](https://user-images.githubusercontent.com/59527089/164376367-863187b9-3312-42ab-91e4-bde94a390486.png)

  - Did you write any new tests?

No

  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)

Linux 64-bit

  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
 
Specific to desktop
