### PR TITLE
Fix timestamp tests on computers with non-US locales

### DIFF
--- a/ts/test-both/util/timestamp_test.ts
+++ b/ts/test-both/util/timestamp_test.ts
@@ -21,6 +21,22 @@ import {
 
 const FAKE_NOW = new Date('2020-01-23T04:56:00.000');
 
+// Force locale of toLocaleTimeString to be US in order to
+// have reproducible outputs
+let dateToLocaleTimeStringStub: sinon.SinonStub;
+before(() => {
+  const original = Date.prototype.toLocaleTimeString;
+  dateToLocaleTimeStringStub = sinon
+    .stub(Date.prototype, 'toLocaleTimeString')
+    // `function` necessary here to pass along the `this` parameter
+    .callsFake(function fakeToLocaleTimeString(this: Date, _, options) {
+      return original.apply(this, [['en-US'], options]);
+    });
+});
+after(() => {
+  dateToLocaleTimeStringStub.restore();
+});
+
 describe('timestamp', () => {
   function useFakeTimers() {
     let sandbox: sinon.SinonSandbox;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #5832 by mocking the underlying `Date.prototype.toLocaleTimeString` function and overriding the provided locale to `en-US`. Since all other parameters are just passed on to the original unmocked function, no other functionality is modified.

`yarn ready` still doesn't work on my machine because https://github.com/signalapp/Signal-Desktop/blob/6a81b339b8409d18b4f185911b7714fb28c1a81d/ts/test-both/util/startTimeTravelDetector_test.ts#L19 is timeouting, but that was also happening while the timestamp tests were failing and they're no longer failing on my computer.