### PR TITLE
Save current image from the gallery view by pressing 's', 'd', or 'Enter'

### DIFF
--- a/ts/components/Lightbox.tsx
+++ b/ts/components/Lightbox.tsx
@@ -161,7 +161,7 @@ export function Lightbox({
   }, [setVideoTime, videoElement]);
 
   const handleSave = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    event: KeyboardEvent | React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     if (isViewOnce) {
       return;
@@ -193,6 +193,8 @@ export function Lightbox({
 
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {
+      const isMacOS = (window.platform === 'darwin');
+
       switch (event.key) {
         case 'Escape': {
           closeLightbox();
@@ -211,10 +213,16 @@ export function Lightbox({
           onNext(event);
           break;
 
+        case 's':
+          if (isMacOS ? event.metaKey : event.ctrlKey) {
+              handleSave(event);
+          }
+          break;
+
         default:
       }
     },
-    [closeLightbox, onNext, onPrevious]
+    [closeLightbox, onNext, onPrevious, handleSave]
   );
 
   const onClose = (event: React.MouseEvent<HTMLElement>) => {


### PR DESCRIPTION

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

This commit will allow to save images from a gallery view by pressing Enter, 's', or 'd' keys.
To test:
 - Open a conversation containing 10+ images attached to a single message.
 - Click on the first image, an image gallery will open.
 - Press 'Enter' to download the first image.
 - Press 'Right' then 'Enter' to download subsequent images.
 - This improves accessibility - no need to right-click on every image and select 'Download' from the popup menu.