### PR TITLE
Open first search candidate on pressing "enter" key

### DIFF
--- a/ts/components/LeftPane.stories.tsx
+++ b/ts/components/LeftPane.stories.tsx
@@ -424,8 +424,8 @@ story.add('Search: all results', () => (
         messageResults: {
           isLoading: false,
           results: [
-            { id: 'msg1', conversationId: 'foo' },
-            { id: 'msg2', conversationId: 'bar' },
+            { id: 'msg1', type: 'outgoing', conversationId: 'foo' },
+            { id: 'msg2', type: 'incoming', conversationId: 'bar' },
           ],
         },
         primarySendsSms: false,

--- a/ts/components/LeftPane.tsx
+++ b/ts/components/LeftPane.tsx
@@ -329,7 +329,8 @@ export const LeftPane: React.FC<PropsType> = ({
           };
 
       const numericIndex = keyboardKeyToNumericIndex(event.key);
-      if (commandOrCtrl && isNumber(numericIndex)) {
+      const openedByNumber = commandOrCtrl && isNumber(numericIndex);
+      if (openedByNumber) {
         conversationToOpen =
           helper.getConversationAndMessageAtIndex(numericIndex);
       } else {
@@ -363,6 +364,9 @@ export const LeftPane: React.FC<PropsType> = ({
       if (conversationToOpen) {
         const { conversationId, messageId } = conversationToOpen;
         openConversationInternal({ conversationId, messageId });
+        if (openedByNumber) {
+          clearSearch();
+        }
         event.preventDefault();
         event.stopPropagation();
       }
@@ -388,6 +392,7 @@ export const LeftPane: React.FC<PropsType> = ({
     showInbox,
     startComposing,
     startSearch,
+    clearSearch,
   ]);
 
   const requiresFullWidth = helper.requiresFullWidth();

--- a/ts/components/LeftPane.tsx
+++ b/ts/components/LeftPane.tsx
@@ -39,6 +39,7 @@ import {
   getWidthFromPreferredWidth,
 } from '../util/leftPaneWidth';
 import type { LookupConversationWithoutUuidActionsType } from '../util/lookupConversationWithoutUuid';
+import type { OpenConversationInternalType } from '../state/ducks/conversations';
 
 import { ConversationList } from './ConversationList';
 import { ContactCheckboxDisabledReason } from './conversationList/ContactCheckbox';
@@ -99,11 +100,7 @@ export type PropsType = {
   closeMaximumGroupSizeModal: () => void;
   closeRecommendedGroupSizeModal: () => void;
   createGroup: () => void;
-  openConversationInternal: (_: {
-    conversationId: string;
-    messageId?: string;
-    switchToAssociatedView?: boolean;
-  }) => void;
+  openConversationInternal: OpenConversationInternalType;
   savePreferredLeftPaneWidth: (_: number) => void;
   searchInConversation: (conversationId: string) => unknown;
   setComposeSearchTerm: (composeSearchTerm: string) => void;
@@ -558,6 +555,7 @@ export const LeftPane: React.FC<PropsType> = ({
           setComposeSearchTerm(event.target.value);
         },
         updateSearchTerm,
+        openConversationInternal,
       })}
       <div className="module-left-pane__dialogs">
         {renderExpiredBuildDialog({

--- a/ts/components/LeftPaneSearchInput.tsx
+++ b/ts/components/LeftPaneSearchInput.tsx
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import React, { useEffect, useRef } from 'react';
-import type { ConversationType } from '../state/ducks/conversations';
+import type {
+  ConversationType,
+  OpenConversationInternalType,
+} from '../state/ducks/conversations';
 import type { LocalizerType } from '../types/Util';
 import { Avatar, AvatarSize } from './Avatar';
 import { SearchInput } from './SearchInput';
@@ -17,6 +20,11 @@ type PropsType = {
   searchTerm: string;
   startSearchCounter: number;
   updateSearchTerm: (searchTerm: string) => void;
+  openConversationInternal: OpenConversationInternalType;
+  onEnterKeyDown?: (
+    clearSearch: () => void,
+    openConversationInternal: OpenConversationInternalType
+  ) => void;
 };
 
 export const LeftPaneSearchInput = ({
@@ -28,6 +36,8 @@ export const LeftPaneSearchInput = ({
   searchTerm,
   startSearchCounter,
   updateSearchTerm,
+  openConversationInternal,
+  onEnterKeyDown,
 }: PropsType): JSX.Element => {
   const inputRef = useRef<null | HTMLInputElement>(null);
 
@@ -89,6 +99,13 @@ export const LeftPaneSearchInput = ({
       onBlur={() => {
         if (!searchConversation && !searchTerm) {
           clearSearch();
+        }
+      }}
+      onKeyDown={event => {
+        if (onEnterKeyDown && event.key === 'Enter') {
+          onEnterKeyDown(clearSearch, openConversationInternal);
+          event.preventDefault();
+          event.stopPropagation();
         }
       }}
       onChange={event => {

--- a/ts/components/leftPane/LeftPaneArchiveHelper.tsx
+++ b/ts/components/leftPane/LeftPaneArchiveHelper.tsx
@@ -12,7 +12,10 @@ import type { Row } from '../ConversationList';
 import { RowType } from '../ConversationList';
 import type { PropsData as ConversationListItemPropsType } from '../conversationList/ConversationListItem';
 import type { LocalizerType } from '../../types/Util';
-import type { ConversationType } from '../../state/ducks/conversations';
+import type {
+  ConversationType,
+  OpenConversationInternalType,
+} from '../../state/ducks/conversations';
 import { LeftPaneSearchInput } from '../LeftPaneSearchInput';
 import type { LeftPaneSearchPropsType } from './LeftPaneSearchHelper';
 import { LeftPaneSearchHelper } from './LeftPaneSearchHelper';
@@ -81,11 +84,13 @@ export class LeftPaneArchiveHelper extends LeftPaneHelper<LeftPaneArchivePropsTy
     clearSearch,
     i18n,
     updateSearchTerm,
+    openConversationInternal,
   }: Readonly<{
     clearConversationSearch: () => unknown;
     clearSearch: () => unknown;
     i18n: LocalizerType;
     updateSearchTerm: (searchTerm: string) => unknown;
+    openConversationInternal: OpenConversationInternalType;
   }>): ReactChild | null {
     if (!this.searchConversation) {
       return null;
@@ -100,6 +105,7 @@ export class LeftPaneArchiveHelper extends LeftPaneHelper<LeftPaneArchivePropsTy
         searchTerm={this.searchTerm}
         startSearchCounter={this.startSearchCounter}
         updateSearchTerm={updateSearchTerm}
+        openConversationInternal={openConversationInternal}
       />
     );
   }

--- a/ts/components/leftPane/LeftPaneHelper.tsx
+++ b/ts/components/leftPane/LeftPaneHelper.tsx
@@ -10,6 +10,7 @@ import type {
   ReplaceAvatarActionType,
   SaveAvatarToDiskActionType,
 } from '../../types/Avatar';
+import type { OpenConversationInternalType } from '../../state/ducks/conversations';
 
 export enum FindDirection {
   Up,
@@ -42,6 +43,7 @@ export abstract class LeftPaneHelper<T> {
         event: ChangeEvent<HTMLInputElement>
       ) => unknown;
       updateSearchTerm: (searchTerm: string) => unknown;
+      openConversationInternal: OpenConversationInternalType;
     }>
   ): null | ReactChild {
     return null;

--- a/ts/components/leftPane/LeftPaneInboxHelper.tsx
+++ b/ts/components/leftPane/LeftPaneInboxHelper.tsx
@@ -7,7 +7,10 @@ import React from 'react';
 
 import { Intl } from '../Intl';
 import type { ToFindType } from './LeftPaneHelper';
-import type { ConversationType } from '../../state/ducks/conversations';
+import type {
+  ConversationType,
+  OpenConversationInternalType,
+} from '../../state/ducks/conversations';
 import { LeftPaneHelper } from './LeftPaneHelper';
 import { getConversationInDirection } from './getConversationInDirection';
 import type { Row } from '../ConversationList';
@@ -83,11 +86,13 @@ export class LeftPaneInboxHelper extends LeftPaneHelper<LeftPaneInboxPropsType> 
     clearSearch,
     i18n,
     updateSearchTerm,
+    openConversationInternal,
   }: Readonly<{
     clearConversationSearch: () => unknown;
     clearSearch: () => unknown;
     i18n: LocalizerType;
     updateSearchTerm: (searchTerm: string) => unknown;
+    openConversationInternal: OpenConversationInternalType;
   }>): ReactChild {
     return (
       <LeftPaneSearchInput
@@ -99,6 +104,7 @@ export class LeftPaneInboxHelper extends LeftPaneHelper<LeftPaneInboxPropsType> 
         searchTerm={this.searchTerm}
         startSearchCounter={this.startSearchCounter}
         updateSearchTerm={updateSearchTerm}
+        openConversationInternal={openConversationInternal}
       />
     );
   }

--- a/ts/components/leftPane/LeftPaneSearchHelper.tsx
+++ b/ts/components/leftPane/LeftPaneSearchHelper.tsx
@@ -38,6 +38,7 @@ export type LeftPaneSearchPropsType = {
   messageResults: MaybeLoadedSearchResultsType<{
     id: string;
     conversationId: string;
+    type: string;
   }>;
   searchConversationName?: string;
   primarySendsSms: boolean;
@@ -61,6 +62,7 @@ export class LeftPaneSearchHelper extends LeftPaneHelper<LeftPaneSearchPropsType
   private readonly messageResults: MaybeLoadedSearchResultsType<{
     id: string;
     conversationId: string;
+    type: string;
   }>;
 
   private readonly searchConversationName?: string;
@@ -319,9 +321,8 @@ export class LeftPaneSearchHelper extends LeftPaneHelper<LeftPaneSearchPropsType
       }
       if (pointer < list.results.length) {
         const result = list.results[pointer];
-        return 'conversationId' in result
-          ? // it is a message result
-            {
+        return result.type === 'incoming' || result.type === 'outgoing' // message
+          ? {
               conversationId: result.conversationId,
               messageId: result.id,
             }

--- a/ts/components/leftPane/LeftPaneSearchHelper.tsx
+++ b/ts/components/leftPane/LeftPaneSearchHelper.tsx
@@ -307,12 +307,12 @@ export class LeftPaneSearchHelper extends LeftPaneHelper<LeftPaneSearchPropsType
   }
 
   getConversationAndMessageAtIndex(
-    _conversationIndex: number
+    conversationIndex: number
   ): undefined | { conversationId: string; messageId?: string } {
-    if (_conversationIndex < 0) {
+    if (conversationIndex < 0) {
       return undefined;
     }
-    let pointer = _conversationIndex;
+    let pointer = conversationIndex;
     for (const list of this.allResults()) {
       if (list.isLoading) {
         continue;

--- a/ts/state/ducks/conversations.ts
+++ b/ts/state/ducks/conversations.ts
@@ -347,6 +347,12 @@ export type ConversationsStateType = {
   messagesByConversation: MessagesByConversationType;
 };
 
+export type OpenConversationInternalType = (_: {
+  conversationId: string;
+  messageId?: string;
+  switchToAssociatedView?: boolean;
+}) => void;
+
 // Helpers
 
 export const getConversationCallMode = (

--- a/ts/test-node/components/leftPane/LeftPaneSearchHelper_test.ts
+++ b/ts/test-node/components/leftPane/LeftPaneSearchHelper_test.ts
@@ -547,4 +547,127 @@ describe('LeftPaneSearchHelper', () => {
       );
     });
   });
+
+  describe('getConversationAndMessageAtIndex', () => {
+    it('returns correct conversation at given index', () => {
+      const expected = getDefaultConversation();
+      const helper = new LeftPaneSearchHelper({
+        conversationResults: {
+          isLoading: false,
+          results: [expected, getDefaultConversation()],
+        },
+        contactResults: { isLoading: false, results: [] },
+        messageResults: {
+          isLoading: false,
+          results: [fakeMessage(), fakeMessage(), fakeMessage()],
+        },
+        searchTerm: 'foo',
+        primarySendsSms: false,
+        searchConversation: undefined,
+        searchDisabled: false,
+        startSearchCounter: 0,
+      });
+      assert.strictEqual(
+        helper.getConversationAndMessageAtIndex(0)?.conversationId,
+        expected.id
+      );
+    });
+
+    it('returns correct contact at given index', () => {
+      const expected = getDefaultConversation();
+      const helper = new LeftPaneSearchHelper({
+        conversationResults: {
+          isLoading: false,
+          results: [getDefaultConversation(), getDefaultConversation()],
+        },
+        contactResults: {
+          isLoading: false,
+          results: [expected],
+        },
+        messageResults: {
+          isLoading: false,
+          results: [fakeMessage(), fakeMessage(), fakeMessage()],
+        },
+        searchTerm: 'foo',
+        primarySendsSms: false,
+        searchConversation: undefined,
+        searchDisabled: false,
+        startSearchCounter: 0,
+      });
+      assert.strictEqual(
+        helper.getConversationAndMessageAtIndex(2)?.conversationId,
+        expected.id
+      );
+    });
+
+    it('returns correct message at given index', () => {
+      const expected = fakeMessage();
+      const helper = new LeftPaneSearchHelper({
+        conversationResults: {
+          isLoading: false,
+          results: [getDefaultConversation(), getDefaultConversation()],
+        },
+        contactResults: { isLoading: false, results: [] },
+        messageResults: {
+          isLoading: false,
+          results: [fakeMessage(), fakeMessage(), expected],
+        },
+        searchTerm: 'foo',
+        primarySendsSms: false,
+        searchConversation: undefined,
+        searchDisabled: false,
+        startSearchCounter: 0,
+      });
+      assert.strictEqual(
+        helper.getConversationAndMessageAtIndex(4)?.messageId,
+        expected.id
+      );
+    });
+
+    it('returns correct message at given index skipping not loaded results', () => {
+      const expected = fakeMessage();
+      const helper = new LeftPaneSearchHelper({
+        conversationResults: { isLoading: true },
+        contactResults: { isLoading: true },
+        messageResults: {
+          isLoading: false,
+          results: [fakeMessage(), expected, fakeMessage()],
+        },
+        searchTerm: 'foo',
+        primarySendsSms: false,
+        searchConversation: undefined,
+        searchDisabled: false,
+        startSearchCounter: 0,
+      });
+      assert.strictEqual(
+        helper.getConversationAndMessageAtIndex(1)?.messageId,
+        expected.id
+      );
+    });
+
+    it('returns undefined if search candidate with given index does not exist', () => {
+      const helper = new LeftPaneSearchHelper({
+        conversationResults: {
+          isLoading: false,
+          results: [getDefaultConversation(), getDefaultConversation()],
+        },
+        contactResults: { isLoading: false, results: [] },
+        messageResults: {
+          isLoading: false,
+          results: [fakeMessage(), fakeMessage(), fakeMessage()],
+        },
+        searchTerm: 'foo',
+        primarySendsSms: false,
+        searchConversation: undefined,
+        searchDisabled: false,
+        startSearchCounter: 0,
+      });
+      assert.isUndefined(
+        helper.getConversationAndMessageAtIndex(100)?.messageId
+      );
+      assert.isUndefined(
+        helper.getConversationAndMessageAtIndex(-100)?.messageId
+      );
+    });
+  });
 });

--- a/ts/test-node/components/leftPane/LeftPaneSearchHelper_test.ts
+++ b/ts/test-node/components/leftPane/LeftPaneSearchHelper_test.ts
@@ -12,6 +12,7 @@ import { LeftPaneSearchHelper } from '../../../components/leftPane/LeftPaneSearc
 describe('LeftPaneSearchHelper', () => {
   const fakeMessage = () => ({
     id: uuid(),
+    type: 'outgoing',
     conversationId: uuid(),
   });
 


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
See issue: #2222

This PR allows user to press `enter` to open first result while searching. Search input is cleared after conversation/message is opened.

I've implemented `LeftPaneSearchHelper::getConversationAndMessageAtIndex` so as a side effect it is now possible to select search results with `ctrl+{1-9}` as well. Let me know if it is not desirable.

I did manual tests on Linux 5.17.4-zen1-1-zen. I also wrote tests for `LeftPaneSearchHelper::getConversationAndMessageAtIndex`