### PR TITLE
Use isFocused() instead of isVisible() in tray service to refocus Signal window

### DIFF
--- a/app/SystemTrayService.ts
+++ b/app/SystemTrayService.ts
@@ -157,7 +157,7 @@ export class SystemTrayService {
       Menu.buildFromTemplate([
         {
           id: 'toggleWindowVisibility',
-          ...(browserWindow?.isVisible()
+          ...(browserWindow?.isFocused()
             ? {
                 label: this.i18n('icu:hide'),
                 click: () => {
@@ -223,7 +223,7 @@ export class SystemTrayService {
       if (!browserWindow) {
         return;
       }
-      if (browserWindow.isVisible()) {
+      if (browserWindow.isFocused()) {
         browserWindow.hide();
       } else {
         browserWindow.show();


### PR DESCRIPTION

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

This PR should close #6429.
As suggested by @Sajito, it changes the `SystemTrayService` in a way that instead of using the [`isVisible`](https://www.electronjs.org/docs/latest/api/base-window#winisvisible) method it now makes use of the [`isFocused`](https://www.electronjs.org/docs/latest/api/base-window#winisfocused) method in the click handler/ menu builder to determine, whether the Signal Desktop app should be hidden or shown.
While in theory `isVisible` should also lead to the desired behavior, on platforms like KDE Plasma this doesn't work and reports true even if the window is out of focus.
With the `isFocused` method, this is not the case anymore.

I only tested this PR on Manjaro Linux running KDE Plasma 6 (Wayland), so it would be helpful to test the new behavior on other platforms as well.
I can maybe do the Windows 11 test as well.