### PR TITLE
Load `og:image` preview even if Content-Length header is missing

### DIFF
--- a/ts/linkPreviews/linkPreviewFetch.ts
+++ b/ts/linkPreviews/linkPreviewFetch.ts
@@ -600,6 +600,12 @@ export async function fetchLinkPreviewImage(
     return null;
   }
 
+  // Second check for image size in case there is no Content-Length header
+  if (data.length > MAX_IMAGE_CONTENT_LENGTH) {
+    logger.warn('fetchLinkPreviewImage: Image size is too large; bailing');
+    return null;
+  }
+
   if (abortSignal.aborted) {
     return null;
   }

--- a/ts/linkPreviews/linkPreviewFetch.ts
+++ b/ts/linkPreviews/linkPreviewFetch.ts
@@ -567,6 +567,14 @@ export async function fetchLinkPreviewImage(
     return null;
   }
 
+  const { type: contentType } = parseContentType(
+    response.headers.get('Content-Type')
+  );
+  if (!contentType || !VALID_IMAGE_MIME_TYPES.has(contentType)) {
+    logger.warn('fetchLinkPreviewImage: Content-Type is not an image; bailing');
+    return null;
+  }
+
   const contentLength = parseContentLength(
     response.headers.get('Content-Length')
   );
@@ -578,14 +586,6 @@ export async function fetchLinkPreviewImage(
     logger.warn(
       'fetchLinkPreviewImage: Content-Length is too large or is unset; bailing'
     );
-    return null;
-  }
-
-  const { type: contentType } = parseContentType(
-    response.headers.get('Content-Type')
-  );
-  if (!contentType || !VALID_IMAGE_MIME_TYPES.has(contentType)) {
-    logger.warn('fetchLinkPreviewImage: Content-Type is not an image; bailing');
     return null;
   }
 

--- a/ts/linkPreviews/linkPreviewFetch.ts
+++ b/ts/linkPreviews/linkPreviewFetch.ts
@@ -177,6 +177,11 @@ const isInlineContentDisposition = (headerValue: string | null): boolean =>
   !headerValue || headerValue.split(';', 1)[0] === 'inline';
 
 const parseContentLength = (headerValue: string | null): number => {
+  if (headerValue == null) {
+    // If no Content-Length header is given, assume the max allowed value
+    return MAX_IMAGE_CONTENT_LENGTH;
+  }
+
   // No need to parse gigantic Content-Lengths; only parse the first 10 digits.
   if (typeof headerValue !== 'string' || !/^\d{1,10}$/g.test(headerValue)) {
     return Infinity;
@@ -583,9 +588,7 @@ export async function fetchLinkPreviewImage(
     return null;
   }
   if (contentLength > MAX_IMAGE_CONTENT_LENGTH) {
-    logger.warn(
-      'fetchLinkPreviewImage: Content-Length is too large or is unset; bailing'
-    );
+    logger.warn('fetchLinkPreviewImage: Content-Length is too large; bailing');
     return null;
   }
 

--- a/ts/test-electron/linkPreviews/linkPreviewFetch_test.ts
+++ b/ts/test-electron/linkPreviews/linkPreviewFetch_test.ts
@@ -1280,7 +1280,7 @@ describe('link preview fetching', () => {
       );
     });
 
-    it('returns null if the response is too large', async () => {
+    it('returns null if the Content-Length is too large', async () => {
       const fakeFetch = stub().resolves(
         new Response(await readFixture('kitten-1-64-64.jpg'), {
           headers: {
@@ -1302,7 +1302,32 @@ describe('link preview fetching', () => {
       sinon.assert.calledOnce(warn);
       sinon.assert.calledWith(
         warn,
-        'fetchLinkPreviewImage: Content-Length is too large or is unset; bailing'
+        'fetchLinkPreviewImage: Content-Length is too large; bailing'
+      );
+    });
+
+    it('returns null if the actual image is too large', async () => {
+      const fakeFetch = stub().resolves(
+        new Response(await readFixture('tina-rolf-269345-unsplash.jpg'), {
+          headers: {
+            'Content-Type': 'image/jpeg',
+          },
+        })
+      );
+
+      assert.isNull(
+        await fetchLinkPreviewImage(
+          fakeFetch,
+          'https://example.com/img',
+          new AbortController().signal,
+          logger
+        )
+      );
+
+      sinon.assert.calledOnce(warn);
+      sinon.assert.calledWith(
+        warn,
+        'fetchLinkPreviewImage: Image size is too large; bailing'
       );
     });
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes #6645. As mentioned in the issue already, a lot of major CDNs (e.g. Amazon's CloudFront) omit the `Content-Length` header in some cases like when compression is enabled. This means that a lot of preview images cannot be loaded on desktop, but load without any issues on the mobile apps, which is confusing for users.

I changed the behavior to not fail when the header is missing. To still keep it safe I moved the `Content-Type` check in front of it and added a second one checking the actual size of the returned body before loading the image.

Tested with product pages of the shop I work with, previously the image wouldn't load at all, now it's displayed nicely in the chat. I also added a test to see if the second check was working as expected to still bail on huge images. I tested it on Fedora Linux 40 but no other devices.

![screenshot-20241010-104432](https://github.com/user-attachments/assets/7a497387-ff88-4f7f-851e-083f7b0426c3)
