### PR TITLE
Show Signal window when clicking on group call notification

### DIFF
--- a/ts/services/calling.ts
+++ b/ts/services/calling.ts
@@ -2290,6 +2290,7 @@ export class CallingClass {
       icon: 'images/icons/v3/video/video-fill.svg',
       message: notificationMessage,
       onNotificationClick: () => {
+        window.IPC.showWindow();
         this.reduxInterface?.startCallingLobby({
           conversationId: conversation.id,
           isVideoCall: true,


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

This PR ensures that the Signal window is brought to the front when clicking on the group call notification for "silent" (notification only) call. Fixes #6406
