### PR TITLE
Added a method to better update the state of enabling/disabling link …

### DIFF
--- a/ts/services/LinkPreview.ts
+++ b/ts/services/LinkPreview.ts
@@ -41,6 +41,10 @@ export function suspendLinkPreviews(): void {
   disableLinkPreviews = true;
 }
 
+export function resumeLinkPreviews(): void {
+  disableLinkPreviews = false;
+}
+
 export function hasLinkPreviewLoaded(): boolean {
   return Boolean(linkPreviewResult);
 }

--- a/ts/state/ducks/conversations.ts
+++ b/ts/state/ducks/conversations.ts
@@ -136,6 +136,7 @@ import { startConversation } from '../../util/startConversation';
 import { UUIDKind } from '../../types/UUID';
 import {
   removeLinkPreview,
+  resumeLinkPreviews,
   suspendLinkPreviews,
 } from '../../services/LinkPreview';
 import type {
@@ -3622,6 +3623,8 @@ function onConversationOpened(
     }
 
     drop(conversation.updateVerified());
+
+    resumeLinkPreviews();
 
     replaceAttachments(
       conversation.get('id'),


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Fixes #6270. Link states were not being properly handled, as when a chat window was closed the link preview would go into a "suspended" state and not re-enable until a reset event occurred (which is seen in the workarounds outlined in the original ticket). This fix adds a new method that simply updates the state of the link preview (to true) whenever a conversation is opened.

An original attempt to use the preexisting ```resetLinkPreview()``` method but due to the logic it contains it only caused more issues, thus a new method of ```resumeLinkPreview()``` was created.

A manual test was done with the following steps & [screenshots](https://imgur.com/a/MIC38YL):
1. Launch Signal & open a new conversation
2. Paste a link in the composition area
3. Confirm the link preview loads and is displayed
4. Switch to another coversation
5. Paste a new link
6. Confirm the link preview loads and is displayed
7. Switch back to the original chat (step 2), and confirm that the original preview is still loaded.

After these tests, the "Generate Link Preview" setting was also disabled to confirm the changes didn't interfere, and they didn't. No previews are generated.

Thanks for your time, cheers!
 