### PR TITLE
Adapt install screen to dark theme

### DIFF
--- a/stylesheets/components/InstallScreenQrCodeNotScannedStep.scss
+++ b/stylesheets/components/InstallScreenQrCodeNotScannedStep.scss
@@ -8,7 +8,6 @@
     $base-max-width: 760px;
 
     align-items: center;
-    background: $color-white;
     border-radius: 8px;
     color: $color-black;
     display: flex;
@@ -20,11 +19,14 @@
     @include light-theme {
       max-width: $base-max-width;
       padding: 22px;
+      background-color: $color-gray-15;
     }
 
     @include dark-theme {
       max-width: $base-max-width + 44px;
       padding: 44px;
+      background-color: $color-gray-80;
+      color: $color-white;
       margin-top: 44px; // Avoids overlap with the Signal logo
     }
   }
@@ -43,8 +45,12 @@
     min-width: $size;
     width: $size;
 
+    animation: 1s module-InstallScreenQrCodeNotScannedStep__slide-in;
+
     &--loaded {
-      background: $color-white;
+      padding: 12px;
+      border-radius: 8px;
+      background-color: $color-white;
     }
 
     &--load-failed {
@@ -57,7 +63,6 @@
     &__code {
       height: $size;
       width: $size;
-      animation: 1s module-InstallScreenQrCodeNotScannedStep__slide-in;
       position: relative;
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Addresses #6344 by adapting the Install Screen to the dark theme. The current implementation has a huge white banner across a black background, which is jarring for dark mode users. The current implementation also has different padding for the light and dark modes; I'm not sure why that is, but I opted to leave that code alone for now.

Tested on Mac OS by flipping between system appearance modes.
