### PR TITLE
Fix: Focus at the end of the pasted contents instead of the beginning

### DIFF
--- a/ts/quill/signal-clipboard/index.ts
+++ b/ts/quill/signal-clipboard/index.ts
@@ -72,7 +72,6 @@ export class SignalClipboard {
         this.quill.updateContents(delta, 'user');
         this.quill.setSelection(delta.length() - selection.length, 0, 'silent');
         this.quill.scrollingContainer.scrollTop = scrollTop;
-
         this.quill.focus();
       }, 1);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

When pasting a long text into the composition input, it does not scroll down to the end of the pasted text--it stays at the beginning instead. This PR changes this behaviour so that the input quill will automatically focus at the end of the text instead (i.e. scroll to the bottom of the pasted text)

I found that the problem emerged because the code calls `this.quill.focus()` *before* updating the contents of the quill, not after, so it would scroll to where the cursor was before the pasted text was being added, and not where it is after pasting the text. Simply calling `this.quill.focus()` *after* updating the contents seems to solve the problem.

This fixes https://community.signalusers.org/t/when-pasting-mutliple-lines-jump-scroll-input-field-to-last-pasted-line/51677

#### Edit:

Here is a visual explanation of the change:
Before pasting (notice that the cursor is between two words):
![beforepasting](https://github.com/signalapp/Signal-Desktop/assets/120066692/121f0579-343e-4f50-b652-5c2cb99f86f4)

After pasting, before the fix:
![afterpastingnofix](https://github.com/signalapp/Signal-Desktop/assets/120066692/fab7ece4-e85f-4d8d-880c-426f120eef5b)

After pasting with the fix:
![afterpastingfix](https://github.com/signalapp/Signal-Desktop/assets/120066692/b9e64319-35d3-44b6-bd45-56531d36628e)

