### PR TITLE
Fixed empty copying overwriting clipboard

### DIFF
--- a/ts/quill/signal-clipboard/index.ts
+++ b/ts/quill/signal-clipboard/index.ts
@@ -67,7 +67,7 @@ export class SignalClipboard {
 
     const { ops } = contents;
 
-    if (ops === undefined) {
+    if (ops === undefined || !ops.length) {
       return;
     }
 

--- a/ts/quill/signal-clipboard/index.ts
+++ b/ts/quill/signal-clipboard/index.ts
@@ -67,7 +67,7 @@ export class SignalClipboard {
 
     const { ops } = contents;
 
-    if (ops === undefined || !ops.length) {
+    if (!ops || !ops.length) {
       return;
     }
 


### PR DESCRIPTION
### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #6315. If there is no selection when a copy action is executed, there will be no overwriting of the clipboard. Manual testing was done to ensure that copying functionality was otherwise unaffected including successful the copying & pasting of white space. Cheers!
