### PR TITLE
Make font fallback stack region-neutral

### DIFF
--- a/sticker-creator/src/fonts.scss
+++ b/sticker-creator/src/fonts.scss
@@ -1,9 +1,8 @@
 // Copyright 2022 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-$inter: Inter, 'Helvetica Neue', 'Source Sans Pro', 'Source Han Sans SC',
-  'Source Han Sans CN', 'Hiragino Sans GB', 'Hiragino Kaku Gothic',
-  'Microsoft Yahei UI', Helvetica, Arial, sans-serif;
+$inter: Inter, 'Source Sans Pro', 'Source Han Sans', -apple-system, system-ui, 
+  'Segoe UI', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
 @mixin font-family {
   font-family: $inter;

--- a/stylesheets/_variables.scss
+++ b/stylesheets/_variables.scss
@@ -1,9 +1,9 @@
 // Copyright 2015 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-$inter: Inter, 'Helvetica Neue', 'Source Sans Pro', 'Source Han Sans SC',
-  'Source Han Sans CN', 'Hiragino Sans GB', 'Hiragino Kaku Gothic',
-  'Microsoft Yahei UI', Helvetica, Arial, sans-serif;
+// Note: Add language-specific fallbacks in @localized-fonts mixin
+$inter: Inter, 'Source Sans Pro', 'Source Han Sans', -apple-system, system-ui, 
+  'Segoe UI', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
 // Note: This font-family is checked for in matchMonospace, to support paste scenarios
 $monospace: 'SF Mono', SFMono-Regular, ui-monospace, 'DejaVu Sans Mono', Menlo,


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This pull request makes changes to the default font fallback stack to ensure a region-neutral experience.

#### Background

Due to [Han unification](https://en.wikipedia.org/wiki/Han_unification), CJK characters are displayed differently based on the current interface language and the font picked for fallback:

<img src="https://upload.wikimedia.org/wikipedia/commons/2/23/Source_Han_Sans_Version_Difference.svg" height="60">

Usually, CJK fonts overlaps heavily on their supported codepoints, so browsers and operating systems will need to do the heavy burden of deciding which CJK font to prioritize. On Windows, this means that Firefox automatically picks “Meiryo” (JP), “Microsoft Jhenghei” (TW), or “Microsoft YaHei” (CN) based on `lang` attribute; On Mac, this means deciding on whether to put “PingFang TC,” “PingFang SC,” or “PingFang HK” higher on the font stack.

#### The current problem

However, the current Signal Desktop font fallback stack introduced in PR #2698 imposed Simplified Chinese font variants regardless of users’ system and interface language. If the user does not have those fonts installed, it will fallback to Japanese font.

<details>

To illustrate, here’s the current font stack applied to `zh-Hant-TW` Wikipedia:
<img height="190" alt="Incorrect font fallback, showing Japanese font and punctuation" src="https://github.com/signalapp/Signal-Desktop/assets/1512231/8ee07e96-5702-4283-a1e0-f0132e446fbc">

And here’s the standard (correct) `sans-serif` font stack by Firefox:
<img height="187" alt="A correct fallback stack showing Mandarin (Taiwan) font and punctuation" src="https://github.com/signalapp/Signal-Desktop/assets/1512231/687523fc-c946-4442-a989-8d3fa82facb3">

</details>

#### The fix

This commit will make the default fallback stack more generic:

* Replace [Source Han Sans](https://github.com/adobe-fonts/source-han-sans) `SC`, `CN` region variants with the generic, language-aware `Source Han Sans`
* Facilitate `system-ui` to automatically pick the correct CJK fallback font for each operating system
* Updates `$inter` variable in sticker creator to match the project font stack

#### Some optional to-dos

* [ ] Remove `lang=ja` `localized-fonts`, as the new stack shall fix the issue
* [ ] Test if `lang=ar` `localized-fonts` could be integrated to the new, more generic stack

Please let me know if there were any questions!