### PR TITLE
feat(input): added ascii to emoji conversion

### DIFF
--- a/ts/components/CompositionInput.tsx
+++ b/ts/components/CompositionInput.tsx
@@ -61,12 +61,14 @@ import {
   matchStrikethrough,
 } from '../quill/formatting/matchers';
 import { missingCaseError } from '../util/missingCaseError';
+import { AutoSubstituteAsciiEmojis } from '../quill/auto-substitute-ascii-emojis';
 
 Quill.register('formats/emoji', EmojiBlot);
 Quill.register('formats/mention', MentionBlot);
 Quill.register('formats/block', DirectionalBlot);
 Quill.register('formats/monospace', MonospaceBlot);
 Quill.register('formats/spoiler', SpoilerBlot);
+Quill.register('modules/autoSubstituteAsciiEmojis', AutoSubstituteAsciiEmojis);
 Quill.register('modules/emojiCompletion', EmojiCompletion);
 Quill.register('modules/mentionCompletion', MentionCompletion);
 Quill.register('modules/formattingMenu', FormattingMenu);
@@ -767,6 +769,7 @@ export function CompositionInput(props: Props): React.ReactElement {
                 callbacksRef.current.onPickEmoji(emoji),
               skinTone,
             },
+            autoSubstituteAsciiEmojis: true,
             formattingMenu: {
               i18n,
               isMenuEnabled: isFormattingEnabled,

--- a/ts/quill/auto-substitute-ascii-emojis/index.tsx
+++ b/ts/quill/auto-substitute-ascii-emojis/index.tsx
@@ -1,0 +1,96 @@
+// Copyright 2020 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type Quill from 'quill';
+import Delta from 'quill-delta';
+import _ from 'lodash';
+import type { EmojiData } from '../../components/emoji/lib';
+import {
+  convertShortName,
+  convertShortNameToData,
+} from '../../components/emoji/lib';
+
+type AutoSubstituteAsciiEmojisOptions = {
+  skinTone: number;
+};
+
+const emojiMap: Record<string, string> = {
+  ':)': 'slightly_smiling_face',
+  ':-)': 'slightly_smiling_face',
+  ':(': 'slightly_frowning_face',
+  ':-(': 'slightly_frowning_face',
+  ':D': 'smiley',
+  ':-D': 'smiley',
+  ':*': 'kissing',
+  ':-*': 'kissing',
+  ':P': 'stuck_out_tongue',
+  ':-P': 'stuck_out_tongue',
+  ';P': 'stuck_out_tongue_winking_eye',
+  ';-P': 'stuck_out_tongue_winking_eye',
+  'D:': 'anguished',
+  "D-':": 'anguished',
+  ':O': 'open_mouth',
+  ':-O': 'open_mouth',
+  ":'(": 'cry',
+  ":'-(": 'cry',
+  ':/': 'confused',
+  ':-/': 'confused',
+  ';)': 'wink',
+  ';-)': 'wink',
+  '(Y)': '+1',
+  '(N)': '-1',
+};
+
+export class AutoSubstituteAsciiEmojis {
+  options: AutoSubstituteAsciiEmojisOptions;
+
+  quill: Quill;
+
+  constructor(quill: Quill, options: AutoSubstituteAsciiEmojisOptions) {
+    this.options = options;
+    this.quill = quill;
+
+    this.quill.on(
+      'text-change',
+      _.debounce(() => this.onTextChange(), 100)
+    );
+  }
+
+  onTextChange(): void {
+    const range = this.quill.getSelection();
+
+    if (!range) {
+      return;
+    }
+
+    const [blot, index] = this.quill.getLeaf(range.index);
+
+    if (blot !== undefined && blot.text !== undefined) {
+      const blotText: string = blot.text;
+      Object.entries(emojiMap).some(([textEmoji, emojiName]) => {
+        if (blotText.substring(0, index).endsWith(textEmoji)) {
+          const emojiData = convertShortNameToData(
+            emojiName,
+            this.options.skinTone
+          );
+          if (emojiData) {
+            this.insertEmoji(
+              emojiData,
+              range.index - textEmoji.length,
+              textEmoji.length
+            );
+            return true;
+          }
+        }
+        return false;
+      });
+    }
+  }
+
+  insertEmoji(emojiData: EmojiData, index: number, range: number): void {
+    const emoji = convertShortName(emojiData.short_name, this.options.skinTone);
+    const delta = new Delta().retain(index).delete(range).insert({ emoji });
+    this.quill.updateContents(delta, 'user');
+    this.quill.setSelection(index + 1, 0);
+  }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Re #1389 
Closes #4942

Testing was done manually. If sensible, I can add automated tests for this feature.