### PR TITLE
Don't close sticker picker if shift is pressed when sending stickers

### DIFF
--- a/ts/components/stickers/StickerButton.tsx
+++ b/ts/components/stickers/StickerButton.tsx
@@ -106,22 +106,6 @@ export const StickerButton = React.memo(function StickerButtonInner({
     setOpen,
   ]);
 
-  const handlePickSticker = React.useCallback(
-    (packId: string, stickerId: number, url: string) => {
-      setOpen(false);
-      onPickSticker(packId, stickerId, url);
-    },
-    [setOpen, onPickSticker]
-  );
-
-  const handlePickTimeSticker = React.useCallback(
-    (style: 'analog' | 'digital') => {
-      setOpen(false);
-      onPickTimeSticker?.(style);
-    },
-    [setOpen, onPickTimeSticker]
-  );
-
   const handleClose = React.useCallback(() => {
     setOpen(false);
   }, [setOpen]);
@@ -367,10 +351,8 @@ export const StickerButton = React.memo(function StickerButtonInner({
                     onClickAddPack={
                       onClickAddPack ? handleClickAddPack : undefined
                     }
-                    onPickSticker={handlePickSticker}
-                    onPickTimeSticker={
-                      onPickTimeSticker ? handlePickTimeSticker : undefined
-                    }
+                    onPickSticker={onPickSticker}
+                    onPickTimeSticker={onPickTimeSticker}
                     recentStickers={recentStickers}
                     showPickerHint={showPickerHint}
                   />

--- a/ts/components/stickers/StickerPicker.tsx
+++ b/ts/components/stickers/StickerPicker.tsx
@@ -92,8 +92,11 @@ export const StickerPicker = React.memo(
         tabIds[recentStickers.length > 0 ? 0 : Math.min(1, tabIds.length)]
       );
       const selectedPack = packs.find(({ id }) => id === currentTab);
+      // Prevent recent stickers from re-rendering each time the user sends a sticker
+      // while keeping the sticker picker open (using Shift).
+      const recentStickersRef = React.useRef(recentStickers);
       const {
-        stickers = recentStickers,
+        stickers = recentStickersRef.current,
         title: packTitle = 'Recent Stickers',
       } = selectedPack || {};
 
@@ -321,7 +324,12 @@ export const StickerPicker = React.memo(
                         <button
                           type="button"
                           className="module-sticker-picker__body__cell module-sticker-picker__time--digital"
-                          onClick={() => onPickTimeSticker('digital')}
+                          onClick={e => {
+                            if (!e.shiftKey) {
+                              onClose();
+                            }
+                            return onPickTimeSticker('digital');
+                          }}
                         >
                           {getDateTimeFormatter({
                             hour: 'numeric',
@@ -337,7 +345,12 @@ export const StickerPicker = React.memo(
                             'icu:stickers__StickerPicker__analog-time'
                           )}
                           className="module-sticker-picker__body__cell module-sticker-picker__time--analog"
-                          onClick={() => onPickTimeSticker('analog')}
+                          onClick={e => {
+                            if (!e.shiftKey) {
+                              onClose();
+                            }
+                            return onPickTimeSticker('analog');
+                          }}
                           type="button"
                         >
                           <span
@@ -378,7 +391,12 @@ export const StickerPicker = React.memo(
                           ref={maybeFocusRef}
                           key={`${packId}-${id}`}
                           className="module-sticker-picker__body__cell"
-                          onClick={() => onPickSticker(packId, id, url)}
+                          onClick={e => {
+                            if (!e.shiftKey) {
+                              onClose();
+                            }
+                            return onPickSticker(packId, id, url);
+                          }}
                         >
                           <img
                             className="module-sticker-picker__body__cell__image"


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

On the mobile apps, the sticker picker stays open when we send stickers, until we decide to close it. This is useful if you want to send multiple stickers quickly. But on Desktop, the interface has to be different, and currently the sticker picker automatically closes right after sending a sticker. This is nice, but if we want to send multiple stickers quickly, we need to reopen the sticker picker, find the sticker pack we want, resend sticker etc.

This PR adds the ability to prevent the sticker picker from closing when we send a sticker if the shift key is held down.

Things to mention:
 * It also affects the sticker picker in the media editor though I don't see this as an issue I feel that it should be pointed out
 * Since there was already a shortcut making use of shift I simplified the code by "merging" the shiftHeld state with the previous shortcut code to prevent having two separate events handling shift.
 * The recent stickers would update below your eyes if you send recent stickers with the tab still open, so I put them behind a state that only updates when the sticker picker is opened. I have still lots to learn with React so let me know if this is the right thing to do.
