### PR TITLE
Toggle context menus on click and add active state

### DIFF
--- a/stylesheets/components/NavSidebar.scss
+++ b/stylesheets/components/NavSidebar.scss
@@ -195,6 +195,15 @@
     }
   }
 
+  &:active {
+    @include light-theme {
+      background: $color-gray-20;
+    }
+    @include dark-theme {
+      background: $color-gray-62;
+    }
+  }
+
   &:focus {
     outline: none;
     @include keyboard-mode {

--- a/ts/components/CallsTab.tsx
+++ b/ts/components/CallsTab.tsx
@@ -207,10 +207,11 @@ export function CallsTab({
                     }}
                     portalToRoot
                   >
-                    {({ openMenu, onKeyDown }) => {
+                    {({ onClick, onKeyDown, ref }) => {
                       return (
                         <NavSidebarActionButton
-                          onClick={openMenu}
+                          ref={ref}
+                          onClick={onClick}
                           onKeyDown={onKeyDown}
                           icon={<span className="CallsTab__MoreActionsIcon" />}
                           label={i18n('icu:CallsTab__MoreActionsLabel')}

--- a/ts/components/ContextMenu.tsx
+++ b/ts/components/ContextMenu.tsx
@@ -25,7 +25,7 @@ export type ContextMenuOptionType<T> = Readonly<{
 }>;
 
 type RenderButtonProps = Readonly<{
-  openMenu: (ev: React.MouseEvent) => void;
+  onClick: (ev: React.MouseEvent) => void;
   onKeyDown: (ev: KeyboardEvent) => void;
   isMenuShowing: boolean;
   ref: React.Ref<HTMLButtonElement> | null;
@@ -207,10 +207,15 @@ export function ContextMenu<T>({
   };
 
   const handleClick = (ev: React.MouseEvent) => {
-    closeCurrentOpenContextMenu?.();
-    closeCurrentOpenContextMenu = () => setIsMenuShowing(false);
-    virtualElement.current = generateVirtualElement(ev.clientX, ev.clientY);
-    setIsMenuShowing(true);
+    if (isMenuShowing && ev.type !== 'contextmenu') {
+      setIsMenuShowing(false);
+      closeCurrentOpenContextMenu = undefined;
+    } else {
+      closeCurrentOpenContextMenu?.();
+      closeCurrentOpenContextMenu = () => setIsMenuShowing(false);
+      virtualElement.current = generateVirtualElement(ev.clientX, ev.clientY);
+      setIsMenuShowing(true);
+    }
     ev.stopPropagation();
     ev.preventDefault();
   };
@@ -316,7 +321,7 @@ export function ContextMenu<T>({
     buttonNode = (
       <>
         {(children as (props: RenderButtonProps) => JSX.Element)({
-          openMenu: onClick || handleClick,
+          onClick: onClick || handleClick,
           onKeyDown: handleKeyDown,
           isMenuShowing,
           ref: setReferenceElement,

--- a/ts/components/LeftPane.tsx
+++ b/ts/components/LeftPane.tsx
@@ -668,10 +668,11 @@ export function LeftPane({
             }}
             portalToRoot
           >
-            {({ openMenu, onKeyDown }) => {
+            {({ onClick, onKeyDown, ref }) => {
               return (
                 <NavSidebarActionButton
-                  onClick={openMenu}
+                  ref={ref}
+                  onClick={onClick}
                   onKeyDown={onKeyDown}
                   icon={<span className="module-left-pane__moreActionsIcon" />}
                   label="More Actions"

--- a/ts/components/NavSidebar.tsx
+++ b/ts/components/NavSidebar.tsx
@@ -16,19 +16,23 @@ import {
 import { WidthBreakpoint, getNavSidebarWidthBreakpoint } from './_util';
 import type { UnreadStats } from '../util/countUnreadStats';
 
-export function NavSidebarActionButton({
-  icon,
-  label,
-  onClick,
-  onKeyDown,
-}: {
+type NavSidebarActionButtonProps = {
   icon: ReactNode;
   label: ReactNode;
   onClick: MouseEventHandler<HTMLButtonElement>;
   onKeyDown?: KeyboardEventHandler<HTMLButtonElement>;
-}): JSX.Element {
+};
+
+export const NavSidebarActionButton = React.forwardRef<
+  HTMLButtonElement,
+  NavSidebarActionButtonProps
+>(function NavSidebarActionButtonInner(
+  { icon, label, onClick, onKeyDown },
+  ref
+): JSX.Element {
   return (
     <button
+      ref={ref}
       type="button"
       className="NavSidebar__ActionButton"
       onClick={onClick}
@@ -38,7 +42,7 @@ export function NavSidebarActionButton({
       <span className="NavSidebar__ActionButtonLabel">{label}</span>
     </button>
   );
-}
+});
 
 export type NavSidebarProps = Readonly<{
   actions?: ReactNode;

--- a/ts/components/NavTabs.tsx
+++ b/ts/components/NavTabs.tsx
@@ -307,7 +307,7 @@ export function NavTabs({
             }}
             portalToRoot
           >
-            {({ openMenu, onKeyDown, ref }) => {
+            {({ onClick, onKeyDown, ref }) => {
               return (
                 <button
                   type="button"
@@ -319,7 +319,7 @@ export function NavTabs({
                   }}
                   onClick={event => {
                     if (hasPendingUpdate) {
-                      openMenu(event);
+                      onClick(event);
                     } else {
                       onShowSettings();
                     }

--- a/ts/components/SendStoryModal.tsx
+++ b/ts/components/SendStoryModal.tsx
@@ -923,14 +923,14 @@ export function SendStoryModal({
               }}
               theme={theme === ThemeType.dark ? Theme.Dark : Theme.Light}
             >
-              {({ openMenu, onKeyDown, ref, menuNode }) => (
+              {({ onClick, onKeyDown, ref, menuNode }) => (
                 <div>
                   <Button
                     ref={ref}
                     className="SendStoryModal__new-story__button"
                     variant={ButtonVariant.Secondary}
                     size={ButtonSize.Small}
-                    onClick={openMenu}
+                    onClick={onClick}
                     onKeyDown={onKeyDown}
                   >
                     {i18n('icu:SendStoryModal__new')}

--- a/ts/components/StoriesTab.tsx
+++ b/ts/components/StoriesTab.tsx
@@ -174,10 +174,11 @@ export function StoriesTab({
                 }}
                 portalToRoot
               >
-                {({ openMenu, onKeyDown }) => {
+                {({ onClick, onKeyDown, ref }) => {
                   return (
                     <NavSidebarActionButton
-                      onClick={openMenu}
+                      ref={ref}
+                      onClick={onClick}
                       onKeyDown={onKeyDown}
                       icon={<span className="StoriesTab__MoreActionsIcon" />}
                       label={i18n('icu:StoriesTab__MoreActionsLabel')}

--- a/ts/components/StoryViewsNRepliesModal.tsx
+++ b/ts/components/StoryViewsNRepliesModal.tsx
@@ -642,9 +642,9 @@ function ReplyOrReactionMessage({
 
   return reply.author.isMe && !reply.deletedForEveryone ? (
     <ContextMenu i18n={i18n} key={reply.id} menuOptions={menuOptions}>
-      {({ openMenu, menuNode }) => (
+      {({ onClick, menuNode }) => (
         <>
-          {renderContent(openMenu)}
+          {renderContent(onClick)}
           {menuNode}
         </>
       )}


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fix for a minor annoyance I had with the behaviour of the context menu at the top of the left pane. Most other menu buttons throughout the app are toggles, i.e., they show the menu on the first click and hide it on the next click. These menu buttons weren't toggles and I'd find myself clicking once to show, then a second time to hide, but the menu wouldn't go away. The buttons at the top of the left pane were also missing active states, unlike most other similar buttons including the hamburger menu.

#### Post-fix demo

https://github.com/signalapp/Signal-Desktop/assets/1466970/5f5bb024-4aa0-4737-a4ef-61718bf563a4

No change to the behaviour of the menus in the conversation pane (just showed them in the demo for reference). The new behaviour is just for the triple dot menu in the left pane.

#### Details
- Refactored `ContextMenu` to toggle the menu state on click rather than always showing it
  - That meant that the name of the `openMenu` render prop wasn't accurate anymore, so I renamed it to `onClick` for consistency with the existing `onKeyDown` render prop
- Adding toggle logic also revealed that a bunch of `ContextMenu` instances weren't getting a `referenceElement` set because their `ref` render prop wasn't being passed down
  - Without a `referenceElement`, a click on the menu button was considered an outside click, which would hide the menu, so toggling would immediately bring it back 👎🏻 
  - I cleaned up the `ref`-less instances and also added `forwardRef` to the `NavSidebarActionButton` to get the button ref and toggling is now working as expected
- I also added styling for the `:active` background on `NavSidebarActionButton` to match the hamburger menu