### PR TITLE
Update NavSidebar.scss with new z-index

### DIFF
--- a/stylesheets/components/NavSidebar.scss
+++ b/stylesheets/components/NavSidebar.scss
@@ -3,7 +3,7 @@
 
 .NavSidebar {
   position: relative;
-  z-index: 10;
+  z-index: 100;
   height: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Previously, NavSidebar used a magic number for z-index. This commit changed this z-index to 100.

Fixes https://github.com/signalapp/Signal-Desktop/issues/6633 where contextmenu--visible (part of ConversationPanel) is hidden behind NavSidebar.

## First time contributor checklist:
 - [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
 - [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

## Contributor checklist:
- [X] My contribution is not related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [main](https://github.com/signalapp/Signal-Desktop/tree/main) branch
 - [X] A yarn ready run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

## Description
 Fixes https://github.com/signalapp/Signal-Desktop/issues/6633, where menu is hidden behind NavSidebar.

Previously, NavSidebar used a magic number for z-index.

This commit changed this z-index to 100.