### PR TITLE
Fix keyboard search when left pane is narrow

### DIFF
--- a/ts/components/LeftPane.stories.tsx
+++ b/ts/components/LeftPane.stories.tsx
@@ -104,7 +104,7 @@ const defaultModeSpecificProps = {
   pinnedConversations,
   conversations: defaultConversations,
   archivedConversations: defaultArchivedConversations,
-  isAboutToSearchInAConversation: false,
+  isAboutToSearch: false,
 };
 
 const emptySearchResultsGroup = { isLoading: false, results: [] };
@@ -278,7 +278,7 @@ export function InboxNoConversations(): JSX.Element {
           pinnedConversations: [],
           conversations: [],
           archivedConversations: [],
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
         },
       })}
     />
@@ -299,7 +299,7 @@ export function InboxOnlyPinnedConversations(): JSX.Element {
           pinnedConversations,
           conversations: [],
           archivedConversations: [],
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
         },
       })}
     />
@@ -320,7 +320,7 @@ export function InboxOnlyNonPinnedConversations(): JSX.Element {
           pinnedConversations: [],
           conversations: defaultConversations,
           archivedConversations: [],
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
         },
       })}
     />
@@ -341,7 +341,7 @@ export function InboxOnlyArchivedConversations(): JSX.Element {
           pinnedConversations: [],
           conversations: [],
           archivedConversations: defaultArchivedConversations,
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
         },
       })}
     />
@@ -362,7 +362,7 @@ export function InboxPinnedAndArchivedConversations(): JSX.Element {
           pinnedConversations,
           conversations: [],
           archivedConversations: defaultArchivedConversations,
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
         },
       })}
     />
@@ -383,7 +383,7 @@ export function InboxNonPinnedAndArchivedConversations(): JSX.Element {
           pinnedConversations: [],
           conversations: defaultConversations,
           archivedConversations: defaultArchivedConversations,
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
         },
       })}
     />
@@ -404,7 +404,7 @@ export function InboxPinnedAndNonPinnedConversations(): JSX.Element {
           pinnedConversations,
           conversations: defaultConversations,
           archivedConversations: [],
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
         },
       })}
     />
@@ -946,7 +946,7 @@ export function CaptchaDialogRequired(): JSX.Element {
           pinnedConversations,
           conversations: defaultConversations,
           archivedConversations: [],
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
           searchTerm: '',
         },
         challengeStatus: 'required',
@@ -969,7 +969,7 @@ export function CaptchaDialogPending(): JSX.Element {
           pinnedConversations,
           conversations: defaultConversations,
           archivedConversations: [],
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
           searchTerm: '',
         },
         challengeStatus: 'pending',
@@ -991,7 +991,7 @@ export const _CrashReportDialog = (): JSX.Element => (
         pinnedConversations,
         conversations: defaultConversations,
         archivedConversations: [],
-        isAboutToSearchInAConversation: false,
+        isAboutToSearch: false,
         searchTerm: '',
       },
       crashReportCount: 42,
@@ -1163,7 +1163,7 @@ export function SearchingConversation(): JSX.Element {
           pinnedConversations: [],
           conversations: defaultConversations,
           archivedConversations: [],
-          isAboutToSearchInAConversation: false,
+          isAboutToSearch: false,
           searchConversation: getDefaultConversation(),
           searchTerm: '',
         },

--- a/ts/components/leftPane/LeftPaneInboxHelper.tsx
+++ b/ts/components/leftPane/LeftPaneInboxHelper.tsx
@@ -24,7 +24,7 @@ export type LeftPaneInboxPropsType = {
   conversations: ReadonlyArray<ConversationListItemPropsType>;
   archivedConversations: ReadonlyArray<ConversationListItemPropsType>;
   pinnedConversations: ReadonlyArray<ConversationListItemPropsType>;
-  isAboutToSearchInAConversation: boolean;
+  isAboutToSearch: boolean;
   startSearchCounter: number;
   searchDisabled: boolean;
   searchTerm: string;
@@ -38,7 +38,7 @@ export class LeftPaneInboxHelper extends LeftPaneHelper<LeftPaneInboxPropsType> 
 
   private readonly pinnedConversations: ReadonlyArray<ConversationListItemPropsType>;
 
-  private readonly isAboutToSearchInAConversation: boolean;
+  private readonly isAboutToSearch: boolean;
 
   private readonly startSearchCounter: number;
 
@@ -52,7 +52,7 @@ export class LeftPaneInboxHelper extends LeftPaneHelper<LeftPaneInboxPropsType> 
     conversations,
     archivedConversations,
     pinnedConversations,
-    isAboutToSearchInAConversation,
+    isAboutToSearch,
     startSearchCounter,
     searchDisabled,
     searchTerm,
@@ -63,7 +63,7 @@ export class LeftPaneInboxHelper extends LeftPaneHelper<LeftPaneInboxPropsType> 
     this.conversations = conversations;
     this.archivedConversations = archivedConversations;
     this.pinnedConversations = pinnedConversations;
-    this.isAboutToSearchInAConversation = isAboutToSearchInAConversation;
+    this.isAboutToSearch = isAboutToSearch;
     this.startSearchCounter = startSearchCounter;
     this.searchDisabled = searchDisabled;
     this.searchTerm = searchTerm;
@@ -245,7 +245,7 @@ export class LeftPaneInboxHelper extends LeftPaneHelper<LeftPaneInboxPropsType> 
       !this.conversations.length &&
       !this.pinnedConversations.length &&
       !this.archivedConversations.length;
-    return hasNoConversations || this.isAboutToSearchInAConversation;
+    return hasNoConversations || this.isAboutToSearch;
   }
 
   shouldRecomputeRowHeights(old: Readonly<LeftPaneInboxPropsType>): boolean {

--- a/ts/state/ducks/search.ts
+++ b/ts/state/ducks/search.ts
@@ -57,6 +57,7 @@ export type MessageSearchResultLookupType = ReadonlyDeep<{
 export type SearchStateType = ReadonlyDeep<{
   startSearchCounter: number;
   searchConversationId?: string;
+  globalSearch?: boolean;
   contactIds: Array<string>;
   conversationIds: Array<string>;
   query: string;
@@ -94,7 +95,7 @@ type UpdateSearchTermActionType = ReadonlyDeep<{
 }>;
 type StartSearchActionType = ReadonlyDeep<{
   type: 'SEARCH_START';
-  payload: null;
+  payload: { globalSearch: boolean };
 }>;
 type ClearSearchActionType = ReadonlyDeep<{
   type: 'SEARCH_CLEAR';
@@ -137,7 +138,7 @@ export const actions = {
 function startSearch(): StartSearchActionType {
   return {
     type: 'SEARCH_START',
-    payload: null,
+    payload: { globalSearch: true },
   };
 }
 function clearSearch(): ClearSearchActionType {
@@ -341,6 +342,7 @@ export function reducer(
     return {
       ...state,
       searchConversationId: undefined,
+      globalSearch: true,
       startSearchCounter: state.startSearchCounter + 1,
     };
   }

--- a/ts/state/selectors/search.ts
+++ b/ts/state/selectors/search.ts
@@ -54,6 +54,23 @@ export const getIsSearchingInAConversation = createSelector(
   Boolean
 );
 
+export const getGlobalSearchValue = createSelector(
+  getSearch,
+  (state: SearchStateType): boolean | undefined => state.globalSearch
+);
+
+export const getIsSearchingGlobally = createSelector(
+  getGlobalSearchValue,
+  Boolean
+);
+
+export const getIsSearching = createSelector(
+  getIsSearchingInAConversation,
+  getIsSearchingGlobally,
+  (isSearchingInAConversation, isSearchingGlobally): boolean =>
+    isSearchingInAConversation || isSearchingGlobally
+);
+
 export const getSearchConversation = createSelector(
   getSearchConversationId,
   getConversationLookup,

--- a/ts/state/selectors/search.ts
+++ b/ts/state/selectors/search.ts
@@ -54,14 +54,9 @@ export const getIsSearchingInAConversation = createSelector(
   Boolean
 );
 
-export const getGlobalSearchValue = createSelector(
-  getSearch,
-  (state: SearchStateType): boolean | undefined => state.globalSearch
-);
-
 export const getIsSearchingGlobally = createSelector(
-  getGlobalSearchValue,
-  Boolean
+  getSearch,
+  (state: SearchStateType): boolean => Boolean(state.globalSearch)
 );
 
 export const getIsSearching = createSelector(

--- a/ts/state/smart/LeftPane.tsx
+++ b/ts/state/smart/LeftPane.tsx
@@ -16,7 +16,7 @@ import { isDone as isRegistrationDone } from '../../util/registration';
 
 import { ComposerStep, OneTimeModalState } from '../ducks/conversationsEnums';
 import {
-  getIsSearchingInAConversation,
+  getIsSearching,
   getQuery,
   getSearchConversation,
   getSearchResults,
@@ -152,7 +152,7 @@ const getModeSpecificProps = (
       }
       return {
         mode: LeftPaneMode.Inbox,
-        isAboutToSearchInAConversation: getIsSearchingInAConversation(state),
+        isAboutToSearch: getIsSearching(state),
         searchConversation: getSearchConversation(state),
         searchDisabled: state.network.challengeStatus !== 'idle',
         searchTerm: getQuery(state),

--- a/ts/test-both/state/selectors/search_test.ts
+++ b/ts/test-both/state/selectors/search_test.ts
@@ -14,6 +14,8 @@ import type { MessageSearchResultType } from '../../../state/ducks/search';
 import { getEmptyState as getEmptySearchState } from '../../../state/ducks/search';
 import { getEmptyState as getEmptyUserState } from '../../../state/ducks/user';
 import {
+  getIsSearching,
+  getIsSearchingGlobally,
   getIsSearchingInAConversation,
   getMessageSearchResultSelector,
   getSearchResults,
@@ -90,6 +92,61 @@ describe('both/state/selectors/search', () => {
       };
 
       assert.isTrue(getIsSearchingInAConversation(state));
+    });
+  });
+
+  describe('#getIsSearchingGlobally', () => {
+    it('returns false if not searching', () => {
+      const state = getEmptyRootState();
+
+      assert.isFalse(getIsSearchingGlobally(state));
+    });
+
+    it('returns true if searching globally', () => {
+      const state = {
+        ...getEmptyRootState(),
+        search: {
+          ...getEmptySearchState(),
+          globalSearch: true,
+        },
+      };
+
+      assert.isTrue(getIsSearchingGlobally(state));
+    });
+  });
+
+  describe('#getIsSearching', () => {
+    it('returns false if not searching in any manner', () => {
+      const state = getEmptyRootState();
+
+      assert.isFalse(getIsSearching(state));
+    });
+
+    it('returns true if searching in a conversation', () => {
+      const state = {
+        ...getEmptyRootState(),
+        search: {
+          ...getEmptySearchState(),
+          searchConversationId: 'abc123',
+          searchConversationName: 'Test Conversation',
+          globalSearch: false,
+        },
+      };
+
+      assert.isTrue(getIsSearching(state));
+    });
+
+    it('returns true if searching globally', () => {
+      const state = {
+        ...getEmptyRootState(),
+        search: {
+          ...getEmptySearchState(),
+          searchConversationId: undefined,
+          globalSearch: true,
+        },
+      };
+
+      assert.isTrue(getIsSearchingGlobally(state));
     });
   });
 

--- a/ts/test-node/components/leftPane/LeftPaneInboxHelper_test.tsx
+++ b/ts/test-node/components/leftPane/LeftPaneInboxHelper_test.tsx
@@ -14,7 +14,7 @@ describe('LeftPaneInboxHelper', () => {
   const defaultProps: LeftPaneInboxPropsType = {
     archivedConversations: [],
     conversations: [],
-    isAboutToSearchInAConversation: false,
+    isAboutToSearch: false,
     pinnedConversations: [],
     searchConversation: undefined,
     searchDisabled: false,
@@ -616,7 +616,7 @@ describe('LeftPaneInboxHelper', () => {
     it("returns true if we're about to search in a conversation", () => {
       const helper = new LeftPaneInboxHelper({
         ...defaultProps,
-        isAboutToSearchInAConversation: true,
+        isAboutToSearch: true,
       });
 
       assert.isTrue(helper.requiresFullWidth());


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Fixes #6281

This PR fixes Cmd+f/Ctrl+f functionality in the left pane. Using a keyboard to search across all
conversations should now automatically change the left pane width to accommodate the search input component.

I made an assumption that when a user searches globally, the behavior of the left pane should be similar to when a user searches within a single conversation.

To do so, I chose to create a new value in state called `globalSearch`. I'm not super happy with the name, but I don't have any better ideas. Another approach that seems to work and avoids adding a new value in state would be to assign any string to `searchConversationId` that doesn't match a real conversation, e.g. `searchConversationId: 'global'`, but that seemed less clear than having a dedicated variable.

https://user-images.githubusercontent.com/3917726/220584444-126b5c0d-cd08-4596-bc56-d42d36ca96af.mov

### Other thoughts/bugs related to search

Although these are out-of-scope for this PR, I noticed a few things while working on this issue that I wanted to capture. I'll break these out into new issues later, assuming none of the Signal maintainers have strong feelings against the proposals.

1. Deleting the conversation avatar (via clicking the 'x' or using the delete/backspace keys) when searching within a conversation could change the input field from a conversation search to a global search instead of closing the left pane immediately (assuming that the original width of the left pane was in its narrow state).
2. Update other helpers (e.g. Stories and Compose) to work similarly to Inbox. Currently cmd+f doesn't give focus to the input field in any of the helpers other than `LeftPaneInboxHelper`
3. `SEARCH_CLEAR` is getting called twice in a row when the user stops searching. I think it's getting called in both the `onBlur` and the `onClear` handlers in `LeftPaneSearchInput.tsx` ([lines 101 and 118](https://github.com/signalapp/Signal-Desktop/blob/main/ts/components/LeftPaneSearchInput.tsx#L101)), but that should be validated.
