### PR TITLE
Remove escaping of notifications on Linux

### DIFF
--- a/ts/services/notifications.ts
+++ b/ts/services/notifications.ts
@@ -9,7 +9,6 @@ import {
   getAudioNotificationSupport,
   shouldHideExpiringMessageBody,
 } from '../types/Settings';
-import * as OS from '../OS';
 import * as log from '../logging/log';
 import { makeEnumParser } from '../util/enum';
 import { missingCaseError } from '../util/missingCaseError';
@@ -145,7 +144,7 @@ class NotificationService extends EventEmitter {
     const audioNotificationSupport = getAudioNotificationSupport();
 
     const notification = new window.Notification(title, {
-      body: OS.isLinux() ? filterNotificationText(message) : message,
+      body: message,
       icon,
       silent:
         silent || audioNotificationSupport !== AudioNotificationSupport.Native,
@@ -386,12 +385,3 @@ class NotificationService extends EventEmitter {
 }
 
 export const notificationService = new NotificationService();
-
-function filterNotificationText(text: string) {
-  return (text || '')
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}


### PR DESCRIPTION
Notifications on Linux were showing escaped versions of HTML entities (e.g. `&apos;` instead of `'`), see issue #6193.

Remove the escaping for Linux which matches the behavior for other platforms as the Notifications API does not expect escaped HTML. Fixes #6193.

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

### Description

Fixes #6193: notifications on Linux display unescaped HTML characters.

I did not setup my dev environment to test this nor write any new tests. That was beyond the time I was willing to spend on this fix at this point.