### PR TITLE
Build AppImage release

### DIFF
--- a/package.json
+++ b/package.json
@@ -454,23 +454,10 @@
         "StartupWMClass": "Signal"
       },
       "target": [
-        "deb"
+        "appimage"
       ],
       "icon": "build/icons/png",
       "publish": []
-    },
-    "deb": {
-      "depends": [
-        "libnotify4",
-        "libxtst6",
-        "libnss3",
-        "libasound2",
-        "libxss1",
-        "libc6 (>= 2.31)",
-        "libgtk-3-0",
-        "libgbm1",
-        "libx11-xcb1"
-      ]
     },
     "protocols": {
       "name": "sgnl-url-scheme",


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X ] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X ] My contribution is **not** related to translations.
- [X ] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X ] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X ] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X ] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.
Changed release type from deb to appimage, removed deb requires in package.json

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"
Fixes  #1758 
Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
Built without errors, test release functionality without any issues.
Tested in Fedora 40 KDE x86_64