### PR TITLE
Always allow 'Note To Self' deletions regardless of time

### DIFF
--- a/ts/components/DeleteMessagesModal.tsx
+++ b/ts/components/DeleteMessagesModal.tsx
@@ -41,7 +41,7 @@ export default function DeleteMessagesModal({
       : i18n('icu:DeleteMessagesModal--deleteForMe'),
   });
 
-  if (canDeleteForEveryone) {
+  if (canDeleteForEveryone || isMe) {
     const tooManyMessages = messageCount > MAX_DELETE_FOR_EVERYONE;
     actions.push({
       'aria-disabled': tooManyMessages,

--- a/ts/util/sendDeleteForEveryoneMessage.ts
+++ b/ts/util/sendDeleteForEveryoneMessage.ts
@@ -45,7 +45,9 @@ export async function sendDeleteForEveryoneMessage(
     const timestamp = Date.now();
     const maxDuration = deleteForEveryoneDuration || DAY;
     if (timestamp - targetTimestamp > maxDuration) {
-      throw new Error(`Cannot send DOE for a message older than ${maxDuration}`);
+      throw new Error(
+        `Cannot send DOE for a message older than ${maxDuration}`
+      );
     }
   }
 

--- a/ts/util/sendDeleteForEveryoneMessage.ts
+++ b/ts/util/sendDeleteForEveryoneMessage.ts
@@ -19,6 +19,7 @@ import { __DEPRECATED$getMessageById } from '../messages/getMessageById';
 import { getRecipientConversationIds } from './getRecipientConversationIds';
 import { getRecipients } from './getRecipients';
 import { repeat, zipObject } from './iterables';
+import { isMe } from './whatTypeOfConversation';
 
 export async function sendDeleteForEveryoneMessage(
   conversationAttributes: ConversationAttributesType,
@@ -39,10 +40,13 @@ export async function sendDeleteForEveryoneMessage(
   }
   const idForLogging = getMessageIdForLogging(message.attributes);
 
-  const timestamp = Date.now();
-  const maxDuration = deleteForEveryoneDuration || DAY;
-  if (timestamp - targetTimestamp > maxDuration) {
-    throw new Error(`Cannot send DOE for a message older than ${maxDuration}`);
+  // If conversation is a Note To Self, no deletion time limits apply.
+  if (!isMe(conversationAttributes)) {
+    const timestamp = Date.now();
+    const maxDuration = deleteForEveryoneDuration || DAY;
+    if (timestamp - targetTimestamp > maxDuration) {
+      throw new Error(`Cannot send DOE for a message older than ${maxDuration}`);
+    }
   }
 
   message.set({


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #6682. This ensures that 'Note To Self' messages can be deleted from all devices at any time as opposed to being constrained to the one day time box as messages to other Signal users are. This reflects the behavior that is seen on other Signal clients.

This fix was manually tested on a Fedora 38 workstation. I attempted to remove old messages in 'Note To Self', ensured the proper prompts were given, and that these message deletions were reflected on my Android Signal client. I also checked with conversations to other Signal users and ensured that the previous functionality was unchanged.

Let me know if there's any critiques, cheers!
