### PR TITLE
Only select message data on triple click

### DIFF
--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -193,6 +193,7 @@ export enum GiftBadgeStates {
   Opened = 'Opened',
   Redeemed = 'Redeemed',
 }
+
 export type GiftBadgeType = {
   expiration: number;
   id: string | undefined;
@@ -389,6 +390,8 @@ export class Message extends React.PureComponent<Props, State> {
   private hasSelectedTextRef: React.MutableRefObject<boolean> = {
     current: false,
   };
+
+  private metadataRef: React.RefObject<HTMLDivElement> = React.createRef();
 
   public reactionsContainerRefMerger = createRefMerger();
 
@@ -823,6 +826,7 @@ export class Message extends React.PureComponent<Props, State> {
         isTapToViewExpired={isTapToViewExpired}
         onWidthMeasured={isInline ? this.updateMetadataWidth : undefined}
         pushPanelForConversation={pushPanelForConversation}
+        ref={this.metadataRef}
         retryMessageSend={retryMessageSend}
         showEditHistoryModal={showEditHistoryModal}
         status={status}
@@ -1779,7 +1783,7 @@ export class Message extends React.PureComponent<Props, State> {
     }
 
     return (
-      <div
+      <div // eslint-disable-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
         className={classNames(
           'module-message__text',
           `module-message__text--${direction}`,
@@ -1790,6 +1794,18 @@ export class Message extends React.PureComponent<Props, State> {
             ? 'module-message__text--delete-for-everyone'
             : null
         )}
+        onClick={e => {
+          // Prevent metadata from being selected on triple clicks.
+          const clickCount = e.detail;
+          const range = window.getSelection()?.getRangeAt(0);
+          if (
+            clickCount === 3 &&
+            this.metadataRef.current &&
+            range?.intersectsNode(this.metadataRef.current)
+          ) {
+            range.setEndBefore(this.metadataRef.current);
+          }
+        }}
         onDoubleClick={(event: React.MouseEvent) => {
           // Prevent double-click interefering with interactions _inside_
           // the bubble.

--- a/ts/components/conversation/MessageMetadata.tsx
+++ b/ts/components/conversation/MessageMetadata.tsx
@@ -1,8 +1,8 @@
 // Copyright 2018 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { ReactChild, ReactElement } from 'react';
-import React, { useCallback, useState } from 'react';
+import type { ReactChild } from 'react';
+import React, { forwardRef, useCallback, useState } from 'react';
 import classNames from 'classnames';
 import type { ContentRect } from 'react-measure';
 import Measure from 'react-measure';
@@ -16,6 +16,7 @@ import { MessageTimestamp } from './MessageTimestamp';
 import { PanelType } from '../../types/Panels';
 import { Spinner } from '../Spinner';
 import { ConfirmationDialog } from '../ConfirmationDialog';
+import { refMerger } from '../../util/refMerger';
 
 type PropsType = {
   deletedForEveryone?: boolean;
@@ -43,46 +44,72 @@ enum ConfirmationType {
   EditError = 'EditError',
 }
 
-export function MessageMetadata({
-  deletedForEveryone,
-  direction,
-  expirationLength,
-  expirationTimestamp,
-  hasText,
-  i18n,
-  id,
-  isEditedMessage,
-  isInline,
-  isShowingImage,
-  isSticker,
-  isTapToViewExpired,
-  onWidthMeasured,
-  pushPanelForConversation,
-  retryMessageSend,
-  showEditHistoryModal,
-  status,
-  textPending,
-  timestamp,
-}: Readonly<PropsType>): ReactElement {
-  const [confirmationType, setConfirmationType] = useState<
-    ConfirmationType | undefined
-  >();
-  const withImageNoCaption = Boolean(!isSticker && !hasText && isShowingImage);
-  const metadataDirection = isSticker ? undefined : direction;
+export const MessageMetadata = forwardRef<HTMLDivElement, Readonly<PropsType>>(
+  function MessageMetadataInner(
+    {
+      deletedForEveryone,
+      direction,
+      expirationLength,
+      expirationTimestamp,
+      hasText,
+      i18n,
+      id,
+      isEditedMessage,
+      isInline,
+      isShowingImage,
+      isSticker,
+      isTapToViewExpired,
+      onWidthMeasured,
+      pushPanelForConversation,
+      retryMessageSend,
+      showEditHistoryModal,
+      status,
+      textPending,
+      timestamp,
+    },
+    ref
+  ) {
+    const [confirmationType, setConfirmationType] = useState<
+      ConfirmationType | undefined
+    >();
+    const withImageNoCaption = Boolean(
+      !isSticker && !hasText && isShowingImage
+    );
+    const metadataDirection = isSticker ? undefined : direction;
 
-  let timestampNode: ReactChild;
-  {
-    const isError = status === 'error' && direction === 'outgoing';
-    const isPartiallySent =
-      status === 'partial-sent' && direction === 'outgoing';
-    const isPaused = status === 'paused';
+    let timestampNode: ReactChild;
+    {
+      const isError = status === 'error' && direction === 'outgoing';
+      const isPartiallySent =
+        status === 'partial-sent' && direction === 'outgoing';
+      const isPaused = status === 'paused';
 
-    if (isError || isPartiallySent || isPaused) {
-      let statusInfo: React.ReactChild;
-      if (isError) {
-        if (deletedForEveryone) {
-          statusInfo = i18n('icu:deleteFailed');
-        } else if (isEditedMessage) {
+      if (isError || isPartiallySent || isPaused) {
+        let statusInfo: React.ReactChild;
+        if (isError) {
+          if (deletedForEveryone) {
+            statusInfo = i18n('icu:deleteFailed');
+          } else if (isEditedMessage) {
+            statusInfo = (
+              <button
+                type="button"
+                className="module-message__metadata__tapable"
+                onClick={(event: React.MouseEvent) => {
+                  event.stopPropagation();
+                  event.preventDefault();
+
+                  setConfirmationType(ConfirmationType.EditError);
+                }}
+              >
+                {i18n('icu:editFailed')}
+              </button>
+            );
+          } else {
+            statusInfo = i18n('icu:sendFailed');
+          }
+        } else if (isPaused) {
+          statusInfo = i18n('icu:sendPaused');
+        } else {
           statusInfo = (
             <button
               type="button"
@@ -91,179 +118,164 @@ export function MessageMetadata({
                 event.stopPropagation();
                 event.preventDefault();
 
-                setConfirmationType(ConfirmationType.EditError);
+                pushPanelForConversation({
+                  type: PanelType.MessageDetails,
+                  args: { messageId: id },
+                });
               }}
             >
-              {i18n('icu:editFailed')}
+              {deletedForEveryone
+                ? i18n('icu:partiallyDeleted')
+                : i18n('icu:partiallySent')}
             </button>
           );
-        } else {
-          statusInfo = i18n('icu:sendFailed');
         }
-      } else if (isPaused) {
-        statusInfo = i18n('icu:sendPaused');
-      } else {
-        statusInfo = (
-          <button
-            type="button"
-            className="module-message__metadata__tapable"
-            onClick={(event: React.MouseEvent) => {
-              event.stopPropagation();
-              event.preventDefault();
 
-              pushPanelForConversation({
-                type: PanelType.MessageDetails,
-                args: { messageId: id },
-              });
-            }}
+        timestampNode = (
+          <span
+            className={classNames({
+              'module-message__metadata__date': true,
+              'module-message__metadata__date--with-sticker': isSticker,
+              'module-message__metadata__date--deleted-for-everyone':
+                deletedForEveryone,
+              [`module-message__metadata__date--${direction}`]: !isSticker,
+              'module-message__metadata__date--with-image-no-caption':
+                withImageNoCaption,
+            })}
           >
-            {deletedForEveryone
-              ? i18n('icu:partiallyDeleted')
-              : i18n('icu:partiallySent')}
-          </button>
+            {statusInfo}
+          </span>
+        );
+      } else {
+        timestampNode = (
+          <MessageTimestamp
+            deletedForEveryone={deletedForEveryone}
+            direction={metadataDirection}
+            i18n={i18n}
+            module="module-message__metadata__date"
+            timestamp={timestamp}
+            withImageNoCaption={withImageNoCaption}
+            withSticker={isSticker}
+            withTapToViewExpired={isTapToViewExpired}
+          />
         );
       }
+    }
 
-      timestampNode = (
-        <span
-          className={classNames({
-            'module-message__metadata__date': true,
-            'module-message__metadata__date--with-sticker': isSticker,
-            'module-message__metadata__date--deleted-for-everyone':
-              deletedForEveryone,
-            [`module-message__metadata__date--${direction}`]: !isSticker,
-            'module-message__metadata__date--with-image-no-caption':
-              withImageNoCaption,
-          })}
+    let confirmation: JSX.Element | undefined;
+    if (confirmationType === undefined) {
+      // no-op
+    } else if (confirmationType === ConfirmationType.EditError) {
+      confirmation = (
+        <ConfirmationDialog
+          dialogName="MessageMetadata.confirmEditResend"
+          actions={[
+            {
+              action: () => {
+                retryMessageSend(id);
+                setConfirmationType(undefined);
+              },
+              style: 'negative',
+              text: i18n('icu:ResendMessageEdit__button'),
+            },
+          ]}
+          i18n={i18n}
+          onClose={() => {
+            setConfirmationType(undefined);
+          }}
         >
-          {statusInfo}
-        </span>
+          {i18n('icu:ResendMessageEdit__body')}
+        </ConfirmationDialog>
       );
     } else {
-      timestampNode = (
-        <MessageTimestamp
-          deletedForEveryone={deletedForEveryone}
-          direction={metadataDirection}
-          i18n={i18n}
-          module="module-message__metadata__date"
-          timestamp={timestamp}
-          withImageNoCaption={withImageNoCaption}
-          withSticker={isSticker}
-          withTapToViewExpired={isTapToViewExpired}
-        />
+      throw missingCaseError(confirmationType);
+    }
+
+    const className = classNames(
+      'module-message__metadata',
+      isInline && 'module-message__metadata--inline',
+      withImageNoCaption && 'module-message__metadata--with-image-no-caption',
+      deletedForEveryone && 'module-message__metadata--deleted-for-everyone'
+    );
+    const children = (
+      <>
+        {isEditedMessage && showEditHistoryModal && (
+          <button
+            className="module-message__metadata__edited"
+            onClick={() => showEditHistoryModal(id)}
+            type="button"
+          >
+            {i18n('icu:MessageMetadata__edited')}
+          </button>
+        )}
+        {timestampNode}
+        {expirationLength ? (
+          <ExpireTimer
+            direction={metadataDirection}
+            deletedForEveryone={deletedForEveryone}
+            expirationLength={expirationLength}
+            expirationTimestamp={expirationTimestamp}
+            withImageNoCaption={withImageNoCaption}
+            withSticker={isSticker}
+            withTapToViewExpired={isTapToViewExpired}
+          />
+        ) : null}
+        {textPending ? (
+          <div className="module-message__metadata__spinner-container">
+            <Spinner svgSize="small" size="14px" direction={direction} />
+          </div>
+        ) : null}
+        {(!deletedForEveryone || status === 'sending') &&
+        !textPending &&
+        direction === 'outgoing' &&
+        status !== 'error' &&
+        status !== 'partial-sent' ? (
+          <div
+            className={classNames(
+              'module-message__metadata__status-icon',
+              `module-message__metadata__status-icon--${status}`,
+              isSticker
+                ? 'module-message__metadata__status-icon--with-sticker'
+                : null,
+              withImageNoCaption
+                ? 'module-message__metadata__status-icon--with-image-no-caption'
+                : null,
+              deletedForEveryone
+                ? 'module-message__metadata__status-icon--deleted-for-everyone'
+                : null,
+              isTapToViewExpired
+                ? 'module-message__metadata__status-icon--with-tap-to-view-expired'
+                : null
+            )}
+          />
+        ) : null}
+        {confirmation}
+      </>
+    );
+
+    const onResize = useCallback(
+      ({ bounds }: ContentRect) => {
+        onWidthMeasured?.(bounds?.width || 0);
+      },
+      [onWidthMeasured]
+    );
+
+    if (onWidthMeasured) {
+      return (
+        <Measure bounds onResize={onResize}>
+          {({ measureRef }) => (
+            <div className={className} ref={refMerger(measureRef, ref)}>
+              {children}
+            </div>
+          )}
+        </Measure>
       );
     }
-  }
 
-  let confirmation: JSX.Element | undefined;
-  if (confirmationType === undefined) {
-    // no-op
-  } else if (confirmationType === ConfirmationType.EditError) {
-    confirmation = (
-      <ConfirmationDialog
-        dialogName="MessageMetadata.confirmEditResend"
-        actions={[
-          {
-            action: () => {
-              retryMessageSend(id);
-              setConfirmationType(undefined);
-            },
-            style: 'negative',
-            text: i18n('icu:ResendMessageEdit__button'),
-          },
-        ]}
-        i18n={i18n}
-        onClose={() => {
-          setConfirmationType(undefined);
-        }}
-      >
-        {i18n('icu:ResendMessageEdit__body')}
-      </ConfirmationDialog>
-    );
-  } else {
-    throw missingCaseError(confirmationType);
-  }
-
-  const className = classNames(
-    'module-message__metadata',
-    isInline && 'module-message__metadata--inline',
-    withImageNoCaption && 'module-message__metadata--with-image-no-caption',
-    deletedForEveryone && 'module-message__metadata--deleted-for-everyone'
-  );
-  const children = (
-    <>
-      {isEditedMessage && showEditHistoryModal && (
-        <button
-          className="module-message__metadata__edited"
-          onClick={() => showEditHistoryModal(id)}
-          type="button"
-        >
-          {i18n('icu:MessageMetadata__edited')}
-        </button>
-      )}
-      {timestampNode}
-      {expirationLength ? (
-        <ExpireTimer
-          direction={metadataDirection}
-          deletedForEveryone={deletedForEveryone}
-          expirationLength={expirationLength}
-          expirationTimestamp={expirationTimestamp}
-          withImageNoCaption={withImageNoCaption}
-          withSticker={isSticker}
-          withTapToViewExpired={isTapToViewExpired}
-        />
-      ) : null}
-      {textPending ? (
-        <div className="module-message__metadata__spinner-container">
-          <Spinner svgSize="small" size="14px" direction={direction} />
-        </div>
-      ) : null}
-      {(!deletedForEveryone || status === 'sending') &&
-      !textPending &&
-      direction === 'outgoing' &&
-      status !== 'error' &&
-      status !== 'partial-sent' ? (
-        <div
-          className={classNames(
-            'module-message__metadata__status-icon',
-            `module-message__metadata__status-icon--${status}`,
-            isSticker
-              ? 'module-message__metadata__status-icon--with-sticker'
-              : null,
-            withImageNoCaption
-              ? 'module-message__metadata__status-icon--with-image-no-caption'
-              : null,
-            deletedForEveryone
-              ? 'module-message__metadata__status-icon--deleted-for-everyone'
-              : null,
-            isTapToViewExpired
-              ? 'module-message__metadata__status-icon--with-tap-to-view-expired'
-              : null
-          )}
-        />
-      ) : null}
-      {confirmation}
-    </>
-  );
-
-  const onResize = useCallback(
-    ({ bounds }: ContentRect) => {
-      onWidthMeasured?.(bounds?.width || 0);
-    },
-    [onWidthMeasured]
-  );
-
-  if (onWidthMeasured) {
     return (
-      <Measure bounds onResize={onResize}>
-        {({ measureRef }) => (
-          <div className={className} ref={measureRef}>
-            {children}
-          </div>
-        )}
-      </Measure>
+      <div className={className} ref={ref}>
+        {children}
+      </div>
     );
   }
-
-  return <div className={className}>{children}</div>;
-}
+);

--- a/ts/util/lint/exceptions.json
+++ b/ts/util/lint/exceptions.json
@@ -2392,6 +2392,14 @@
     "reasonDetail": "Used for propagating click from the Message to MessageAudio's button"
   },
   {
+    "rule": "React-createRef",
+    "path": "ts/components/conversation/Message.tsx",
+    "line": "  private metadataRef: React.RefObject<HTMLDivElement> = React.createRef();",
+    "reasonCategory": "usageTrusted",
+    "updated": "2023-06-30T22:12:49.259Z",
+    "reasonDetail": "Used for excluding the message metadata from triple-click selections."
+  },
+  {
     "rule": "React-useRef",
     "path": "ts/components/conversation/MessageDetail.tsx",
     "line": "  const focusRef = useRef<HTMLDivElement>(null);",


### PR DESCRIPTION
Fixes #6428

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

I'm not sure if the code should exist somewhere else, if so I can move it.
I'm not sure if triple-clicking is a macOS specific functionality or not.  If it is, a check can be added to only enable this change for macOS devices.

Can be tested by opening a conversation and triple-clicking a message.  All text up to the next line break in the message should be selected.  It can then be copied and pasted with only the message text, the timestamp should not be copied or pasted.

I didn't find any existing tests to go off of for the `Message` component, so I didn't write any new tests.

Tested on macOS 13.4.1 (22F82).

https://github.com/signalapp/Signal-Desktop/assets/52075362/a6e69298-4201-4c1d-abaf-6dc2b3049651