### PR TITLE
Stop video playback on close #6661

### DIFF
--- a/ts/components/Lightbox.tsx
+++ b/ts/components/Lightbox.tsx
@@ -26,6 +26,7 @@ import { isGIF } from '../types/Attachment';
 import { useRestoreFocus } from '../hooks/useRestoreFocus';
 import { usePrevious } from '../hooks/usePrevious';
 import { arrow } from '../util/keyboard';
+import { ipcRenderer } from 'electron';
 
 export type PropsType = {
   children?: ReactNode;
@@ -223,6 +224,21 @@ export function Lightbox({
 
     closeLightbox();
   };
+
+  useEffect(() => {
+    const prepareClose = () => {
+      if (videoElement && !videoElement.paused) {
+        videoElement.pause();
+      }
+      ipcRenderer.send('stop-playback-confirmed');
+    };
+
+    ipcRenderer.on('prepare-close', prepareClose);
+
+    return () => {
+      ipcRenderer.removeListener('prepare-close', prepareClose);
+    };
+  }, [videoElement]);
 
   const playVideo = useCallback(() => {
     if (!videoElement) {


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [] My changes are ready to be shipped to users

### Description


Fixes #6661 but the timeout for IPC could be subject to change which is why I am reluctant to say my changes are ready to be shipped to users. I tried to strike a balance between responsiveness in the case that no video renderer is present and providing enough time for a response from the renderer. This timeout will likely have to be reviewed.

I manually tested my changes on Windows 11.
