### PR TITLE
Add ability to send an image as view-once

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -6123,10 +6123,6 @@
     "message": "Visit link",
     "description": "Title for the link preview tooltip"
   },
-  "ViewOnce--invalid": {
-    "message": "View-once message is invalid",
-    "description": "Error string if the view-once message is invalid"
-  },
   "ViewOnce--invalidAttachmentTypeError": {
     "message": "View-once attachment type is invalid",
     "description": "Error string if the view-once attachment is invalid"
@@ -6134,18 +6130,6 @@
   "ViewOnce--tooManyAttachments": {
     "message": "You cannot send more than one attachment as view-once",
     "description": "Error string if user sends more than one attachment at once in view-once"
-  },
-  "ViewOnceSettingButton--title": {
-    "message": "View-once settings",
-    "description": "Title for the view-once toggle setting button"
-  },
-  "ViewOnceSettingButton--view-once-title": {
-    "message": "Send as View-once media",
-    "description": "Title for the view-once option in the view-once toggle settings"
-  },
-  "ViewOnceSettingButton--view-forever-title": {
-    "message": "Send as attachment",
-    "description": "Title for the attachment option in the view-once toggle settings"
   },
   "Quote__story": {
     "message": "Story",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1103,6 +1103,10 @@
     "message": "Message",
     "description": "Placeholder text in the message entry field"
   },
+  "sendViewOnceMedia": {
+    "message": "View-Once Media",
+    "description": "Shown in place of message input text when View-once mode is toggled"
+  },
   "groupMembers": {
     "message": "Group members"
   },
@@ -6118,6 +6122,30 @@
   "TextAttachment__preview__link": {
     "message": "Visit link",
     "description": "Title for the link preview tooltip"
+  },
+  "ViewOnce--invalid": {
+    "message": "View-once message is invalid",
+    "description": "Error string if the view-once message is invalid"
+  },
+  "ViewOnce--invalidAttachmentTypeError": {
+    "message": "View-once attachment type is invalid",
+    "description": "Error string if the view-once attachment is invalid"
+  },
+  "ViewOnce--tooManyAttachments": {
+    "message": "You cannot send more than one attachment as view-once",
+    "description": "Error string if user sends more than one attachment at once in view-once"
+  },
+  "ViewOnceSettingButton--title": {
+    "message": "View-once settings",
+    "description": "Title for the view-once toggle setting button"
+  },
+  "ViewOnceSettingButton--view-once-title": {
+    "message": "Send as View-once media",
+    "description": "Title for the view-once option in the view-once toggle settings"
+  },
+  "ViewOnceSettingButton--view-forever-title": {
+    "message": "Send as attachment",
+    "description": "Title for the attachment option in the view-once toggle settings"
   },
   "Quote__story": {
     "message": "Story",

--- a/stylesheets/components/CompositionArea.scss
+++ b/stylesheets/components/CompositionArea.scss
@@ -49,6 +49,17 @@
       margin-right: 12px;
     }
   }
+  
+  &__view-once {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-grow: 1;
+    margin: {
+      bottom: 6px;
+    }
+  }
+
   &__send-button {
     display: flex;
     justify-content: center;

--- a/stylesheets/components/ViewOnceSettingButton.scss
+++ b/stylesheets/components/ViewOnceSettingButton.scss
@@ -1,0 +1,60 @@
+// Copyright 2022 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+.ViewOnceSettingButton {
+    &__button {
+      @include button-reset();
+      align-items: center;
+      border-radius: 4px;
+      display: flex;
+      height: 32px;
+      justify-content: center;
+      width: 32px;
+  
+      outline: none;
+  
+      &::after {
+        content: '';
+        display: block;
+        flex-shrink: 0;
+        height: 24px;
+        width: 24px;
+  
+        @include light-theme {
+          @include color-svg('../images/icons/v2/hq-solid-24.svg', $color-gray-75);
+        }
+        @include dark-theme {
+          @include color-svg('../images/icons/v2/hq-solid-24.svg', $color-gray-15);
+        }
+      }
+  
+      &--toggled {
+        &::after {
+          @include light-theme {
+            @include color-svg(
+              '../images/icons/v2/view-once-24.svg',
+              $color-gray-75
+            );
+          }
+          @include dark-theme {
+            @include color-svg(
+              '../images/icons/v2/view-once-24.svg',
+              $color-gray-15
+            );
+          }
+        }
+      }
+  
+      &--active {
+        opacity: 1;
+  
+        @include light-theme() {
+          background-color: $color-gray-05;
+        }
+  
+        @include dark-theme() {
+          background-color: $color-gray-75;
+        }
+      }
+    }
+  }

--- a/stylesheets/manifest.scss
+++ b/stylesheets/manifest.scss
@@ -131,4 +131,5 @@
 @import './components/TimelineWarnings.scss';
 @import './components/TitleBarContainer.scss';
 @import './components/Toast.scss';
+@import './components/ViewOnceSettingButton.scss';
 @import './components/WhatsNew.scss';

--- a/ts/components/CompositionArea.tsx
+++ b/ts/components/CompositionArea.tsx
@@ -416,7 +416,6 @@ export function CompositionArea({
       {showViewOnceToggle ? (
         <div className="CompositionArea__button-cell">
           <ViewOnceSettingButton
-            i18n={i18n}
             isViewOnceToggled={shouldSendAsViewOnce}
             onViewOnceButtonToggle={onViewOnceToggle}
           />

--- a/ts/components/CompositionArea.tsx
+++ b/ts/components/CompositionArea.tsx
@@ -36,9 +36,8 @@ import { AttachmentList } from './conversation/AttachmentList';
 import type {
   AttachmentDraftType,
   InMemoryAttachmentDraftType,
-  isVideoAttachment,
 } from '../types/Attachment';
-import { isImageAttachment } from '../types/Attachment';
+import { isImageAttachment, isVideoAttachment } from '../types/Attachment';
 import { AudioCapture } from './conversation/AudioCapture';
 import { CompositionUpload } from './CompositionUpload';
 import type {

--- a/ts/components/ToastViewOnceAttachmentError.tsx
+++ b/ts/components/ToastViewOnceAttachmentError.tsx
@@ -1,0 +1,18 @@
+// Copyright 2022 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import React from 'react';
+import type { LocalizerType } from '../types/Util';
+import { Toast } from './Toast';
+
+type PropsType = {
+  i18n: LocalizerType;
+  onClose: () => unknown;
+};
+
+export function ToastViewOnceAttachmentError({
+  i18n,
+  onClose,
+}: PropsType): JSX.Element {
+  return <Toast onClose={onClose}>{i18n('ViewOnce--invalidAttachmentTypeError')}</Toast>;
+}

--- a/ts/components/ToastViewOnceTooManyAttachmentsError.tsx
+++ b/ts/components/ToastViewOnceTooManyAttachmentsError.tsx
@@ -1,0 +1,18 @@
+// Copyright 2022 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import React from 'react';
+import type { LocalizerType } from '../types/Util';
+import { Toast } from './Toast';
+
+type PropsType = {
+  i18n: LocalizerType;
+  onClose: () => unknown;
+};
+
+export function ToastViewOnceTooManyAttachmentsError({
+  i18n,
+  onClose,
+}: PropsType): JSX.Element {
+  return <Toast onClose={onClose}>{i18n('ViewOnce--tooManyAttachments')}</Toast>;
+}

--- a/ts/components/ViewOnceSettingButton.tsx
+++ b/ts/components/ViewOnceSettingButton.tsx
@@ -1,0 +1,45 @@
+// Copyright 2022 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import React from 'react';
+import classNames from 'classnames';
+import { Manager, Reference } from 'react-popper';
+import type { LocalizerType } from '../types/Util';
+import { useRefMerger } from '../hooks/useRefMerger';
+
+export type PropsType = {
+  i18n: LocalizerType;
+  isViewOnceToggled: boolean;
+  onViewOnceButtonToggle: (isVO: boolean) => unknown;
+};
+
+export function ViewOnceSettingButton({
+  i18n,
+  isViewOnceToggled,
+  onViewOnceButtonToggle,
+}: PropsType): JSX.Element {
+  const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+  const refMerger = useRefMerger();
+
+  const handleClick = () => {
+    onViewOnceButtonToggle(!isViewOnceToggled);
+  };
+
+  return (
+    <Manager>
+      <Reference>
+        {({ ref }) => (
+          <button
+            className={classNames({
+              ViewOnceSettingButton__button: true,
+              'ViewOnceSettingButton__button--toggled': isViewOnceToggled,
+            })}
+            onClick={handleClick}
+            ref={refMerger(buttonRef, ref)}
+            type="button"
+          />
+        )}
+      </Reference>
+    </Manager>
+  );
+}

--- a/ts/components/ViewOnceSettingButton.tsx
+++ b/ts/components/ViewOnceSettingButton.tsx
@@ -8,7 +8,6 @@ import type { LocalizerType } from '../types/Util';
 import { useRefMerger } from '../hooks/useRefMerger';
 
 export type PropsType = {
-  i18n: LocalizerType;
   isViewOnceToggled: boolean;
   onViewOnceButtonToggle: (isVO: boolean) => unknown;
 };

--- a/ts/components/conversation/AttachmentList.tsx
+++ b/ts/components/conversation/AttachmentList.tsx
@@ -22,6 +22,7 @@ export type Props<T extends AttachmentType | AttachmentDraftType> = Readonly<{
   attachments: ReadonlyArray<T>;
   canEditImages?: boolean;
   i18n: LocalizerType;
+  viewOnceAttachment?: boolean;
   onAddAttachment?: () => void;
   onClickAttachment?: (attachment: T) => void;
   onClose?: () => void;
@@ -53,6 +54,7 @@ export function AttachmentList<T extends AttachmentType | AttachmentDraftType>({
   attachments,
   canEditImages,
   i18n,
+  viewOnceAttachment,
   onAddAttachment,
   onClickAttachment,
   onCloseAttachment,
@@ -145,7 +147,7 @@ export function AttachmentList<T extends AttachmentType | AttachmentDraftType>({
             />
           );
         })}
-        {allVisualAttachments && onAddAttachment ? (
+        {!viewOnceAttachment && allVisualAttachments && onAddAttachment ? (
           <StagedPlaceholderAttachment onClick={onAddAttachment} i18n={i18n} />
         ) : null}
       </div>

--- a/ts/jobs/helpers/sendNormalMessage.ts
+++ b/ts/jobs/helpers/sendNormalMessage.ts
@@ -157,6 +157,7 @@ export async function sendNormalMessage(
       storyMessage,
       storyContext,
       reaction,
+      isViewOnce,
     } = await getMessageSendData({ log, message });
 
     if (reaction) {
@@ -221,6 +222,7 @@ export async function sendNormalMessage(
         storyContext,
         timestamp: messageTimestamp,
         reaction,
+        isViewOnce,
       });
       messageSendPromise = message.sendSyncMessageOnly(dataMessage, saveErrors);
     } else {
@@ -267,6 +269,7 @@ export async function sendNormalMessage(
                 reaction,
                 timestamp: messageTimestamp,
                 mentions,
+                isViewOnce,
               },
               messageId,
               sendOptions,
@@ -324,6 +327,7 @@ export async function sendNormalMessage(
           // Note: 1:1 story replies should not set story=true -   they aren't group sends
           urgent: true,
           includePniSignatureMessage: true,
+          isViewOnce,
         });
       }
 
@@ -476,6 +480,7 @@ async function getMessageSendData({
   reaction: ReactionType | undefined;
   storyMessage?: MessageModel;
   storyContext?: StoryContextType;
+  isViewOnce?: boolean;
 }> {
   const {
     loadAttachmentData,
@@ -501,6 +506,8 @@ async function getMessageSendData({
   }
 
   const storyId = message.get('storyId');
+  
+  const isViewOnce = message.get('isViewOnce');
 
   const [attachmentsWithData, contact, preview, quote, sticker, storyMessage] =
     await Promise.all([
@@ -553,6 +560,7 @@ async function getMessageSendData({
           remove: false,
         }
       : undefined,
+    isViewOnce,
   };
 }
 

--- a/ts/models/conversations.ts
+++ b/ts/models/conversations.ts
@@ -4054,7 +4054,7 @@ export class ConversationModel extends window.Backbone
 
     // If there are link previews present in the message we shouldn't include
     // any attachments as well.
-    const attachmentsToSend = preview && preview.length ? [] : attachments;
+    let attachmentsToSend = preview && preview.length ? [] : attachments;
 
     if (preview && preview.length) {
       attachments.forEach(attachment => {

--- a/ts/models/conversations.ts
+++ b/ts/models/conversations.ts
@@ -3990,12 +3990,14 @@ export class ConversationModel extends window.Backbone
       sendHQImages,
       storyId,
       timestamp,
+      isViewOnce,
       extraReduxActions,
     }: {
       dontClearDraft?: boolean;
       sendHQImages?: boolean;
       storyId?: string;
       timestamp?: number;
+      isViewOnce?: boolean;
       extraReduxActions?: () => void;
     } = {}
   ): Promise<MessageAttributesType | undefined> {

--- a/ts/state/ducks/composer.ts
+++ b/ts/state/ducks/composer.ts
@@ -94,6 +94,7 @@ const SET_FOCUS = 'composer/SET_FOCUS';
 const SET_HIGH_QUALITY_SETTING = 'composer/SET_HIGH_QUALITY_SETTING';
 const SET_QUOTED_MESSAGE = 'composer/SET_QUOTED_MESSAGE';
 const SET_COMPOSER_DISABLED = 'composer/SET_COMPOSER_DISABLED';
+const SET_VIEW_ONCE_SETTING = 'composer/SET_VIEW_ONCE_SETTING';
 
 type AddPendingAttachmentActionType = {
   type: typeof ADD_PENDING_ATTACHMENT;

--- a/ts/state/selectors/message.ts
+++ b/ts/state/selectors/message.ts
@@ -707,7 +707,7 @@ const getShallowPropsForMessage = createSelectorCreator(memoizeByRoot, isEqual)(
       isTapToView: isMessageTapToView,
       isTapToViewError:
         isMessageTapToView && isIncoming(message) && message.isTapToViewInvalid,
-      isTapToViewExpired: isMessageTapToView && message.isErased,
+      isTapToViewExpired: (isMessageTapToView && message.isErased) || !isIncoming(message),
       readStatus: message.readStatus ?? ReadStatus.Read,
       selectedReaction,
       status: getMessagePropStatus(message, ourConversationId),

--- a/ts/state/smart/CompositionArea.tsx
+++ b/ts/state/smart/CompositionArea.tsx
@@ -76,6 +76,7 @@ const mapStateToProps = (state: StateType, props: ExternalProps) => {
     messageCompositionId,
     quotedMessage,
     shouldSendHighQualityAttachments,
+    shouldSendAsViewOnce,
   } = state.composer;
 
   const recentEmojis = selectRecentEmojis(state);
@@ -103,6 +104,8 @@ const mapStateToProps = (state: StateType, props: ExternalProps) => {
       shouldSendHighQualityAttachments !== undefined
         ? shouldSendHighQualityAttachments
         : window.storage.get('sent-media-quality') === 'high',
+    // ViewOnceSettingButton
+    shouldSendAsViewOnce,
     // StagedLinkPreview
     linkPreviewLoading,
     linkPreviewResult,

--- a/ts/state/smart/ConversationView.tsx
+++ b/ts/state/smart/ConversationView.tsx
@@ -37,6 +37,7 @@ export type PropsType = {
     | 'onCloseLinkPreview'
     | 'onEditorStateChange'
     | 'onSelectMediaQuality'
+    | 'onViewOnceToggle'
     | 'onTextTooLong'
   >;
   conversationHeaderProps: ConversationHeaderPropsType;

--- a/ts/util/isValidViewOnceMessage.ts
+++ b/ts/util/isValidViewOnceMessage.ts
@@ -1,0 +1,47 @@
+// Copyright 2022 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { MessageAttributesType } from '../model-types';
+
+export function canMessageBeViewOnce(message: MessageAttributesType): 
+    boolean {
+
+    if(message.isViewOnce !== true){
+        return false;
+    }
+
+    // Checks taken from isValidTapToView()
+    const body = message.body;
+    if (body) {
+        return false;
+    }
+
+    const attachments = message.attachments;
+    if (!attachments || attachments.length !== 1) {
+        return false;
+    }
+
+    const firstAttachment = attachments[0];
+    if (
+        !window.Signal.Util.GoogleChrome.isImageTypeSupported(
+        firstAttachment.contentType
+        ) &&
+        !window.Signal.Util.GoogleChrome.isVideoTypeSupported(
+        firstAttachment.contentType
+        )
+    ) {
+        return false;
+    }
+
+    if (
+        message.quote ||
+        message.sticker ||
+        (message.contact && message.contact.length > 0) ||
+        (message.preview && message.preview.length > 0)
+    ) {
+        return false;
+    }
+
+    // All checks passed, return true
+    return true;
+}

--- a/ts/util/showToast.tsx
+++ b/ts/util/showToast.tsx
@@ -38,6 +38,8 @@ import type { ToastTapToViewExpiredIncoming } from '../components/ToastTapToView
 import type { ToastTapToViewExpiredOutgoing } from '../components/ToastTapToViewExpiredOutgoing';
 import type { ToastVoiceNoteLimit } from '../components/ToastVoiceNoteLimit';
 import type { ToastVoiceNoteMustBeOnlyAttachment } from '../components/ToastVoiceNoteMustBeOnlyAttachment';
+import type { ToastViewOnceAttachmentError } from '../components/ToastViewOnceAttachmentError';
+import type { ToastViewOnceTooManyAttachmentsError } from '../components/ToastViewOnceTooManyAttachmentsError';
 
 export function showToast(Toast: typeof ToastAlreadyGroupMember): void;
 export function showToast(Toast: typeof ToastAlreadyRequestedToJoin): void;

--- a/ts/util/showToast.tsx
+++ b/ts/util/showToast.tsx
@@ -76,6 +76,9 @@ export function showToast(Toast: typeof ToastVoiceNoteLimit): void;
 export function showToast(
   Toast: typeof ToastVoiceNoteMustBeOnlyAttachment
 ): void;
+export function showToast(Toast: typeof ToastViewOnceAttachmentError): void;
+export function showToast(Toast: typeof ToastViewOnceTooManyAttachmentsError): void;
+export function showToast(Toast: typeof ToastViewOnceInvalidError): void;
 
 // eslint-disable-next-line max-len
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types

--- a/ts/util/showToast.tsx
+++ b/ts/util/showToast.tsx
@@ -78,7 +78,6 @@ export function showToast(
 ): void;
 export function showToast(Toast: typeof ToastViewOnceAttachmentError): void;
 export function showToast(Toast: typeof ToastViewOnceTooManyAttachmentsError): void;
-export function showToast(Toast: typeof ToastViewOnceInvalidError): void;
 
 // eslint-disable-next-line max-len
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types

--- a/ts/views/conversation_view.tsx
+++ b/ts/views/conversation_view.tsx
@@ -354,7 +354,11 @@ export class ConversationView extends window.Backbone.View<ConversationModel> {
       onSelectMediaQuality: (isHQ: boolean) => {
         window.reduxActions.composer.setMediaQualitySetting(isHQ);
       },
-
+      
+      onViewOnceToggle: (isVO: boolean) => {
+        window.reduxActions.composer.setViewOnceSetting(isVO);
+      },
+      
       onCloseLinkPreview: () => {
         suspendLinkPreviews();
         removeLinkPreview();


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [ ] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

### Description

This PR aims to add the ability to send images as view-once on desktop directly. 

I am not a developer, just someone who really wanted this feature to be done, so I have very little experience in any of this. The codebase is new to me, so it is likely I have done something wrong or improperly. I added the files in this branch by hand (I have issues using git...) so let me know if I accidentally made a mistake/forgot to add something.

I can answer questions on why I did something a certain way but I have reached the limits of my knowledge with this PR and can't continue further on my own, and I hope that one day that the developers will continue working on this. Thanks!

#### Screenshots
![image](https://user-images.githubusercontent.com/120066692/208801151-2a652c9c-b3e2-4fa6-b970-fcd57ca53513.png)
![image](https://user-images.githubusercontent.com/120066692/208801161-f2433287-9916-49eb-bb56-c82d4d937017.png)

#### Design considerations
- The View-once is a simple click-to-toggle button. The "unactivated" icon is the "high quality media" icon as of now because of the lack of 'x∞' icon as of today which will have to be created.
- The text field gets removed if view-once mode is selected to prevent users to type anything
- The view-once setting button gets shown only if there is one (and only one) attachment selected. If any text is entered, or audio recorded etc. then the button will disappear
- I made it so that users cannot drag attachments in the view-once mode to prevent sending multiple since this should not be possible
#### Things I've tested
- The x1 messages sync properly between devices and can be sent to any device on stable right now seemingly without issues
- I manually tried messing with the UI to see if it possible to break the feature by adding text or anything to the view-once message. This looks fine but I could've definitely missed something
#### Things I haven't tested
- It looks like from my implementation that the x1 messages only delete if a synced device is present (since the erasing call is in sendSyncMessages()). I haven't tested sending x1 messages with a standalone device, but since Desktop apps cannot be standalone right now this might not be an issue
- I have poor understanding of the backend code, so I don't know what classifies as a "correct" view-once message. I added checks to make sure a view-once message (when isViewOnce is set to true) can't contain text etc. but I don't know if it's enough. This needs to be looked at.
#### Things left to be done
- A proper review, obviously this is a large commit and it should be looked at thoroughly to see if there are any mistakes
- I may have accidentally left in useless code, or did a poor implementation which can be improved
- Testing with Mocha. I didn't know where to start or how to do testing so I have not implemented any.
