### PR TITLE
Fixed draft removal upon sending a sticker

### DIFF
--- a/ts/models/conversations.ts
+++ b/ts/models/conversations.ts
@@ -3972,11 +3972,14 @@ export class ConversationModel extends window.Backbone
     };
 
     drop(
-      this.enqueueMessageForSend({
-        body: undefined,
-        attachments: [],
-        sticker,
-      })
+      this.enqueueMessageForSend(
+        {
+          body: undefined,
+          attachments: [],
+          sticker,
+        },
+        { dontClearDraft: true }
+      )
     );
     window.reduxActions.stickers.useSticker(packId, stickerId);
   }


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #6310. Quick one liner to ensure the current draft test doesn't get cleared when the a sticker gets enqueued to be sent. Manually tested to confirm the expected result occurs, but also that regular messaging/drafting wasn't impacted by this change. Cheers!