### PR TITLE
Fix padding in compositor for RTL langauges

### DIFF
--- a/stylesheets/components/CompositionInput.scss
+++ b/stylesheets/components/CompositionInput.scss
@@ -4,7 +4,7 @@
 .module-composition-input {
   &__quill {
     height: 100%;
-    padding-inline-start: 12px;
+    padding-inline: 12px;
 
     .ql-editor {
       caret-color: transparent;


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Padding is missing in compositor for RTL languages.

Wrong:
![image](https://github.com/signalapp/Signal-Desktop/assets/4103710/95ad26ce-8e2e-4d7d-8d28-61758c85c6c7)
Right:
![image](https://github.com/signalapp/Signal-Desktop/assets/4103710/ada8bf98-da17-42b3-96fb-5722d9781472)

