### PR TITLE
Specify border color of quote when quoted file is not found

### DIFF
--- a/stylesheets/components/Quote.scss
+++ b/stylesheets/components/Quote.scss
@@ -398,6 +398,7 @@
   border-bottom-right-radius: 4px;
   border-inline-start-style: solid;
   border-left-width: 4px;
+  border-color: white;
   padding-inline: 8px;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

There sometimes is a visual problem where the quote border becomes black on the "Original file not found part", like so:
![beforenotfound2](https://github.com/signalapp/Signal-Desktop/assets/120066692/3d789e4b-66ec-4173-b05e-fd9c16d0734a)

I can't 100% fully reproduce which is odd, but it does happen sometimes (moreso with light theme?) so I added CSS to explicitly specify the border color on the appropriate element and make sure it can't happen anymore: 
![afternotfound2](https://github.com/signalapp/Signal-Desktop/assets/120066692/bce10599-b0fe-46dd-b9cd-a59b35ec6a24)

Note that both light theme and dark these use `#FFFFFF` for this border so I didn't feel the need to consider the individual cases
