### PR TITLE
Disable ctrl+alt+/ from showing shortcut guide

### DIFF
--- a/ts/background.ts
+++ b/ts/background.ts
@@ -1289,7 +1289,7 @@ export async function startApp(): Promise<void> {
     });
 
     document.addEventListener('keydown', event => {
-      const { ctrlKey, metaKey, shiftKey } = event;
+      const { ctrlKey, metaKey, shiftKey, altKey } = event;
 
       const commandKey = window.platform === 'darwin' && metaKey;
       const controlKey = window.platform !== 'darwin' && ctrlKey;
@@ -1305,7 +1305,7 @@ export async function startApp(): Promise<void> {
 
       // Show keyboard shortcuts - handled by Electron-managed keyboard shortcuts
       // However, on linux Ctrl+/ selects all text, so we prevent that
-      if (commandOrCtrl && key === '/') {
+      if (commandOrCtrl && !altKey && key === '/') {
         window.Events.showKeyboardShortcuts();
 
         event.stopPropagation();


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #6214 

This PR allows showing the shortcut guide when pressing ctrl+/ without also allowing ctrl+alt+/.