### PR TITLE
Default to staging SFU for non-production builds

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -13,7 +13,7 @@
   "resourcesUrl": "https://updates2.signal.org",
   "artCreatorUrl": "https://create.staging.signal.art",
   "updatesPublicKey": "05fd7dd3de7149dc0a127909fee7de0f7620ddd0de061b37a2c303e37de802a401",
-  "sfuUrl": "https://sfu.voip.signal.org/",
+  "sfuUrl": "https://sfu.staging.voip.signal.org/",
   "challengeUrl": "https://signalcaptchas.org/staging/challenge/generate.html",
   "registrationChallengeUrl": "https://signalcaptchas.org/staging/registration/generate.html",
   "updatesEnabled": false,

--- a/config/production.json
+++ b/config/production.json
@@ -9,6 +9,7 @@
     "3": "https://cdn3.signal.org"
   },
   "artCreatorUrl": "https://create.signal.art",
+  "sfuUrl": "https://sfu.voip.signal.org/",
   "challengeUrl": "https://signalcaptchas.org/challenge/generate.html",
   "registrationChallengeUrl": "https://signalcaptchas.org/registration/generate.html",
   "serverPublicParams": "AMhf5ywVwITZMsff/eCyudZx9JDmkkkbV6PInzG4p8x3VqVJSFiMvnvlEKWuRob/1eaIetR31IYeAbm0NdOuHH8Qi+Rexi1wLlpzIo1gstHWBfZzy1+qHRV5A4TqPp15YzBPm0WSggW6PbSn+F4lf57VCnHF7p8SvzAA2ZZJPYJURt8X7bbg+H3i+PEjH9DXItNEqs2sNcug37xZQDLm7X36nOoGPs54XsEGzPdEV+itQNGUFEjY6X9Uv+Acuks7NpyGvCoKxGwgKgE5XyJ+nNKlyHHOLb6N1NuHyBrZrgtY/JYJHRooo5CEqYKBqdFnmbTVGEkCvJKxLnjwKWf+fEPoWeQFj5ObDjcKMZf2Jm2Ae69x+ikU5gBXsRmoF94GXTLfN0/vLt98KDPnxwAQL9j5V1jGOY8jQl6MLxEs56cwXN0dqCnImzVH3TZT1cJ8SW1BRX6qIVxEzjsSGx3yxF3suAilPMqGRp4ffyopjMD1JXiKR2RwLKzizUe5e8XyGOy9fplzhw3jVzTRyUZTRSZKkMLWcQ/gv0E4aONNqs4P",


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

#### Reason for change

Currently, the staging builds (including the official ones for [Public Username Testing (Staging Environment)](https://community.signalusers.org/t/56866)) use the production SFU by default.

The production (or the `test`) SFU doesn't work (i.e. group calls are cancelled immediately) in the staging environment (because of different ZK parameters, I believe), requiring manually changing the SFU url via `SignalDebug.setSfuUrl` to the staging SFU.

#### Change

This PR changes the default SFU for builds to the staging SFU, overriding it with the production SFU only for production builds.

#### Other clients

With this PR, Desktop's behavior aligns with [Signal Android](https://github.com/signalapp/Signal-Android/blob/19e726a630c1f0aa681cd4e771f01ce5bb0b4148/app/src/main/java/org/thoughtcrime/securesms/util/Environment.kt#L29-L31) and [Signal iOS](https://github.com/signalapp/Signal-iOS/blob/8658c039068993ef9cc4d0d9bed8807d67988f44/SignalServiceKit/src/TSConstants.swift#L256), both of which use the staging SFU by default in staging builds.

#### Testing

Successfully tried a group call (video and audio) between primary iOS physical device and the development Desktop for:
- Staging: Default build without any changes + iOS staging custom build 6.52.0.3.
- Production: Copying `production.json` to `local-development.json` and building + iOS beta 6.52.0.5.
