### PR TITLE
Make release build's timestamp more deterministic

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "build:esbuild": "node scripts/esbuild.js",
     "build:esbuild:prod": "node scripts/esbuild.js --prod",
     "build:electron": "electron-builder --config.extraMetadata.environment=$SIGNAL_ENV",
-    "build:release": "cross-env SIGNAL_ENV=production npm run build:electron -- --config.directories.output=release",
+    "build:release": "cross-env SOURCE_DATE_EPOCH=1984 SIGNAL_ENV=production npm run build:electron -- --config.directories.output=release",
     "verify": "run-p --print-label verify:*",
     "verify:ts": "tsc --noEmit",
     "electron:install-app-deps": "electron-builder install-app-deps"


### PR DESCRIPTION
This allows building with a deterministic timestamp. For instance, it's used in the `.deb` package to generate changelogs, which are timestamped.

See https://reproducible-builds.org/specs/source-date-epoch/

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Hello, 

I am trying to make Desktop builds reproducible, at least on Linux (I have yet to look at the macOS and Windows builds).

One source of non-determinism in the building was the introduction of a timestamp in `fpm`, which is used by `electron-builder` to generate the `.deb` package. See for youself: 

- Extract the official release `.deb` and look for `data.tar.xz`, and extract that.
- Inside data.tar.xz, go look for `usr/share/doc/signal-desktop/changelog.gz`.
- changelog.gz contains a `changelog` file that has at timestamp generated a build time. `changelog.gz` itself also contains a timestamp. For 7.15.0 it's the following (just do `file [...]/changelog.gz` to see it):
```
usr/share/doc/signal-desktop/changelog.gz: gzip compressed data, last modified: Wed Jul  3 00:45:21 2024, max compression, from Unix, original size modulo 2^32 161
```

This timestamp can be made deterministic using the `SOURCE_DATE_EPOCH` (0) environment variable, as I have done in this PR, which `fpm` honors. The value of the UNIX timestamp is irrelevant, as signal-desktop doesn't even deal with that `changelog.gz`, it is set to a meaningless default message. 

I set the timestamp to 1984 because Signal originated from "Thoughtcrime Labs", but feel free to change the value to anything. Note however that the value 0 won't work: `fpm`'s ZLib library treats the timestamp 0 as "no timestamp available", and in that case will generate a fresh timestamp for the .gz file(1).

(0): https://reproducible-builds.org/specs/source-date-epoch/
(1): https://apidock.com/ruby/Zlib/GzipWriter/mtime%3D 