### PR TITLE
Remove legacy forward modal header CSS

### DIFF
--- a/stylesheets/components/ForwardMessageModal.scss
+++ b/stylesheets/components/ForwardMessageModal.scss
@@ -23,22 +23,6 @@
     }
   }
 
-  &__header {
-    align-items: center;
-    display: flex;
-    justify-content: center;
-    position: relative;
-    @include font-body-1-bold;
-
-    &--edit {
-      border-bottom: 1px solid $color-gray-15;
-
-      @include dark-theme() {
-        border-color: $color-gray-60;
-      }
-    }
-  }
-
   &__list-wrapper {
     flex-grow: 1;
     overflow: hidden;


### PR DESCRIPTION
This removes old css that is now handled in `Modal.scss`. This legacy CSS code would force the modal title to be centered (something that isn't the case nowadays) and override the new `Modal.scss` CSS which messed up the X button.

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

This PR fixes the broken CSS of the forward messages header modal. The change is rather straightforward, I added an explanation in the commit description (or see above).

Note that even though the title is left-aligned now, it still gets centered inside the "editing mode", because of the back button that suddenly appears, but and as far as I can tell this is intended behaviour.

I tested it in both light theme, dark theme, and RTL language, and there seems to be no apparent issues (except something unrelated I discovered which I'll open an issue about).

I can't seem to upload images to show the before/after so let me know if you can't see what the change is doing (it should be easy to spot though) and I'll be glad to show you.