### PR TITLE
Change the highest priority Persian font to Vazirmatn

### DIFF
--- a/stylesheets/_mixins.scss
+++ b/stylesheets/_mixins.scss
@@ -12,8 +12,8 @@
   }
   /* Farsi (Persian) */
   &:lang(fa) {
-    font-family: -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI',
-      Tahoma, 'Noto Sans Arabic', Helvetica, Arial, sans-serif;
+    font-family: 'Vazirmatn', -apple-system, system-ui, BlinkMacSystemFont,
+      'Segoe UI', Tahoma, 'Noto Sans Arabic', Helvetica, Arial, sans-serif;
   }
 }
 


### PR DESCRIPTION
### Description

With the introduction of the language setting in version 6.39.0, this may be a good time to update the default font for Persian to Vazirmatn, which can greatly enhance readability and aesthetics. It is worth noting that Vazirmatn font is highly sought after by the Signal community, as can be observed in the following sources:
- [Issue Comment](https://github.com/signalapp/Signal-Desktop/issues/2648#issuecomment-762425666) on Signal-Desktop repository
- [Issue Comment](https://github.com/signalapp/Signal-Desktop/issues/4296#issuecomment-763381693) on Signal-Desktop repository
- [Signal Users Forum Post](https://community.signalusers.org/t/signal-persian-font-problem/21882/4)
- [Signal Users Forum Post](https://community.signalusers.org/t/more-sophisticated-farsi-persian-font/3865/11)

While personal preferences regarding font readability and aesthetics may vary, I believe that Vazirmatn font will cater to the needs of the majority of Signal users who read and write in Persian.

The code has been tested on macOS Sonoma 14.1.1.
<img width="665" alt="Screenshot 2023-11-25 at 2 42 27 PM" src="https://github.com/signalapp/Signal-Desktop/assets/11276349/14a350a2-4348-40aa-a427-e7a72d485563">


### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users