### PR TITLE
Add autoplay for voice messages

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4231,6 +4231,10 @@
     "message": "Chat color",
     "description": "This is a button in the conversation context menu to show the chat color editor"
   },
+  "autoplayVoiceMessages": {
+    "message": "Autoplay voice messages",
+    "description": "Whether to automatically play incoming voice messages or not"
+  },
   "showConversationDetails": {
     "message": "Group settings",
     "description": "This is a button in the conversation context menu to show group settings"

--- a/stylesheets/components/ConversationDetails.scss
+++ b/stylesheets/components/ConversationDetails.scss
@@ -440,6 +440,21 @@
           }
         }
       }
+
+      &--play {
+        &::after {
+          -webkit-mask: url(../images/icons/v2/play-solid-24.svg) no-repeat
+            center;
+
+          @include light-theme {
+            background-color: $color-gray-75;
+          }
+
+          @include dark-theme {
+            background-color: $color-gray-15;
+          }
+        }
+      }
     }
   }
 

--- a/ts/components/conversation/MessageAudio.tsx
+++ b/ts/components/conversation/MessageAudio.tsx
@@ -233,6 +233,20 @@ function PlayedDot({
   );
 }
 
+type AutoplayWrapperProps = {
+  callback: () => void;
+};
+
+class AutoplayWrapper extends React.Component<AutoplayWrapperProps> {
+  override componentDidMount() {
+    log.info('Unplayed message -> autoplaying');
+    this.props.callback();
+  }
+  override render() {
+    return this.props.children;
+  }
+}
+
 /**
  * Display message audio attachment along with its waveform, duration, and
  * toggle Play/Pause button.
@@ -536,6 +550,18 @@ export function MessageAudio(props: Props): JSX.Element {
         onClick={toggleIsPlaying}
       />
     );
+
+    if (
+      !played &&
+      window.ConversationController.get(conversationId)?.attributes.autoplay
+    ) {
+      const originalButton = button;
+      button = (
+        <AutoplayWrapper callback={toggleIsPlaying}>
+          {originalButton}
+        </AutoplayWrapper>
+      );
+    }
   }
 
   const countDown = Math.max(0, duration - (active?.currentTime ?? 0));

--- a/ts/components/conversation/conversation-details/ConversationDetails.stories.tsx
+++ b/ts/components/conversation/conversation-details/ConversationDetails.stories.tsx
@@ -94,6 +94,7 @@ const createProps = (
   userAvatarData: [],
   toggleSafetyNumberModal: action('toggleSafetyNumberModal'),
   toggleAddUserToAnotherGroupModal: action('toggleAddUserToAnotherGroup'),
+  toggleAutoplay: action('toggleAutoplay'),
   onOutgoingAudioCallInConversation: action(
     'onOutgoingAudioCallInConversation'
   ),

--- a/ts/components/conversation/conversation-details/ConversationDetails.tsx
+++ b/ts/components/conversation/conversation-details/ConversationDetails.tsx
@@ -52,6 +52,7 @@ import type {
 import { isConversationMuted } from '../../../util/isConversationMuted';
 import { ConversationDetailsGroups } from './ConversationDetailsGroups';
 import { PanelType } from '../../../types/Panels';
+import { getClassNamesFor } from '../../../util/getClassNamesFor';
 
 enum ModalState {
   NothingOpen,
@@ -116,6 +117,7 @@ type ActionProps = {
   showContactModal: (contactId: string, conversationId?: string) => void;
   showConversation: ShowConversationType;
   toggleAddUserToAnotherGroupModal: (contactId?: string) => void;
+  toggleAutoplay: (conversationId: string) => void;
   toggleSafetyNumberModal: (conversationId: string) => unknown;
 } & Pick<ConversationDetailsMediaListPropsType, 'showLightboxWithMedia'>;
 
@@ -164,6 +166,7 @@ export function ConversationDetails({
   toggleAddUserToAnotherGroupModal,
   updateGroupAttributes,
   userAvatarData,
+  toggleAutoplay,
 }: Props): JSX.Element {
   const [modalState, setModalState] = useState<ModalState>(
     ModalState.NothingOpen
@@ -318,6 +321,8 @@ export function ConversationDetails({
 
   const isMuted = isConversationMuted(conversation);
 
+  const getClassName = getClassNamesFor('Checkbox');
+
   return (
     <div className="conversation-details-panel">
       <ConversationDetailsHeader
@@ -471,6 +476,23 @@ export function ConversationDetails({
             }
           />
         )}
+        <PanelRow
+          icon={
+            <ConversationDetailsIcon
+              ariaLabel={i18n('autoplayVoiceMessages')}
+              icon={IconType.play}
+            />
+          }
+          label={i18n('autoplayVoiceMessages')}
+          onClick={() => toggleAutoplay(conversation.id)}
+          right={
+            <input
+              type="checkbox"
+              checked={conversation.autoplay}
+              className={getClassName('__checkbox')}
+            />
+          }
+        />
       </PanelSection>
 
       {isGroup && (

--- a/ts/components/conversation/conversation-details/ConversationDetailsIcon.tsx
+++ b/ts/components/conversation/conversation-details/ConversationDetailsIcon.tsx
@@ -25,6 +25,7 @@ export enum IconType {
   'timer' = 'timer',
   'trash' = 'trash',
   'verify' = 'verify',
+  'play' = 'play',
 }
 
 export type Props = {

--- a/ts/model-types.d.ts
+++ b/ts/model-types.d.ts
@@ -274,6 +274,7 @@ export type ValidateConversationType = Pick<
 export type ConversationAttributesType = {
   accessKey?: string | null;
   addedBy?: string;
+  autoplay?: boolean;
   badges?: Array<
     | { id: string }
     | {

--- a/ts/models/conversations.ts
+++ b/ts/models/conversations.ts
@@ -731,6 +731,14 @@ export class ConversationModel extends window.Backbone
     });
   }
 
+  toggleAutoplay(): void {
+    const autoplay = !this.get('autoplay');
+    log.info(`toggleAutoplay(${this.idForLogging()}): newValue=${autoplay}`);
+    this.set({ autoplay });
+    this.captureChange('autoplay');
+    window.Signal.Data.updateConversation(this.attributes);
+  }
+
   async modifyGroupV2({
     usingCredentialsFrom,
     createGroupChange,
@@ -1829,6 +1837,7 @@ export class ConversationModel extends window.Backbone
         ourConversationId && ourACI && this.isMemberAwaitingApproval(ourACI)
       ),
       areWeAdmin: this.areWeAdmin(),
+      autoplay: this.get('autoplay'),
       avatars: getAvatarData(this.attributes),
       badges: this.get('badges') || [],
       canChangeTimer: this.canChangeTimer(),

--- a/ts/state/ducks/conversations.ts
+++ b/ts/state/ducks/conversations.ts
@@ -246,6 +246,7 @@ export type ConversationType = {
   publicParams?: string;
   profileKey?: string;
   voiceNotePlaybackRate?: number;
+  autoplay?: boolean;
 
   badges: Array<
     | {
@@ -937,6 +938,7 @@ export const actions = {
   startComposing,
   startSettingGroupMetadata,
   toggleAdmin,
+  toggleAutoplay,
   toggleComposeEditingAvatar,
   toggleConversationInChooseMembers,
   toggleGroupsForStorySend,
@@ -2867,6 +2869,21 @@ function toggleAdmin(
     const conversationModel = window.ConversationController.get(conversationId);
     if (conversationModel) {
       conversationModel.toggleAdmin(contactId);
+    }
+    dispatch({
+      type: 'NOOP',
+      payload: null,
+    });
+  };
+}
+
+function toggleAutoplay(
+  conversationId: string
+): ThunkAction<void, RootStateType, unknown, NoopActionType> {
+  return dispatch => {
+    const conversationModel = window.ConversationController.get(conversationId);
+    if (conversationModel) {
+      conversationModel.toggleAutoplay();
     }
     dispatch({
       type: 'NOOP',


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

This PR adds a possibility to automatically play voice messages in selected chats/groups as they come in.


#### Motivation:

There are situations where one would like to keep Signal open on one screen while doing something else on another. Following the conversation in Signal is easy for text messages, but currently voice messages require interaction to play. In some circles voice messages are surprisingly common, and this required interaction quickly becomes a burden.

On the other hand, some chats/groups might be more private and users wouldn't like to always autoplay all voice messages. Thus the possibility to enable it only for specific chats/groups.

This feature may not make sense for video messages, since videos aren't "conversation". Thus implemented only for audio.

This feature makes sense in Signal Desktop where the client is often open all the time. It may not make sense for mobile devices which are locked most of the time. Or maybe it might, what do you think?


#### Discussion:

This functionality was partially discussed in https://community.signalusers.org/t/autoplay-play-continuously-voice-messages/ but it seems that only continuous playing of consecutive messages was implemented, and automatically playing incoming messages wasn't specifically discussed.

I couldn't find other discussion. I don't have experience in other messaging applications, and I don't know if a similar feature has been discussed in those contexts.

Would You prefer this functionality to be discussed somewhere before accepting this PR? Should I perhaps create a new thread to community.signalusers.org?


#### Disclaimer:

I have practically no experience in Signal, React or even TypeScript development, so there may be a lot to improve in this PR. Apologies if I have totally missed some aspect that makes this feature somehow problematic. Please let me know of anything! 

I implemented and manually tested on macOS with a standalone client against the staging environment, using a iOS simulator with another phone number to send messages. I couldn't think of what kind of unit tests to add for this functionality since it's quite "high level", but I'd be happy to add something. Any suggestions about what kind of tests might make sense and would be realistic to implement in Signal codebase?

If You'd prefer to add this functionality in some completely different way, please feel free to discard this PR. I don't mind as long as the feature gets implemented :)


Thank you!