### PR TITLE
Fix overflow in Chat Settings -> Conversation Color

### DIFF
--- a/stylesheets/_mixins.scss
+++ b/stylesheets/_mixins.scss
@@ -573,13 +573,13 @@
 @mixin color-bubble($bubble-size) {
   background-clip: content-box;
   border-color: transparent;
-  border-radius: $bubble-size + 12px;
+  border-radius: $bubble-size;
   border-style: solid;
   border-width: 4px;
   cursor: pointer;
-  height: $bubble-size + 12px;
+  height: $bubble-size;
   padding: 2px;
-  width: $bubble-size + 12px;
+  width: $bubble-size;
 
   @each $color, $value in $conversation-colors {
     &--#{$color} {

--- a/stylesheets/components/ChatColorPicker.scss
+++ b/stylesheets/components/ChatColorPicker.scss
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 .ChatColorPicker {
-  $bubble-size: 40px;
+  $bubble-size: 52px;
 
   &__container {
     max-width: 748px;

--- a/stylesheets/components/ConversationDetails.scss
+++ b/stylesheets/components/ConversationDetails.scss
@@ -71,7 +71,7 @@
   }
 
   &__chat-color {
-    @include color-bubble(20px);
+    @include color-bubble(32px);
   }
 
   &-membership-list,

--- a/stylesheets/components/CustomColorEditor.scss
+++ b/stylesheets/components/CustomColorEditor.scss
@@ -16,7 +16,7 @@
   }
 
   &__gradient-knob {
-    @include color-bubble(30px);
+    @include color-bubble(42px);
     cursor: move;
     position: absolute;
   }

--- a/stylesheets/components/GradientDial.scss
+++ b/stylesheets/components/GradientDial.scss
@@ -33,7 +33,7 @@
   }
 
   &__knob {
-    @include color-bubble(30px);
+    @include color-bubble(42px);
     box-shadow: 0 0 4px $color-black-alpha-20;
     cursor: move;
     margin-left: -20px;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #6359.

The `color-bubble` mixin was adding 12px to the provided `bubble-size`, but the style of the grid element in the conversation color picker was not compensating for this. I have removed the 12px addition from the mixin and instead increased all `bubble-sizes` by 12px. This fixes the overflow issue in the color picker grid.

I tested this on Mac OS with multiple window sizes.
