### PR TITLE
Fix active chat color when setting default color

### DIFF
--- a/ts/state/smart/TimelineItem.tsx
+++ b/ts/state/smart/TimelineItem.tsx
@@ -5,7 +5,8 @@ import type { RefObject } from 'react';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { TimelineItem } from '../../components/conversation/TimelineItem';
+import type { StateType } from '../reducer';
+import { TimelineItem, TimelineItemType } from '../../components/conversation/TimelineItem';
 import type { WidthBreakpoint } from '../../components/_util';
 import { useProxySelector } from '../../hooks/useProxySelector';
 import { useConversationsActions } from '../ducks/conversations';
@@ -22,6 +23,7 @@ import {
   getTheme,
   getPlatform,
 } from '../selectors/user';
+import { getDefaultConversationColor } from '../selectors/items';
 import { getTargetedMessage } from '../selectors/conversations';
 import { getTimelineItem } from '../selectors/timeline';
 import {
@@ -56,6 +58,14 @@ function renderUniversalTimerNotification(): JSX.Element {
   return <SmartUniversalTimerNotification />;
 }
 
+function getTimelineItemWithMemoParams(
+  state: StateType,
+  id?: string,
+  ..._memoParams: ReadonlyArray<unknown>
+): TimelineItemType | undefined {
+  return getTimelineItem(state, id);
+};
+
 export function SmartTimelineItem(props: ExternalProps): JSX.Element {
   const {
     containerElementRef,
@@ -73,7 +83,13 @@ export function SmartTimelineItem(props: ExternalProps): JSX.Element {
   const interactionMode = useSelector(getInteractionMode);
   const theme = useSelector(getTheme);
   const platform = useSelector(getPlatform);
-  const item = useProxySelector(getTimelineItem, messageId);
+  const defaultConversationColor = useSelector(getDefaultConversationColor);
+  const item = useProxySelector(
+    getTimelineItemWithMemoParams,
+    messageId,
+    defaultConversationColor.color,
+    defaultConversationColor.customColorData?.value
+  );
   const previousItem = useProxySelector(getTimelineItem, previousMessageId);
   const nextItem = useProxySelector(getTimelineItem, nextMessageId);
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

* `yarn ready` results in `test-node` with 1 timeout failure (locale Init.LocaleMatcher should work for locales outside of their region) which also happens to me on `main` at 35d1451e4246e10c102e45c819920f91b087dbb1. `yarn test` is successful.

### Description

Fixes #6423

When a conversation is selected and then the Preferences window is used to update default Chat Color (Preferences -> Appearance -> Chat color), the selected conversation's messages do not update their chat color.

This was happening because in `SmartTimelineItem` a memoized selector cached the old color, which was calculated in the `getTimelineItem` selector from the default color setting.

This patch adds in `SmartTimelineItem` a new function which wraps `getTimelineItem` to take a new argument for watched params for the memo cache. When the watched params (in this case default color) change, the memo will refresh the cached result of `getTimelineItem` correctly.

This approach I'm not sure is the best one but it seemed reasonably simple and isolated to one file. I considered adding additional logic to `useProxySelector` to add watched memo params but didn't want to complicate the helper. I'd be happy to hear feedback on the best approach here. Thanks! :)

#### Manual Testing:
- Open app and select a conversation with messages. Make a new conversation and add messages if needed.
- You should see outgoing chat messages with the default chat color. (There should not be a custom color for this chat.)
- Open the Preferences window and navigate to Appearance and select Chat Color. Choose a new chat color.
- Back in the main window, the conversation's message color should change to the new chat color.

#### Tested on:
- Debian 11
- Windows 10
