### PR TITLE
Bidirectional isolation for links

### DIFF
--- a/ts/components/conversation/Linkify.tsx
+++ b/ts/components/conversation/Linkify.tsx
@@ -380,9 +380,9 @@ export class Linkify extends React.Component<Props> {
         count += 1;
         if (SUPPORTED_PROTOCOLS.test(url) && !isLinkSneaky(url)) {
           results.push(
-            <a key={count} href={url}>
+            <bdi><a key={count} href={url}>
               {originalText}
-            </a>
+            </a></bdi>
           );
         } else {
           results.push(renderNonLink({ text: originalText, key: count }));


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [ ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

For better RTL support, links should be bidirectional isolated. It helps when message starting with a link, but the context text is in RTL language, and may could help in other situations.
<!--
Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
-->
  - What kind of manual testing did you do?
    Send a message that starts with a link, following with a RTL text. The message context should be in RTL mode, even if it starting with the link LTR characters. 

