### PR TITLE
Use automatic direction for messages

### DIFF
--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -1323,7 +1323,7 @@ export class Message extends React.PureComponent<Props, State> {
                 'module-message__text',
                 `module-message__text--${direction}`
               )}
-              dir={isRTL ? 'rtl' : undefined}
+              dir="auto"
             >
               {description}
               {this.getMetadataPlacement() ===


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Messages should use `dir=auto` attribute, which is supporting bidirectional isolation (`<bdi>` html tag) [used in mentions](https://github.com/signalapp/Signal-Desktop/blob/7554d8326a87d1280b6710e64ced58d4d4d47e81/ts/components/conversation/AtMentionify.tsx#L71) for example. The `direction` library doesn't support it, and the result is degraded RTL support.

If message starts with a bidirectional isolated element, the direction of the message should be determined buy this element content, but by the rest of the content of the message.