### PR TITLE
Handle outside click for story creator url popover

### DIFF
--- a/ts/components/TextStoryCreator.tsx
+++ b/ts/components/TextStoryCreator.tsx
@@ -301,6 +301,29 @@ export function TextStoryCreator({
     );
   }, [isColorPickerShowing, colorPickerPopperRef, colorPickerPopperButtonRef]);
 
+  useEffect(() => {
+    if (!isLinkPreviewInputShowing) {
+      return noop;
+    }
+    return handleOutsideClick(
+      () => {
+        setIsLinkPreviewInputShowing(false);
+        return true;
+      },
+      {
+        containerElements: [
+          linkPreviewInputPopperRef,
+          linkPreviewInputPopperButtonRef,
+        ],
+        name: 'TextStoryCreator.linkPreviewInput',
+      }
+    );
+  }, [
+    isLinkPreviewInputShowing,
+    linkPreviewInputPopperRef,
+    linkPreviewInputPopperButtonRef,
+  ]);
+
   const sliderColorNumber = getRGBANumber(sliderValue);
 
   let textForegroundColor = sliderColorNumber;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
Fixes https://github.com/signalapp/Signal-Desktop/issues/6207

Currently, the story creator url popover does not close on outside click. This change sets up a click handler, following the pattern used for the similar background color picker, use handleOutsideClick to close the url popover.

### Testing
Tested on macOS 10.15.7. No new test cases written.
  - Verified on outside click closes url popover. (note it causes the text editor to open, but this is not a new issue)
  - Verified esc key closed the url popover.
  - Verified clicking on text in edit mode places text cursor where mouse click occurred, and closes url popover. This issue was noted in the previous #6209.
  - Verified esc and outside click work as expected on color popover.
  - Verified I could add a URL to the story.

https://github.com/signalapp/Signal-Desktop/assets/7935599/65663dea-577a-4196-b265-c7cf5ee8e6ad


