### PR TITLE
 Adds shutdown confirmation logic before exiting a call

### DIFF
--- a/ts/services/beforeShutdown.ts
+++ b/ts/services/beforeShutdown.ts
@@ -1,0 +1,49 @@
+// Copyright 2024 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { IpcMainEvent } from 'electron';
+
+type Listener = (event: IpcMainEvent, ...args: Array<unknown>) => void;
+
+const listeners: Array<Listener> = [];
+
+/**
+ * Add a listener that will be called right before the app shuts down.
+ *
+ * This is useful for doing any necessary cleanup, such as closing connections
+ * or saving data.
+ *
+ * @param listener The listener to add.
+ */
+export function addBeforeShutdownListener(listener: Listener): void {
+  listeners.push(listener);
+}
+
+/**
+ * Remove a previously added listener.
+ *
+ * @param listener The listener to remove.
+ */
+export function removeBeforeShutdownListener(listener: Listener): void {
+  const index = listeners.indexOf(listener);
+  if (index > -1) {
+    listeners.splice(index, 1);
+  }
+}
+
+/**
+ * Call all of the registered listeners.
+ *
+ * This should be called right before the app shuts down.
+ *
+ * @param event The event that triggered the shutdown.
+ * @param args Any additional arguments to pass to the listeners.
+ */
+export function callBeforeShutdownListeners(
+  event: IpcMainEvent,
+  ...args: Array<unknown>
+): void {
+  for (const listener of listeners) {
+    listener(event, ...args);
+  }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Modifies the event handling logic related to closing the window in the Signal Desktop application. The goal was to detect when there was an active call and display a confirmation dialog asking the user if they were sure they wanted to end the call and close the application. Adds shutdown service and integrates it into background.ts
