### PR TITLE
feat: dark theme support on InstallScreen QR code page

### DIFF
--- a/stylesheets/components/InstallScreenQrCodeNotScannedStep.scss
+++ b/stylesheets/components/InstallScreenQrCodeNotScannedStep.scss
@@ -26,6 +26,8 @@
       max-width: $base-max-width + 44px;
       padding: 44px;
       margin-top: 44px; // Avoids overlap with the Signal logo
+      background: $color-gray-90;
+      color: $color-white;
     }
   }
 
@@ -43,6 +45,11 @@
     min-height: $size;
     min-width: $size;
     width: $size;
+
+    @include dark-theme {
+      padding: 0.5rem;
+      border-radius: $NavTabs__Toggle__blockPadding;
+    }
 
     &--loaded {
       background: $color-white;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #6344

I added style rules that change the background and text colors when the device prefers a dark theme.
I tested it on my Mac and Windows devices. The PR is simple and clear, so there will be no more unpredictable errors.
I added a bit of padding to the QR code on dark theme, because it had bad look without it with light background

Here are screenshots of the app with changes

Dark before:
![telegram-cloud-document-2-5289509051183414828](https://github.com/signalapp/Signal-Desktop/assets/49361764/9127ed83-4637-484b-bdf8-6ad62219cce5)

Dark After:
![telegram-cloud-document-2-5289509051183416145](https://github.com/signalapp/Signal-Desktop/assets/49361764/95321526-2eeb-4dd9-8c47-56c8c9466c84)

Light before:
![telegram-cloud-document-2-5289509051183416153](https://github.com/signalapp/Signal-Desktop/assets/49361764/579ee816-0529-4cab-b838-e2ca53cf449b)

Light after:
![tg_image_913883949](https://github.com/signalapp/Signal-Desktop/assets/49361764/2e9e7563-305e-4818-86cb-4b59980b6c8a)

The pull request is ready to be shipped to users