### PR TITLE
Add Vagrant configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vagrant
 node_modules
 .sass-cache
 coverage/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@ still useful, but it doesn't support `.nvmrc` files.
 
 Then you need [`git`](https://git-scm.com/) and [`git-lfs`](https://github.com/git-lfs/git-lfs/wiki/Installation), if you don't have those yet.
 
+Alternatively, you can simply install [Vagrant](https://www.vagrantup.com/intro), and use the included `Vagrantfile` to install all the project's dependencies into an Ubuntu virtual machine. Consult the `Vagrantfile` for more details.
+
 ### macOS
 
 Install the [Xcode Command-Line Tools](http://osxdaily.com/2014/02/12/install-command-line-tools-mac-os-x/).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,68 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# Copyright 2021 Signal Messenger, LLC
+# SPDX-License-Identifier: AGPL-3.0-only
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-20.04"
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  #
+  # Disabling the default mount, since it doesn't work in Ubuntu:
+  # https://github.com/hashicorp/vagrant/issues/11506
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/home/vagrant/Signal-Desktop"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    vb.gui = true
+    # Enough RAM to run "yarn ready" with minimal swapping
+    vb.memory = "3072"
+    # Without this configuration, interacting with the UI will be very slow
+    vb.customize ['modifyvm', :id, "--graphicscontroller", "vmsvga"]
+    vb.customize ['modifyvm', :id, "--accelerate3d", "on"]
+    vb.customize ["modifyvm", :id, "--vram", "64"]
+  end
+
+  # Perform these steps as root.
+  # The reboot is an easy way to start the window manager.
+  config.vm.provision "shell", reboot: true, inline: <<-SHELL
+    apt update
+    # Signal dependencies, based on the contribution guide
+    DEBIAN_FRONTEND=noninteractive apt install -y \
+      python3 \
+      build-essential \
+      curl \
+      git-lfs
+
+    # Configure window manager and VirtualBox integration, based on:
+    # https://stackoverflow.com/a/33138627/3043071
+    DEBIAN_FRONTEND=noninteractive apt install -y \
+      xfce4 \
+      virtualbox-guest-dkms \
+      virtualbox-guest-utils \
+      virtualbox-guest-x11
+    sed -i 's/allowed_users=.*$/allowed_users=anybody/' /etc/X11/Xwrapper.config
+    sed -i 's/#  AutomaticLoginEnable =.*$/AutomaticLoginEnable = true/' /etc/gdm3/custom.conf
+    sed -i 's/#  AutomaticLogin =.*$/AutomaticLogin = vagrant/' /etc/gdm3/custom.conf
+  SHELL
+
+  # Perform these steps as vagrant, a non-privileged user
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    # Signal dependencies, based on the contribution guide
+    cd /home/vagrant/Signal-Desktop
+    git lfs install
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+    source ~/.nvm/nvm.sh
+    nvm install `cat .nvmrc`
+    npm install --global yarn
+    yarn install --frozen-lockfile
+
+    # Configure the window manager
+    gsettings set org.gnome.desktop.session idle-delay 0
+  SHELL
+end


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Currently, the contribution guidelines describe setting up development environments on Windows, Linux, and macOS. I've added another alternative: developing Signal within a [Vagrant](https://www.vagrantup.com) box (i.e., a VirtualBox virtual machine). 

This provides several advantages:

- Faster initial setup of the development environment (i.e., just clone the repo and run `vagrant up`)
- A more consistent development environment will help avoid spurious issues (e.g., issues due to a developer's environment being misconfigured)
- Isolate the development environment from the rest of the developer's computer for security
  - Given the very real possibility of [malicious Node packages](https://arstechnica.com/information-technology/2022/03/sabotage-code-added-to-popular-npm-package-wiped-files-in-russia-and-belarus/), I prefer to run third-party code in VMs or containers
- Gain insight into the minimum specifications needed to develop the project. For example, I found that `yarn ready` failed with 2.5GB of RAM, but passed with 3GB of RAM.

My PR includes a `Vagrantfile` which installs Signal Desktop's development dependencies into an Ubuntu 20.04 virtual machine. To verify that it works properly, simply run `vagrant up` within the cloned repo, and wait for this command to complete. Then, open the box's window manager in VirtualBox. Next, open a Terminal window, and run `yarn ready`

Vagrant is not my preferred solution for developing code – I find that Docker is usually much easier to set up, uses less resources, etc. However, in this case I think Vagrant is a more portable solution, because I believe Signal Desktop has an implicit requirement for a desktop environment and a GPU. I *mostly* got Signal Desktop running in Docker, but [I ran into some issues](https://community.signalusers.org/t/docker-configuration-for-development/43620/4), so I decided Vagrant was better in this case. 
