### PR TITLE
Fix a bug that Lightbox navs(the left/right arrows) cover video player control

### DIFF
--- a/stylesheets/components/Lightbox.scss
+++ b/stylesheets/components/Lightbox.scss
@@ -191,7 +191,6 @@
   &__nav-prev {
     --height: 224px;
     position: absolute;
-    top: calc(50% - var(--height) / 2);
     width: 25%;
     max-width: 96px;
     height: var(--height);


### PR DESCRIPTION
 ### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes [#6424](https://github.com/signalapp/Signal-Desktop/issues/6424)

This PR fixes that the issue "Some video player controls are not clickable because of left / right arrows".
It's caused because Lightbox navs(the left/right arrows) cover video player control.
I fix a part of css not to cover video player control

 I tested it with Signal Desktop for macOS Monterey 12.6.5, Apple M1.
[screenshot.mp.4](https://github.com/signalapp/Signal-Desktop/assets/44369261/5efb2592-9384-465f-a039-03cb53928d5f)