### PR TITLE
Replace getLanguages with getPreferredLanguage and add tests

### DIFF
--- a/app/spell_check.ts
+++ b/app/spell_check.ts
@@ -20,14 +20,12 @@ strictAssert(
   "Ensure Intl doesn't change our fake locale ever"
 );
 
-export function getLanguages(
+export function getPreferredLanguage(
   preferredSystemLocales: ReadonlyArray<string>,
   availableLocales: ReadonlyArray<string>,
   defaultLocale: string
-): Array<string> {
-  const matchedLocales = [];
-
-  preferredSystemLocales.forEach(preferredSystemLocale => {
+): string {
+  for (const preferredSystemLocale of preferredSystemLocales) {
     const matchedLocale = LocaleMatcher.match(
       [preferredSystemLocale],
       availableLocales as Array<string>, // bad types
@@ -41,16 +39,13 @@ export function getLanguages(
       FAKE_DEFAULT_LOCALE,
       { algorithm: 'best fit' }
     );
-    if (matchedLocale !== FAKE_DEFAULT_LOCALE) {
-      matchedLocales.push(matchedLocale);
-    }
-  });
 
-  if (matchedLocales.length === 0) {
-    matchedLocales.push(defaultLocale);
+    if (matchedLocale !== FAKE_DEFAULT_LOCALE) {
+      return matchedLocale;
+    }
   }
 
-  return matchedLocales;
+  return defaultLocale;
 }
 
 export const setup = (
@@ -75,7 +70,8 @@ export const setup = (
   });
 
   const availableLocales = session.availableSpellCheckerLanguages;
-  const languages = getLanguages(
+
+  const language = getPreferredLanguage(
     preferredSystemLocales,
     availableLocales,
     'en'
@@ -85,8 +81,8 @@ export const setup = (
     'spellcheck: available spellchecker languages:',
     availableLocales
   );
-  console.log('spellcheck: setting languages to:', languages);
-  session.setSpellCheckerLanguages(languages);
+  console.log('spellcheck: setting languages to:', language);
+  session.setSpellCheckerLanguages([language]);
 
   browserWindow.webContents.on('context-menu', (_event, params) => {
     const { editFlags } = params;

--- a/ts/test-node/app/spell_check_test.ts
+++ b/ts/test-node/app/spell_check_test.ts
@@ -3,61 +3,42 @@
 
 import { assert } from 'chai';
 
-import { getLanguages } from '../../../app/spell_check';
+import { getPreferredLanguage } from '../../../app/spell_check';
 
 describe('SpellCheck', () => {
-  describe('getLanguages', () => {
+  describe('getPreferredLanguage', () => {
     it('works with locale and base available', () => {
-      assert.deepEqual(getLanguages(['en-US'], ['en-US', 'en'], 'en'), [
-        'en-US',
-      ]);
+      assert.strictEqual(getPreferredLanguage(['en-US'], ['en-US', 'en'], 'en'), 'en-US');
     });
 
     it('uses icu likely subtags rules to match languages', () => {
-      assert.deepEqual(getLanguages(['fa-FR'], ['fa-IR'], 'en'), ['fa-IR']);
-      assert.deepEqual(getLanguages(['zh'], ['zh-Hans-CN'], 'en'), [
-        'zh-Hans-CN',
-      ]);
-      assert.deepEqual(
-        getLanguages(['zh-HK'], ['zh-Hans-CN', 'zh-Hant-HK'], 'en'),
-        ['zh-Hant-HK']
-      );
+      assert.strictEqual(getPreferredLanguage(['fa-FR'], ['fa-IR'], 'en'), 'fa-IR');
+      assert.strictEqual(getPreferredLanguage(['zh'], ['zh-Hans-CN'], 'en'), 'zh-Hans-CN');
+      assert.strictEqual(getPreferredLanguage(['zh-HK'], ['zh-Hans-CN', 'zh-Hant-HK'], 'en'), 'zh-Hant-HK');
     });
 
-    it('matches multiple locales', () => {
-      assert.deepEqual(
-        getLanguages(['fr-FR', 'es'], ['fr', 'es-ES', 'en-US'], 'en'),
-        ['fr', 'es-ES']
-      );
+    it('matches the most preferred locale', () => {
+      assert.strictEqual(getPreferredLanguage(['fr-FR', 'es'], ['fr', 'es-ES', 'en-US'], 'en'), 'fr');
     });
 
     it('works with only base locale available', () => {
-      assert.deepEqual(getLanguages(['en-US'], ['en'], 'en'), ['en']);
+      assert.strictEqual(getPreferredLanguage(['en-US'], ['en'], 'fr'), 'en');
     });
 
     it('works with only full locale available', () => {
-      assert.deepEqual(getLanguages(['en-US'], ['en-CA', 'en-US'], 'en'), [
-        'en-US',
-      ]);
+      assert.strictEqual(getPreferredLanguage(['en-US'], ['en-CA', 'en-US'], 'en'), 'en-US');
     });
 
     it('works with base provided and base available', () => {
-      assert.deepEqual(getLanguages(['en'], ['en-CA', 'en-US', 'en'], 'en'), [
-        'en',
-      ]);
+      assert.strictEqual(getPreferredLanguage(['en'], ['en-CA', 'en-US', 'en'], 'fr'), 'en');
     });
 
     it('falls back to default', () => {
-      assert.deepEqual(getLanguages(['fa-IR'], ['es-ES', 'fr-FR'], 'en'), [
-        'en',
-      ]);
+      assert.strictEqual(getPreferredLanguage(['fa-IR'], ['es-ES', 'fr-FR'], 'en'), 'en');
     });
 
-    it('matches en along with other languages', () => {
-      assert.deepEqual(getLanguages(['en', 'fr'], ['fr', 'en'], 'en'), [
-        'en',
-        'fr',
-      ]);
+    it('matches the most preferred locale from list', () => {
+      assert.strictEqual(getPreferredLanguage(['en', 'fr'], ['fr', 'en'], 'en'), 'en');
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #6534. The preferred language is now passed to spellchecker as stated in Signal's [documentation](https://support.signal.org/hc/en-us/articles/360049188372-Language-Options).

Rewrote previously implemented tests and manually tested spell checking on Windows 11 by alternating between different preferred languages.
