### PR TITLE
build: use `resolve4`/`resolve6` in `build:dns-fallback`.

### DIFF
--- a/ts/scripts/generate-dns-fallback.ts
+++ b/ts/scripts/generate-dns-fallback.ts
@@ -1,15 +1,15 @@
 // Copyright 2024 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { join } from 'path';
-import { lookup as lookupCb } from 'dns';
+import { resolve4 as resolve4Cb, resolve6 as resolve6Cb } from 'dns';
 import { writeFile } from 'fs/promises';
+import { join } from 'path';
 import { promisify } from 'util';
-import type { ResolvedEndpoint } from 'electron';
 
 import { isNotNil } from '../util/isNotNil';
 
-const lookup = promisify(lookupCb);
+const resolve4 = promisify(resolve4Cb);
+const resolve6 = promisify(resolve6Cb);
 
 const FALLBACK_DOMAINS = [
   'chat.signal.org',
@@ -25,35 +25,31 @@ const FALLBACK_DOMAINS = [
 async function main() {
   const config = await Promise.all(
     FALLBACK_DOMAINS.sort().map(async domain => {
-      const addresses = await lookup(domain, { all: true });
 
-      const endpoints = addresses
-        .map(({ address, family }): ResolvedEndpoint | null => {
-          if (family === 4) {
-            return { family: 'ipv4', address };
-          }
-          if (family === 6) {
-            return { family: 'ipv6', address };
-          }
-          return null;
-        })
-        .filter(isNotNil)
-        .sort((a, b) => {
-          if (a.family < b.family) {
-            return -1;
-          }
-          if (a.family > b.family) {
-            return 1;
-          }
+      const ipv4endpoints = (await resolve4(domain))
+        .map(a => ({"family": "ipv4", "address": a}))
 
-          if (a.address < b.address) {
-            return -1;
-          }
-          if (a.address > b.address) {
-            return 1;
-          }
-          return 0;
-        });
+      const ipv6endpoints = (await resolve6(domain))
+        .map(a => ({"family": "ipv6", "address": a}))
+
+      const endpoints = [...ipv4endpoints, ...ipv6endpoints]
+      .filter(isNotNil)
+      .sort((a, b) => {
+        if (a.family < b.family) {
+          return -1;
+        }
+        if (a.family > b.family) {
+          return 1;
+        }
+
+        if (a.address < b.address) {
+          return -1;
+        }
+        if (a.address > b.address) {
+          return 1;
+        }
+        return 0;
+      })
 
       return { domain, endpoints };
     })


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

`dns.lookup` relies on making syscalls to the underlying system using `getaddrinfo`, which can sometimes fail in proxy situations.

This is an equivalent implementation using the native NodeJS DNS functions.
