### PR TITLE
Clarify directory for additional storage profiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ empty application. But you can use the information from your production install 
 Desktop to populate your testing application!
 
 First, exit both production and development apps (In macOS - literally quit the apps).
-Second, find your application data in the [userData](https://www.electronjs.org/docs/latest/api/app#appgetpathname) directory:
+Second, find your application data in the [appData](https://www.electronjs.org/docs/latest/api/app#appgetpathname) directory:
 
 - macOS: `~/Library/Application Support/Signal`
 - Linux: `~/.config/Signal`
@@ -150,7 +150,7 @@ Once you have the additional numbers, you can setup additional storage profiles 
 between them using the `NODE_APP_INSTANCE` environment variable.
 
 For example, to create an 'alice' profile, put a file called `local-alice.json` in the
-`config` directory for the `NODE_CONFIG_DIR` environment variable, not `userData` from above:
+`config` directory, a child of the Signal directory, not `appData` from above:
 
 ```
 {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ empty application. But you can use the information from your production install 
 Desktop to populate your testing application!
 
 First, exit both production and development apps (In macOS - literally quit the apps).
-Second, find your application data:
+Second, find your application data in the `userData` directory:
 
 - macOS: `~/Library/Application Support/Signal`
 - Linux: `~/.config/Signal`
@@ -150,7 +150,7 @@ Once you have the additional numbers, you can setup additional storage profiles 
 between them using the `NODE_APP_INSTANCE` environment variable.
 
 For example, to create an 'alice' profile, put a file called `local-alice.json` in the
-`config` directory:
+`config` directory for the `NODE_CONFIG_DIR` environment variable, not `userData` from above:
 
 ```
 {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ empty application. But you can use the information from your production install 
 Desktop to populate your testing application!
 
 First, exit both production and development apps (In macOS - literally quit the apps).
-Second, find your application data in the `userData` directory:
+Second, find your application data in the [userData](https://www.electronjs.org/docs/latest/api/app#appgetpathname) directory:
 
 - macOS: `~/Library/Application Support/Signal`
 - Linux: `~/.config/Signal`
@@ -164,8 +164,7 @@ Then you can start up the application a little differently to load the profile:
 NODE_APP_INSTANCE=alice yarn run start
 ```
 
-This changes the [userData](https://electron.atom.io/docs/all/#appgetpathname)
-directory from `%appData%/Signal` to `%appData%/Signal-aliceProfile`.
+This changes the `userData` directory from `%appData%/Signal` to `%appData%/Signal-aliceProfile`.
 
 # Making changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Once you have the additional numbers, you can setup additional storage profiles 
 between them using the `NODE_APP_INSTANCE` environment variable.
 
 For example, to create an 'alice' profile, put a file called `local-alice.json` in the
-`config` directory, a child of the Signal directory, not `appData` from above:
+`/config` subdirectory of your project checkout where you'll find other `.json` config files:
 
 ```
 {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

The existing instructions help us to create multiple additional storage profiles with `NODE_APP_INSTANCE.` However, it was not immediately clear where to find the `config` directory, as there is a config.json in `userData,` and for Linux the data directory is in `.config.` Therefore, some minor adjustments can clarify potential points of confusion.