### PR TITLE
Generalize macOS arm64 platform name: `M1` -> `Apple silicon`

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -7,6 +7,10 @@
         "message": "Bedingungen & Datenschutzerklärung",
         "description": "Shown in the about box for the link to https://signal.org/legal"
     },
+    "appleSilicon": {
+      "message": "Apple Prozessoren",
+      "description": "Shown in the about box for Apple silicon product name"
+    },
     "copyErrorAndQuit": {
         "message": "Fehler kopieren und beenden",
         "description": "Shown in the top-level error popup, allowing user to copy the error text and close the app"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -7,6 +7,10 @@
     "message": "Terms & Privacy Policy",
     "description": "Shown in the about box for the link to https://signal.org/legal"
   },
+  "appleSilicon": {
+    "message": "Apple silicon",
+    "description": "Shown in the about box for Apple silicon product name"
+  },
   "copyErrorAndQuit": {
     "message": "Copy error and quit",
     "description": "Shown in the top-level error popup, allowing user to copy the error text and close the app"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -7,6 +7,10 @@
         "message": "使用条件とプライバシーポリシー",
         "description": "Shown in the about box for the link to https://signal.org/legal"
     },
+    "appleSilicon": {
+        "message": "Appleシリコン",
+        "description": "Shown in the about box for Apple silicon product name"
+    },
     "copyErrorAndQuit": {
         "message": "エラーメッセージをコピーして終了します",
         "description": "Shown in the top-level error popup, allowing user to copy the error text and close the app"

--- a/ts/windows/about/preload.ts
+++ b/ts/windows/about/preload.ts
@@ -24,7 +24,7 @@ contextBridge.exposeInMainWorld('SignalContext', {
     let platform = '';
     if (process.platform === 'darwin') {
       if (process.arch === 'arm64') {
-        platform = ' (M1)';
+        platform = ` (${SignalContext.i18n('appleSilicon')})`;
       } else {
         platform = ' (Intel)';
       }


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Use Apple's official name for their ARM-based desktop processor (`Apple silicon`) in the "About" window.

Reference: https://support.apple.com/en-us/HT211814

Darwin (macOS) architecture string was originally added in e60773cdf33bf7529e241d7907f27618f29a7a9b by @indutny-signal .

#### Change tested manually on an M2 Mac, macOS 12.5:

<img width="300" alt="en" src="https://user-images.githubusercontent.com/10822203/180376722-de0623d5-1984-47b1-9a4c-f5ae3dbbbb8e.png">

<img width="300" alt="de" src="https://user-images.githubusercontent.com/10822203/180376730-2a5c5946-067c-4af6-b9db-db2c9b112924.png">

<img width="300" alt="ja" src="https://user-images.githubusercontent.com/10822203/180376739-72575e58-2350-479d-886c-6edae8282f1b.png">

<img width="152" alt="env" src="https://user-images.githubusercontent.com/10822203/180376671-fc3451c2-e161-4222-a45a-2c1b7be78998.png">

#### `yarn ready` passed

```
[test-electron] Passed 1669 | Failed 0 | Total 1669
[lint         ] [eslint       ] $ eslint --cache .
✨  Done in 31.67s.
```

:)