### PR TITLE
Made sticker picker padding smaller so it doesn't overflow.

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -5563,7 +5563,7 @@ button.module-image__border-overlay:focus {
   &__content {
     width: 332px;
     height: 356px;
-    padding: 8px 20px 16px 16px;
+    padding: 8px 13px 16px 13px;
     overflow-y: auto;
     display: grid;
     grid-gap: 8px;


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes #5816, which describes the fact that the sticker picker scrolls sideways because it slightly overflows the size of its container. This is because 9px-wide vertical scroll bar was not factored in to the size of the inner content. (Note that 4x68px (items) + 3x8px (grid-gap) + 20px + 16px = 332px, so the grid is sized correctly if there is no vertical scroll bar, but the scroll bar takes up an additional 9px so have to shrink the content further in order to make it fit.)

Tested manually on macOS 12.5, and it does fix the problem without any obvious aesthetic flaws. 