### PR TITLE
Fix alignment of the conversation pill in search input

### DIFF
--- a/stylesheets/components/LeftPaneSearchInput.scss
+++ b/stylesheets/components/LeftPaneSearchInput.scss
@@ -10,13 +10,13 @@
     @include button-reset;
     @include rounded-corners;
     align-items: center;
-    bottom: 3px;
+    bottom: 4px;
     display: flex;
     flex-direction: row;
     left: 3px;
     padding: 0 3px 0 0;
     position: absolute;
-    top: 5px;
+    top: 4px;
 
     @include light-theme {
       background-color: $color-gray-25;


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

In the process of reducing avatar sizes (3a246656e3dc3b9b01d3c0a162a23a423afee43b), the vertical centering of the conversation pill (chip) in the search input was broken. This PR restore conversation pill vertical centering by correcting corresponding `bottom` and `top` CSS properties.

Before the fix:
![image](https://user-images.githubusercontent.com/4142906/222800335-ca422ca4-0e76-4b03-b12d-ee3e65efa734.png)

After the fix:
![image](https://user-images.githubusercontent.com/4142906/222798772-b3fc52ef-2e06-40fd-8803-7c7e731e581e.png)