### PR TITLE
Fix overlapped navigation divs that break zoom in Lightbox

### DIFF
--- a/stylesheets/components/Lightbox.scss
+++ b/stylesheets/components/Lightbox.scss
@@ -189,11 +189,10 @@
   &__nav-next,
   &__nav-prev {
     position: absolute;
-    top: 0;
+    top: 50%;
+    transform: translateY(-50%);
     display: flex;
     flex-direction: column;
-    width: 25%;
-    height: 100%;
     justify-content: center;
 
     // We need this so that the buttons stack above the container
@@ -327,24 +326,23 @@
 
     &--previous,
     &--next {
-      width: 100%;
-      height: 100%;
-      max-width: 96px;
-      max-height: 224px;
+      width: 48px;
+      height: 48px;
       opacity: 0;
       transition: opacity 200ms ease-in-out;
+      flex-shrink: 0;
 
       display: flex;
       flex-direction: row;
       align-items: center;
 
+      &.show {
+        opacity: 1;
+      }
+
       &::before {
         width: 32px;
         height: 32px;
-      }
-
-      &:hover {
-        opacity: 1;
       }
 
       outline: none;

--- a/ts/util/lint/exceptions.json
+++ b/ts/util/lint/exceptions.json
@@ -2115,6 +2115,13 @@
   {
     "rule": "React-useRef",
     "path": "ts/components/Lightbox.tsx",
+    "line": "  const zoomableContainerRef = useRef<HTMLDivElement | null>(null);",
+    "reasonCategory": "usageTrusted",
+    "updated": "2023-04-11T19:20:47.381Z"
+  },
+  {
+    "rule": "React-useRef",
+    "path": "ts/components/Lightbox.tsx",
     "line": "  const imageRef = useRef<HTMLImageElement | null>(null);",
     "reasonCategory": "usageTrusted",
     "updated": "2021-09-24T00:03:36.061Z"


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #6357

The current implementation of the next and previous buttons in the media preview lightbox overlaps divs on top of the left fourth and right fourth of the zoomable container. When the user hovers one of the divs, the respective next/previous button is given `opacity: 1`.

This implementation is flawed, because the overlapping div steals the pointer event away from the zoomable container. If the user clicks one of these overlapping divs (which take up a significant portion of the zoomable container), the lightbox is closed. Even if we use JS to pass the click event to the zoomable container, the overlapping divs would still be showing the wrong cursor because of the style conflict. Although setting `pointer-events: none` on the overlapping divs and `pointer-events: auto` on the nav buttons may seem like a solution, those styles still break zoom functionality where the overlapping divs are placed.

I have settled on using a `mousemove` event to detect if the mouse is on the left or the right side of the zoomable container, and giving the nav buttons `opacity: 1` if so.

I have tested this with various image and window sizes on Mac OS.