### PR TITLE
fix #6119: respect previously maximized state when clicking tray to restore window

### DIFF
--- a/app/SystemTrayService.ts
+++ b/app/SystemTrayService.ts
@@ -226,7 +226,11 @@ export class SystemTrayService {
       if (browserWindow.isVisible()) {
         browserWindow.hide();
       } else {
-        browserWindow.show();
+        if (browserWindow.isMinimized()) {
+          browserWindow.restore();
+        } else {
+          browserWindow.show();
+        }
         focusAndForceToTop(browserWindow);
       }
     });

--- a/ts/test-node/app/SystemTrayService_test.ts
+++ b/ts/test-node/app/SystemTrayService_test.ts
@@ -274,4 +274,20 @@ describe('SystemTrayService', function (this: Mocha.Suite) {
 
     sinon.assert.notCalled(createTrayInstance);
   });
+
+  it('should remember its maximized state upon restore', () => {
+    const service = newService();
+    service.setEnabled(true);
+    const browserWindow = new BrowserWindow({ show: false });
+    service.setMainWindow(browserWindow);
+    const tray = service._getTray();
+    if (!tray) {
+      throw new Error('Test setup failed: expected a tray');
+    }
+    
+    browserWindow.maximize();
+    browserWindow.minimize();
+    tray.emit("click");
+    assert.isTrue(browserWindow.isMaximized());
+  });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #6119.  If the system tray is clicked, it will restore a minimized window, respecting the previous maximized state.  Before this patch, it would clobber the previously maximized state.

I added an automated test that failed, and with my new changes, now passes.

Tested on Windows 10 only.
