### PR TITLE
Replace Audio Message Playback Rate Multipler close icon with multiplication symbol

### DIFF
--- a/stylesheets/components/PlaybackRateButton.scss
+++ b/stylesheets/components/PlaybackRateButton.scss
@@ -46,25 +46,6 @@
   }
 
   &::after {
-    content: '';
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    margin-inline-start: 2px;
-
-    @mixin x-icon($color) {
-      @include color-svg('../images/icons/v3/x/x-compact.svg', $color, false);
-    }
-
-    @include light-theme {
-      @include x-icon($color-gray-60);
-    }
-    @include dark-theme {
-      @include x-icon($color-gray-25);
-    }
-
-    .module-message__audio-attachment--outgoing & {
-      @include x-icon($color-white-alpha-80);
-    }
+    content: '×';
   }
 }


### PR DESCRIPTION
Replaces with typographical "×" character to reduce confusion with close icons elsewhere.

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

The current playback rate multiplier symbol is the x icon used throughout the app as the close symbol.  This creates a component that looks like it has a close button, but cannot be closed.

This PR removes the close icon and replaces it with the typeface's multiplication symbol (unicode: U+00D7) instead!

**Before**
<img width="312" alt="Screenshot 2023-07-20 at 1 55 17 PM" src="https://github.com/signalapp/Signal-Desktop/assets/5672810/b016dc37-16de-43d1-8e34-c149318fe72b">

**After**
<img width="301" alt="Screenshot 2023-07-20 at 1 06 09 PM" src="https://github.com/signalapp/Signal-Desktop/assets/5672810/a6f76679-0856-4c39-bb51-1979bbe87c35">

### Caveats

If accepted, this change should also be applied to the iOS and Android apps... Something that may be beyond my abilities (not a Swift or Java programmer 😅)