### PR TITLE
Introduce a reproducible build system for Linux

### DIFF
--- a/reproducible-builds/Dockerfile
+++ b/reproducible-builds/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:jammy-20230624@sha256:b060fffe8e1561c9c3e6dea6db487b900100fc26830b9ea2ec966c151ab4c020
+
+# Allows package builders like FPM (used for creating the .deb package
+# on linux) to make their build timestamps determistic. Otherwise, a fresh
+# UNIX timestamp will be generated at the time of the build, and is non-deterministic.
+#
+# Read https://reproducible-builds.org/specs/source-date-epoch/ for more info
+ENV SOURCE_DATE_EPOCH=1
+
+# Due to some issues with NVM reading .nvmrc, we define the version
+# as an environment variable and use that instead. 
+ARG NODE_VERSION
+
+# ---
+# This portion of the code is identical to the Signal Android's
+# reproducible build system. https://github.com/signalapp/Signal-Android/blob/main/reproducible-builds/Dockerfile
+
+# APT source files
+COPY docker/ docker/
+COPY docker/apt.conf docker/sources.list /etc/apt/
+
+# Temporarily disables APT's certificate signature checking
+# to download the certificates. See 
+RUN apt update -oAcquire::https::Verify-Peer=false
+RUN apt install -oAcquire::https::Verify-Peer=false -y ca-certificates
+
+RUN apt update
+RUN apt install -y git curl g++ gcc make python3 tar
+# ---
+
+# Install nvm
+ENV NVM_DIR=/usr/local/nvm
+ENV NVM_VERSION=0.39.7
+RUN mkdir $NVM_DIR
+
+RUN curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias $NODE_VERSION \
+    && nvm use $NODE_VERSION
+
+ENV NODE_PATH=$NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+RUN git config --global --add safe.directory /project

--- a/reproducible-builds/README.md
+++ b/reproducible-builds/README.md
@@ -1,0 +1,78 @@
+# Reproducible builds
+
+In order to verify that Signal's official apps are correctly built from the open source code, we need *reproducible builds*. 
+
+Reproducible builds help ensure that anyone, including you, can build Signal Desktop in a way that is completely identical to the official downloads available to all users. 
+
+This provides an extra security layer to ensure that the builds aren't tampered with, corrupted, and built with the free open source code.
+
+## Reproduce and verify the Windows/macOS build
+
+Reproducible builds for macOS and Windows are not available yet.
+
+## Reproduce and verify the Linux build
+
+### Pre-requisites
+
+- Docker Engine is installed and running on your computer
+- You need `git`.
+- This guide assumes you are running a Unix-based system, but should otherwise work on any platform that runs Docker Engine.
+
+### Building
+
+First, grab the source code by using `git`:
+
+```bash
+$ git clone https://github.com/signalapp/Signal-Desktop.git
+```
+
+This will download Signal Desktop's source code under the `Signal-Desktop` file. Once the download is complete, go inside the file and make sure you are selecting the branch used in official builds. For instance, if you are trying to build `7.18.0`, then do:
+
+```bash
+$ cd Signal-Desktop/
+Signal-Desktop$ git checkout tags/7.16.0
+```
+
+You are now on the version of the source code used for `7.16.0`. Then, make sure your shell is in the `reproducible-builds` directory first:
+
+```bash
+Signal-Desktop$ cd reproducible-builds/
+Signal-Desktop/reproducible-builds$ pwd
+[...]/Signal-Desktop/reproducible-builds
+```
+
+Last step is to run the `./build.sh` script. (If your user is not in Docker's `docker` group, then you may need to run the script as `sudo`).
+
+```bash
+Signal-Desktop/reproducible-builds$ chmod +x ./build.sh
+Signal-Desktop/reproducible-builds$ ./build.sh
+```
+
+This bash script will do two things. First, it will create the Docker container where Signal Desktop will be built. Second, it will build Signal Desktop inside the container. 
+
+When the build is completed, the resulting file will be available at `Signal-Desktop/release/signal-desktop_7.18.0_amd64.deb`.
+
+### Verify the official build
+
+If you have followed the official Linux instructions to install Signal Desktop at https://signal.org/download/, then you will have `signal-desktop` available in your `apt` repositories. You can then simply grab the official build by typing:
+
+```bash
+$ apt download signal-desktop
+```
+
+This will automatically download the official `.deb` package.
+
+To verify the official `.deb` package against your build, make sure that your version is the same as the official version, for example version `7.18.0`. Then, compare the checksums and make sure they are identical. If they are identical, then the two builds are exactly the same, and you have successfully reproduced Signal Desktop.
+
+(Note: do not compare with the checksums given below! They only serve as a visual example of what the output would look like)
+
+```bash
+$ sha256sum signal-desktop_7.18.0_amd64-OUR_BUILD.deb signal-desktop_7.18.0_amd64_OFFICIAL_BUILD.deb
+
+0df3d06f74c6855559ef079b368326ca18e144a28ede559fd76648a62ec3eed7  signal-desktop_7.18.0_amd64-OUR_BUILD.deb 
+0df3d06f74c6855559ef079b368326ca18e144a28ede559fd76648a62ec3eed7  signal-desktop_7.18.0_amd64_OFFICIAL_BUILD.deb
+```
+
+### What to do if the checksums don't match
+
+- File an issue [on the Github Issues page](https://github.com/signalapp/Signal-Desktop/issues).

--- a/reproducible-builds/build.sh
+++ b/reproducible-builds/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+docker build -t signal-desktop --build-arg NODE_VERSION=$(cat ../.nvmrc) .
+cd ..
+docker run --rm -v "$(pwd)":/project -w /project --user "$(id -u):$(id -g)" signal-desktop sh -c "npm install; npm run generate; npm run build-release" 

--- a/reproducible-builds/docker/apt.conf
+++ b/reproducible-builds/docker/apt.conf
@@ -1,0 +1,6 @@
+Acquire::Check-Valid-Until "false";
+Acquire::Languages "none";
+Binary::apt-get::Acquire::AllowInsecureRepositories "false";
+
+APT::Install-Recommends "false";
+APT::Immediate-Configure "false";

--- a/reproducible-builds/docker/sources.list
+++ b/reproducible-builds/docker/sources.list
@@ -1,0 +1,3 @@
+deb http://mirror.signalusers.org/ubuntu/1687461439/ jammy main universe
+deb http://mirror.signalusers.org/ubuntu/1687461439/ jammy-security main universe
+deb http://mirror.signalusers.org/ubuntu/1687461439/ jammy-updates main universe

--- a/ts/scripts/generate-dns-fallback.ts
+++ b/ts/scripts/generate-dns-fallback.ts
@@ -61,7 +61,7 @@ async function main() {
 
   const outPath = join(__dirname, '../../build/dns-fallback.json');
 
-  await writeFile(outPath, `${JSON.stringify(config, null, 2)}\n`);
+  //await writeFile(outPath, `${JSON.stringify(config, null, 2)}\n`);
 }
 
 main().catch(error => {


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

### Description

This PR attempts to introduces reproducible builds on Linux.

<details>

<summary><h2>Motivation for reproducible builds</h2></summary>

- Reproducible builds are a guarantee that the open source code available to all users is the one used in the official builds
- Reproducible builds help audit the source code a lot easily and confidently, since we can be use the official build is running the source code we're auditing.
- Reproducible builds prevents developers introducing backdoors into the official builds, which is more than ever relevant given the recent XZ Utils incident
- Reproducible builds _any_ build more trustworthy. Delegating the official build process to a single developer is a lot more safe if builds are reproducible and can be built on any computer.
- Telegram recently called out Signal for not having reproducible builds on iOS. Outside of the political reasons and obvious technical problems with reproducibility on iOS, I think that making reproducible builds wherever possible could increase public confidence in Signal and avoid callouts like that. 
- https://reproducible-builds.org/ go into more detail
</details>

### What needs to be reproducible on Desktop

From what I gathered, there are three things making Signal Desktop non-reproducible:

- Potential timestamps included in the packages themselves. In the case of `.deb`, FPM was inserting timestamps in the `.deb` files and tar archives (metadata). I have written more about it on https://github.com/signalapp/Signal-Desktop/pull/6940
- Node dependency bindings built from C/C++. This includes for instance `@signalapp/better-sqlite3` and `@nodert-win10-rs4`. This is why I decided to use Docker, to ensure the C compilers were identical for everyone.
- DNS fallback configuration dynamically generated at build time. See https://github.com/signalapp/Signal-Desktop/issues/6823

### What has been done in this PR

- [X] Linux `.deb` builds on `amd64`
- [ ] Windows `.exe` builds: not done by this PR. Windows builds have to be built on Windows, and the Docker image is Linux.
- [ ] macOS `.dmg` builds: same issue as above.
- [ ] I have temporarily disabled the DNS fallback configuration generation to prototype a reproducible build. Of course that's unacceptable for official builds, but I am planning in a later commit, if this idea goes forward, to remove `build/dns-fallback.json` from `.gitignore` to make it the same for everyone (though again there will need to be approval from the Desktop team because that would mean manually updating the file with say an `npm` command, as I had suggested in the issue above).

I have essentially repurposed Signal Android's reproducible build system to make Signal Desktop linux builds, for several reasons:
- The infrastructure already exists and is already maintained by Signal.
- This process is already well known by the Android team.
- And honestly it was just way easier to modify something that already exists than to make it from scratch too.

I have written a quick guide in `reproducible-builds/README.md`, though it will need more work. Essentially, `reproducible-builds/build.sh` should do everything on its own, you just need Docker and git.

I understand that this PR only covers Linux, at least for now, but in my opinion it is better than nothing. This is something that can only be improved, and is parallel to the existing build CI so it won't break it. 

### How to verify the builds

I tried to make it so that the entire `.deb` file is reproducible. Currently, the resulting `.deb` build on my tree should have the SHA256 hash: `34441fec941c4cb2450e50f3b0a2ce9170d2ded6ae73a8812bdfc37c29805050`. I invite more people to try building this themselves and verify that they are also getting the same hash. If you don't, let me know.

If that doesn't work out (perhaps because of post-build signatures in the `.deb` file, but I don't think that's the case), then the contents of `signal-desktop...deb/control.tar.gz/md5sums` can also be compared. That file contains the md5 hashes of all the files inside the `.deb`.
 
### The downsides of this PR

Of course, this PR only makes sense if the Desktop team agrees to start building the official apps on this kind of build system. I am pretty sure this can be done automatically in CI (I don't know how Desktop is actually built/where the build comes from though), but this still adds extra complexity and effort, notably because of the DNS fallback issue.

I also understand that this is unfortunately not a high priority issue, which makes justifying drastic changes to the build process a lot harder, but I hope this PR will get the ball rolling.
