### PR TITLE
Lower MP3 bitrate for voice message from 160 to 80 kbps

### DIFF
--- a/components/webaudiorecorder/lib/WebAudioRecorder.js
+++ b/components/webaudiorecorder/lib/WebAudioRecorder.js
@@ -44,7 +44,7 @@
       },
       mp3: {
         mimeType: "audio/mpeg",
-        bitRate: 160            // (CBR only): bit rate = [64 .. 320]
+        bitRate: 80            // (CBR only): bit rate = [64 .. 320]
       }
     }
   };


### PR DESCRIPTION
Good enough quality and less space/network used.

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)) => tiny change, to illustrate the issue. 
- [X] My changes are ready to be shipped to users

### Description

This contributes to #6128 which aims at lowering the bitrate used by Signal. That would end up in using less storage and network resources. 
