### PR TITLE
Add the ability to pass to electron --disable-features values

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -1738,7 +1738,10 @@ async function getDefaultLoginItemSettings(): Promise<LoginItemSettingsOptions> 
 
 // Signal doesn't really use media keys so we set this switch here to unblock
 // them so that other apps can use them if they need to.
-app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling');
+const featuresToDisable =
+		`HardwareMediaKeyHandling,${app.commandLine.getSwitchValue('disable-features')}`;
+app.commandLine.appendSwitch('disable-features', featuresToDisable);
+
 
 // If we don't set this, Desktop will ask for access to keychain/keyring on startup
 app.commandLine.appendSwitch('password-store', 'basic');


### PR DESCRIPTION
Right now, HardwareMediaKeyHandling is the only disabled value and all other disabled values are ignored.

This flag is needed when using Wayland due to the bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1356014 In order to have a non blurry app, WaylandFractionalScaleV1 has to be added to the disabled features

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

I didn't find this exact issue in this project but any app using electron - and also chromium - needs this parameter when the
scale is 200% in Gnome/Wayland

I launched the app and verified that it's not blurry when I added the following parameters in the command line:
``
--enable-features=WaylandWindowDecorations --ozone-platform-hint=auto --disable-features=WaylandFractionalScaleV1
``