### PR TITLE
Updated message for attaching multiple non-image files

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -673,6 +673,10 @@
     "message": "You can't select photos and videos along with files.",
     "description": "An error popup when the user has attempted to add an attachment"
   },
+  "cannotSelectMultipleNonImageAttachments": {
+    "message": "You can only select one non-image attachment.",
+    "description": "An error popup when the user has attempted to add multiple non-image attachments"
+  },
   "maximumAttachments": {
     "message": "You cannot add any more attachments to this message.",
     "description": "An error popup when the user has attempted to add an attachment"

--- a/ts/components/ToastManager.tsx
+++ b/ts/components/ToastManager.tsx
@@ -228,7 +228,7 @@ export function ToastManager({
   if (toastType === ToastType.UnsupportedMultiAttachment) {
     return (
       <Toast onClose={hideToast}>
-        {i18n('cannotSelectPhotosAndVideosAlongWithFiles')}
+        {i18n('cannotSelectMultipleNonImageAttachments')}
       </Toast>
     );
   }


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X ] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

This PR fixes #6220, as an error message saying "You can't select photos and videos along with files." would appear when a single non-image file was a draft attachment, and a second non-image file was attempted to be attached. This adds a new message that indicates "You can only select one non-image attachment" when the previously mentioned scenario occurs.

Manual test was done by first attaching an image as an attachment draft, then uploading a PDF file to guarantee original "You can't select photos and videos along with files." functionality still worked. Then attached a single test PDF as an draft attachment, followed by an attempt to attach another PDF. This yielded the intended "You can only select one non-image attachment" , both outlined by the screenshots linked below. No new tests were written.

Screenshots of the fix can be seen here: https://imgur.com/a/XHtUXZU

Thanks & Happy Holidays!
