### PR TITLE
Close story editor's link preview on outside click

### DIFF
--- a/ts/components/TextStoryCreator.tsx
+++ b/ts/components/TextStoryCreator.tsx
@@ -251,6 +251,29 @@ export function TextStoryCreator({
     }
   );
 
+  useEffect(() => {
+    if (!isLinkPreviewInputShowing) {
+      return noop;
+    }
+    return handleOutsideClick(
+      () => {
+        setIsLinkPreviewInputShowing(false);
+        return true;
+      },
+      {
+        containerElements: [
+          linkPreviewInputPopperRef,
+          linkPreviewInputPopperButtonRef,
+        ],
+        name: 'TextStoryCreator.linkPreview',
+      }
+    );
+  }, [
+    isLinkPreviewInputShowing,
+    linkPreviewInputPopperButtonRef,
+    linkPreviewInputPopperRef,
+  ]);
+
   useEscapeHandling(
     useCallback(() => {
       if (isColorPickerShowing || isEditingText || isLinkPreviewInputShowing) {

--- a/ts/components/TextStoryCreator.tsx
+++ b/ts/components/TextStoryCreator.tsx
@@ -161,6 +161,26 @@ export function TextStoryCreator({
   const [colorPickerPopperRef, setColorPickerPopperRef] =
     useState<HTMLDivElement | null>(null);
 
+  const [toolsRef, setToolsRef] = useState<HTMLDivElement | null>(null);
+  const [controlTextButtonRef, setControlTextButtonRef] =
+    useState<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!isEditingText) {
+      return noop;
+    }
+    return handleOutsideClick(
+      () => {
+        setIsEditingText(false);
+        return true;
+      },
+      {
+        containerElements: [toolsRef, controlTextButtonRef],
+        name: 'TextStoryCreator.fontEditor',
+      }
+    );
+  }, [toolsRef, controlTextButtonRef, isEditingText]);
+
   const colorPickerPopper = usePopper(
     colorPickerPopperButtonRef,
     colorPickerPopperRef,
@@ -359,7 +379,7 @@ export function TextStoryCreator({
         </div>
         <div className="StoryCreator__toolbar">
           {isEditingText ? (
-            <div className="StoryCreator__tools">
+            <div className="StoryCreator__tools" ref={setToolsRef}>
               <Slider
                 handleStyle={{ backgroundColor: getRGBA(sliderValue) }}
                 label={getRGBA(sliderValue)}
@@ -534,6 +554,7 @@ export function TextStoryCreator({
                   setIsEditingText(!isEditingText);
                 }}
                 type="button"
+                ref={setControlTextButtonRef}
               />
               <button
                 aria-label={i18n('StoryCreator__control--link')}

--- a/ts/components/TextStoryCreator.tsx
+++ b/ts/components/TextStoryCreator.tsx
@@ -34,6 +34,7 @@ import { objectMap } from '../util/objectMap';
 import { handleOutsideClick } from '../util/handleOutsideClick';
 import { ConfirmDiscardDialog } from './ConfirmDiscardDialog';
 import { Spinner } from './Spinner';
+import { useEscapeHandling } from '../hooks/useEscapeHandling';
 
 export type PropsType = {
   debouncedMaybeGrabLinkPreview: (
@@ -250,40 +251,23 @@ export function TextStoryCreator({
     }
   );
 
-  useEffect(() => {
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        if (
-          isColorPickerShowing ||
-          isEditingText ||
-          isLinkPreviewInputShowing
-        ) {
-          setIsColorPickerShowing(false);
-          setIsEditingText(false);
-          setIsLinkPreviewInputShowing(false);
-        } else {
-          onTryClose();
-        }
-        event.preventDefault();
-        event.stopPropagation();
+  useEscapeHandling(
+    useCallback(() => {
+      if (isColorPickerShowing || isEditingText || isLinkPreviewInputShowing) {
+        setIsColorPickerShowing(false);
+        setIsEditingText(false);
+        setIsLinkPreviewInputShowing(false);
+      } else {
+        onTryClose();
       }
-    };
-
-    const useCapture = true;
-    document.addEventListener('keydown', handleEscape, useCapture);
-
-    return () => {
-      document.removeEventListener('keydown', handleEscape, useCapture);
-    };
-  }, [
-    isColorPickerShowing,
-    isEditingText,
-    isLinkPreviewInputShowing,
-    colorPickerPopperButtonRef,
-    showConfirmDiscardModal,
-    setShowConfirmDiscardModal,
-    onTryClose,
-  ]);
+    }, [
+      isColorPickerShowing,
+      isEditingText,
+      isLinkPreviewInputShowing,
+      onTryClose,
+    ]),
+    true
+  );
 
   useEffect(() => {
     if (!isColorPickerShowing) {

--- a/ts/hooks/useEscapeHandling.ts
+++ b/ts/hooks/useEscapeHandling.ts
@@ -3,7 +3,10 @@
 
 import { useEffect } from 'react';
 
-export function useEscapeHandling(handleEscape?: () => unknown): void {
+export function useEscapeHandling(
+  handleEscape?: () => unknown,
+  useCapture?: boolean
+): void {
   useEffect(() => {
     if (!handleEscape) {
       return;
@@ -17,10 +20,10 @@ export function useEscapeHandling(handleEscape?: () => unknown): void {
         event.stopPropagation();
       }
     };
-    document.addEventListener('keydown', handler);
+    document.addEventListener('keydown', handler, useCapture);
 
     return () => {
-      document.removeEventListener('keydown', handler);
+      document.removeEventListener('keydown', handler, useCapture);
     };
-  }, [handleEscape]);
+  }, [handleEscape, useCapture]);
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
  *(They fail due to the issue described in #5832)*
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #6207 

This PR adds an event handler to clicks outside of the link preview popup in the story editor to close the corresponding popup. During implementation, I noticed that the font editor serves a similar purpose despite being implemented differently. Most importantly, it's opened by clicks into / next to the story itself. I decided to add a similar event handler nonetheless, but it's in a separate commit, so it can be easily removed from this PR if desired.
