### PR TITLE
Remove domain that does not exist

### DIFF
--- a/ts/scripts/generate-dns-fallback.ts
+++ b/ts/scripts/generate-dns-fallback.ts
@@ -20,7 +20,6 @@ const FALLBACK_DOMAINS = [
   'cdn3.signal.org',
   'updates2.signal.org',
   'sfu.voip.signal.org',
-  'create.signal.art',
 ];
 
 async function main() {


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Hi! I hope this isn't noise. 

I was trying to build the project to test my other contribution. I could not do so successfully. My build kept failing with this error:

```
Error: getaddrinfo ENOTFOUND create.signal.art
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:118:26) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'create.signal.art'
}
```

When I check for the existence of this domain via `dig create.signal.art A +short`, I get that no record exists. I also do not see it checking on an external tool (e.g. mxtoolbox.com), so I don't think it's a problem with my machine configuration. 

To resolve this, I just removed the "create.signal.art" domain from the generate-dns-fallback.ts file. I see that @indutny-signal created this just a few weeks ago, so hopefully this is the right thing to do. 

### Test Strategy

All tests passed when I ran `yarn ready`. I also was able to launch the app and send a message to myself using `yarn start`. 