### PR TITLE
Focus the text input box after successfully attaching a file

### DIFF
--- a/ts/state/ducks/composer.ts
+++ b/ts/state/ducks/composer.ts
@@ -1031,6 +1031,7 @@ export function replaceAttachments(
         attachments: attachments.map(resolveDraftAttachmentOnDisk),
       },
     });
+    dispatch(setComposerFocus(conversationId));
   };
 }
 


### PR DESCRIPTION
 Fixes #6284 - does not focus immediately (so as to avoid stealing
 focus) and does not focus if the file browser is cancelled.
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Since there is no Send button, this makes it easier and reduces frustration when adding attachments.
Currently a user must manually click on the text input box or shift-tab to focus it and then press Enter to send.
This change automatically focuses the text input box if an attachment has been added, allowing users to just press Enter.

Manually tested on Ubuntu 22 64-bit / Gnome. No new tests since I can't find good examples of tests for
similarly small UX-related changes, though I'm happy to do so.
