### PR TITLE
Use base64url encoding for encrypted username

### DIFF
--- a/ts/Bytes.ts
+++ b/ts/Bytes.ts
@@ -26,6 +26,10 @@ export function toBase64(data: Uint8Array): string {
   return bytes.toBase64(data);
 }
 
+export function toBase64url(data: Uint8Array): string {
+  return bytes.toBase64url(data);
+}
+
 export function toHex(data: Uint8Array): string {
   return bytes.toHex(data);
 }

--- a/ts/context/Bytes.ts
+++ b/ts/context/Bytes.ts
@@ -25,6 +25,10 @@ export class Bytes {
     return Buffer.from(data).toString('base64');
   }
 
+  public toBase64url(data: Uint8Array): string {
+    return Buffer.from(data).toString('base64url');
+  }
+
   public toHex(data: Uint8Array): string {
     return Buffer.from(data).toString('hex');
   }

--- a/ts/state/selectors/items.ts
+++ b/ts/state/selectors/items.ts
@@ -115,7 +115,7 @@ export const getUsernameLink = createSelector(
     const content = Bytes.concatenate([entropy, serverId]);
 
     return contactByEncryptedUsernameRoute
-      .toWebUrl({ encryptedUsername: Bytes.toBase64(content) })
+      .toWebUrl({ encryptedUsername: Bytes.toBase64url(content) })
       .toString();
   }
 );

--- a/ts/test-mock/pnp/username_test.ts
+++ b/ts/test-mock/pnp/username_test.ts
@@ -345,7 +345,7 @@ describe('pnp/username', function (this: Mocha.Suite) {
         encryptedUsername: Buffer.concat([
           entropy,
           uuidToBytes(serverId),
-        ]).toString('base64'),
+        ]).toString('base64url'),
       })
       .toString();
 


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Changes the base64 encoding used for encrypted username links (`https://signal.me/#eu/<encrypted username>`) from base64 to base64url encoding to match Android and iOS behavior. (https://community.signalusers.org/t/beta-feedback-for-the-upcoming-desktop-7-3-release/59611/4?u=bjoel)
