### PR TITLE
ts:scripts: Use SOURCE_DATE_EPOCH env if available

### DIFF
--- a/ts/scripts/get-expire-time.ts
+++ b/ts/scripts/get-expire-time.ts
@@ -8,7 +8,7 @@ import { writeFileSync } from 'fs';
 import { DAY } from '../util/durations';
 
 const unixTimestamp = parseInt(
-  execSync('git show -s --format=%ct').toString('utf8'),
+  process.env.SOURCE_DATE_EPOCH || execSync('git show -s --format=%ct').toString('utf8'),
   10
 );
 const buildCreation = unixTimestamp * 1000;


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

For packaging you want to use the SOURCE_DATE_EPOCH environment variable as release tarballs don't inlcude git information. The variable is widely available on different distributions.

Details: https://reproducible-builds.org/docs/source-date-epoch/