### PR TITLE
Fix: Contact avatar not aligned correctly in LeftPane - narrow + scrollbar

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -5406,7 +5406,7 @@ button.module-image__border-overlay:focus {
 }
 
 .module-left-pane__list--wrapper {
-  position: relative;
+  position: absolute;
 }
 
 .module-left-pane__list {

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -4593,7 +4593,7 @@ button.module-image__border-overlay:focus {
       width: 100%;
 
       .module-conversation-list--width-narrow & {
-        padding-inline: 14px 0;
+        padding-inline: 10px 0;
       }
 
       #{$unread-indicator} {
@@ -5410,7 +5410,7 @@ button.module-image__border-overlay:focus {
 }
 
 .module-left-pane__list {
-  position: absolute;
+  position: relative;
   outline: none;
 }
 


### PR DESCRIPTION


<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes incorrect alignment of profile avatar in left pane when in narrow mode and with scroll bar visible (conversations do not fit into the screen height).

Before:
![Signal-before](https://github.com/signalapp/Signal-Desktop/assets/79979498/16fb10ee-6498-4ad1-aa60-2e1d98eac958)
(notice the highlighted conversation with profile avatar in the left pane)

After:
![Signal-after-without](https://github.com/signalapp/Signal-Desktop/assets/79979498/6c399ee0-a3f3-4ccc-a568-f5fd5d86da44)

After with scrollbar visible:
![Signal-after-with](https://github.com/signalapp/Signal-Desktop/assets/79979498/7d23a6e8-8c2f-4522-8ee3-e523b9ccf436)

After the change, the items in the left pane are aligned the same way as they are while in widened mode of the left pane = there is more space on the right side from the list item to accommodate the scrollbar. 

This issue appears only when there is enough conversations open in the left pane to overflow the window's view height.