### PR TITLE
New scrollable sticker picker

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -5740,10 +5740,6 @@ button.module-calling-participants-list__contact {
   }
 }
 
-.module-sticker-picker__recents--title {
-  color: $color-gray-05;
-}
-
 .module-sticker-picker__header__button {
   width: 28px;
   height: 28px;
@@ -5960,6 +5956,55 @@ button.module-calling-participants-list__contact {
   background-color: $color-gray-05;
 }
 
+.module-sticker-picker__pack-title {
+  display: flex;
+  flex-direction: column;
+  justify-content: end;
+
+  margin-bottom: 5px;
+  height: 40px;
+
+  white-space: nowrap;
+
+  &__recents {
+    height: 20px;
+    margin-top: 0;
+    margin-bottom: 10px;
+  }
+
+  & > h3 {
+    height: 20px;
+
+    @include light-theme {
+      color: $color-gray-95;
+    }
+
+    @include dark-theme {
+      color: $color-gray-05;
+    }
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    margin: 0;
+    padding: 0;
+  }
+
+  & > i {
+    @include light-theme {
+      color: $color-gray-90;
+    }
+
+    @include dark-theme {
+      color: $color-gray-15;
+    }
+    height: 20px;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
 .module-sticker-picker__body {
   position: relative;
 
@@ -5968,14 +6013,15 @@ button.module-calling-participants-list__contact {
     grid-gap: 8px;
     grid-template-columns: repeat(4, 1fr);
     grid-auto-rows: 68px;
+
+    margin-bottom: 20px;
   }
 
   &__content {
     width: 332px;
-    height: 356px;
-    padding-block: 8px 16px;
+    height: 386px;
     padding-inline: 13px;
-    overflow-y: auto;
+    overflow: none;
 
     &--under-text {
       height: 320px;
@@ -6031,8 +6077,8 @@ button.module-calling-participants-list__contact {
     @include font-body-1-bold;
 
     text-align: center;
-    padding-block: 8px 12px;
-    padding-inline: 0 16px;
+    height: 30px;
+    padding: 0;
 
     @include light-theme() {
       color: $color-gray-60;
@@ -6057,6 +6103,7 @@ button.module-calling-participants-list__contact {
     }
 
     &--hint {
+      height: 60px;
       @include light-theme() {
         color: $color-ultramarine;
       }
@@ -6065,12 +6112,23 @@ button.module-calling-participants-list__contact {
         color: $color-ultramarine-light;
       }
     }
+  }
+}
 
-    &--pin {
-      padding-block: 8px 12px;
-      padding-inline: 0px 16px;
-      position: absolute;
-      top: 0;
+.module-sticker-picker__featured {
+  margin-bottom: 20px;
+
+  &--title {
+    height: 20px;
+    margin-top: 0;
+    margin-bottom: 10px;
+
+    @include light-theme {
+      color: $color-gray-95;
+    }
+
+    @include dark-theme {
+      color: $color-gray-05;
     }
   }
 }

--- a/ts/components/stickers/StickerPicker.tsx
+++ b/ts/components/stickers/StickerPicker.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
+import { List } from 'react-virtualized';
 
 import { useRestoreFocus } from '../../hooks/useRestoreFocus';
 import type { StickerPackType, StickerType } from '../../state/ducks/stickers';
@@ -28,22 +29,21 @@ export type OwnProps = {
 
 export type Props = OwnProps & Pick<React.HTMLProps<HTMLDivElement>, 'style'>;
 
-function useTabs<T>(tabs: ReadonlyArray<T>, initialTab = tabs[0]) {
-  const [tab, setTab] = React.useState(initialTab);
-  const handlers = React.useMemo(
-    () =>
-      tabs.map(t => () => {
-        setTab(t);
-      }),
-    [tabs]
-  );
-
-  return [tab, handlers] as [T, ReadonlyArray<() => void>];
-}
-
 const PACKS_PAGE_SIZE = 7;
 const PACK_ICON_WIDTH = 32;
 const PACK_PAGE_WIDTH = PACKS_PAGE_SIZE * PACK_ICON_WIDTH;
+
+const STICKER_HEIGHT = 68;
+// 20 in height + 5 in margin-top + 5 in margin-bottom
+const RECENTS_HEADER_HEIGHT = 20 + 5 + 5;
+const SHOW_TEXT_HEIGHT = 30;
+const SHOW_LONG_TEXT_HEIGHT = 60;
+// 40 in height + 5 in margin-bottom
+const PACK_NAME_HEIGHT = 40 + 5;
+const PACK_MARGIN_BOTTOM = 20;
+// 20px in margin-bottom
+const FEATURED_STICKERS_HEIGHT =
+  RECENTS_HEADER_HEIGHT + STICKER_HEIGHT + PACK_MARGIN_BOTTOM;
 
 function getPacksPageOffset(page: number, packs: number): number {
   if (page === 0) {
@@ -80,22 +80,12 @@ export const StickerPicker = React.memo(
       }: Props,
       ref
     ) => {
-      const tabIds = React.useMemo(
-        () => ['recents', ...packs.map(({ id }) => id)],
-        [packs]
-      );
-      const [currentTab, [recentsHandler, ...packsHandlers]] = useTabs(
-        tabIds,
-        // If there are no recent stickers,
-        // default to the first sticker pack,
-        // unless there are no sticker packs.
-        tabIds[recentStickers.length > 0 ? 0 : Math.min(1, tabIds.length)]
-      );
-      const selectedPack = packs.find(({ id }) => id === currentTab);
-      const {
-        stickers = recentStickers,
-        title: packTitle = 'Recent Stickers',
-      } = selectedPack || {};
+      // The index of the pack we're browsing (whether by
+      // scrolling to it, or clicking on it) on the virtualized list.
+      // 0 is the index for the recent/feature stickers element.
+      const [selectedPackIndex, setSelectedPackIndex] = React.useState(0);
+
+      const isRTL = i18n.getLocaleDirection() === 'rtl';
 
       const [isUsingKeyboard, setIsUsingKeyboard] = React.useState(false);
       const [packsPage, setPacksPage] = React.useState(0);
@@ -105,6 +95,90 @@ export const StickerPicker = React.memo(
       const onClickNextPackPage = React.useCallback(() => {
         setPacksPage(i => i + 1);
       }, [setPacksPage]);
+
+      const packDownloadInfo = React.useCallback((pack: StickerPackType) => {
+        const pendingCount =
+          pack && pack.status === 'pending'
+            ? pack.stickerCount - pack.stickers.length
+            : 0;
+
+        const hasDownloadError =
+          pack &&
+          pack.status === 'error' &&
+          pack.stickerCount !== pack.stickers.length;
+
+        const showPendingText = pendingCount > 0;
+        const showEmptyText =
+          pack && !hasDownloadError && pack.stickerCount === 0;
+        const showText = showPendingText || hasDownloadError || showEmptyText;
+
+        return [
+          showText,
+          showPendingText,
+          pendingCount,
+          showEmptyText,
+          hasDownloadError,
+        ];
+      }, []);
+
+      const hasPacks = packs.length > 0;
+      const hasRecents = recentStickers.length > 0;
+      const isRecentsSelected = hasPacks && selectedPackIndex === 0;
+
+      const hasTimeStickers = isRecentsSelected && onPickTimeSticker;
+      const isEmpty = !hasPacks && !hasTimeStickers && !hasRecents;
+
+      const rowHeight = React.useCallback(
+        ({ index }: { index: number }) => {
+          const isRecents = index === 0;
+
+          if (isRecents && !hasRecents && !hasTimeStickers) {
+            return 0;
+          }
+
+          const isLastPack = !isRecents && index === packs.length;
+          const stickerCount = isRecents
+            ? recentStickers.length
+            : packs[index - 1].stickers.length;
+
+          const [showText] = packDownloadInfo(packs[index - 1]);
+
+          const rows = Math.ceil(stickerCount / 4);
+
+          // Extra height can be needed to render pending downloads or errors
+          const showTextHeight = !isRecents && showText ? SHOW_TEXT_HEIGHT : 0;
+
+          const showHintHeight =
+            isRecents && showPickerHint ? SHOW_LONG_TEXT_HEIGHT : 0;
+
+          const recentStickersHeaderHeight =
+            (hasRecents ? RECENTS_HEADER_HEIGHT : 0) +
+            (hasTimeStickers ? FEATURED_STICKERS_HEIGHT : 0) +
+            showHintHeight;
+
+          const packHeaderHeight = isRecents
+            ? recentStickersHeaderHeight
+            : PACK_NAME_HEIGHT;
+
+          const packGridHeight = STICKER_HEIGHT * rows;
+          const packBottomMargin =
+            !isLastPack || (isRecents && hasRecents) ? PACK_MARGIN_BOTTOM : 0;
+          // We have to consider 8px padding in between each row
+          const packGridPadding = 8 * (rows - 1) + packBottomMargin;
+
+          return (
+            packHeaderHeight + showTextHeight + packGridHeight + packGridPadding
+          );
+        },
+        [
+          recentStickers,
+          packs,
+          showPickerHint,
+          hasRecents,
+          hasTimeStickers,
+          packDownloadInfo,
+        ]
+      );
 
       // Handle escape key
       React.useEffect(() => {
@@ -135,27 +209,259 @@ export const StickerPicker = React.memo(
       // Focus popup on after initial render, restore focus on teardown
       const [focusRef] = useRestoreFocus();
 
-      const hasPacks = packs.length > 0;
-      const isRecents = hasPacks && currentTab === 'recents';
-      const hasTimeStickers = isRecents && onPickTimeSticker;
-      const isEmpty = stickers.length === 0 && !hasTimeStickers;
       const addPackRef = isEmpty ? focusRef : undefined;
-      const downloadError =
-        selectedPack &&
-        selectedPack.status === 'error' &&
-        selectedPack.stickerCount !== selectedPack.stickers.length;
-      const pendingCount =
-        selectedPack && selectedPack.status === 'pending'
-          ? selectedPack.stickerCount - stickers.length
-          : 0;
 
-      const showPendingText = pendingCount > 0;
-      const showDownloadErrorText = downloadError;
-      const showEmptyText = !downloadError && isEmpty;
-      const showText =
-        showPendingText || showDownloadErrorText || showEmptyText;
-      const showLongText = showPickerHint;
-      const analogTime = getAnalogTime();
+      const listRef = React.createRef<List>();
+
+      // Computing the entire list height when rendering
+      // (or after new packs are added) is important to get
+      // an accurate scroll offset and scrollbar length
+      React.useEffect(() => {
+        if (listRef.current) {
+          listRef.current.measureAllRows();
+        }
+        // We don't want to have listRef as a dependency because
+        // it updates too much and `measureAllRows()` is an expensive
+        // operation. The only thing that can affect row height is newly
+        // downloaded packs, so `packs.length` is enough
+        //
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [packs.length]);
+
+      const renderStickerGrid = React.useCallback(
+        (packTitle: string, stickerList: ReadonlyArray<StickerType>) =>
+          stickerList.map(sticker => (
+            <button
+              type="button"
+              key={`${sticker.packId}-${sticker.id}`}
+              className="module-sticker-picker__body__cell"
+              onClick={() =>
+                onPickSticker(sticker.packId, sticker.id, sticker.url)
+              }
+            >
+              <img
+                className="module-sticker-picker__body__cell__image"
+                src={sticker.url}
+                width={STICKER_HEIGHT}
+                height={STICKER_HEIGHT}
+                alt={`${packTitle} ${sticker.emoji}`}
+              />
+            </button>
+          )),
+        [onPickSticker]
+      );
+
+      const rowRenderer = React.useCallback(
+        ({
+          index,
+          key: listKey,
+          style: listStyle,
+        }: {
+          index: number;
+          key: string;
+          style: React.CSSProperties;
+        }) => {
+          const analogTime = getAnalogTime();
+
+          // Recents and/or featured stickers are at special index 0.
+          if (index === 0) {
+            const featuredStickerElement = hasTimeStickers && (
+              <div className="module-sticker-picker__featured">
+                <h3 className="module-sticker-picker__featured--title">
+                  {i18n('icu:stickers__StickerPicker__featured')}
+                </h3>
+                <div className="module-sticker-picker__body__grid">
+                  <button
+                    type="button"
+                    className="module-sticker-picker__body__cell module-sticker-picker__time--digital"
+                    onClick={() => onPickTimeSticker('digital')}
+                  >
+                    {getDateTimeFormatter({
+                      hour: 'numeric',
+                      minute: 'numeric',
+                    })
+                      .formatToParts(Date.now())
+                      .filter(x => x.type !== 'dayPeriod')
+                      .reduce((acc, { value }) => `${acc}${value}`, '')}
+                  </button>
+
+                  <button
+                    aria-label={i18n(
+                      'icu:stickers__StickerPicker__analog-time'
+                    )}
+                    className="module-sticker-picker__body__cell module-sticker-picker__time--analog"
+                    onClick={() => onPickTimeSticker('analog')}
+                    type="button"
+                  >
+                    <span
+                      className="module-sticker-picker__time--analog__hour"
+                      style={{
+                        transform: `rotate(${analogTime.hour}deg)`,
+                      }}
+                    />
+                    <span
+                      className="module-sticker-picker__time--analog__minute"
+                      style={{
+                        transform: `rotate(${analogTime.minute}deg)`,
+                      }}
+                    />
+                  </button>
+                </div>
+              </div>
+            );
+
+            const recentsPackTitle = i18n(
+              'icu:stickers__StickerPicker__recent'
+            );
+            const recentStickersElement = hasRecents && (
+              <>
+                <div
+                  className={classNames(
+                    'module-sticker-picker__pack-title',
+                    'module-sticker-picker__pack-title__recents'
+                  )}
+                >
+                  <h3>{recentsPackTitle}</h3>
+                </div>
+                <div className="module-sticker-picker__body__grid">
+                  {renderStickerGrid(recentsPackTitle, recentStickers)}
+                </div>
+              </>
+            );
+
+            return (
+              <div key={listKey} style={listStyle}>
+                {showPickerHint ? (
+                  <div
+                    className={classNames(
+                      'module-sticker-picker__body__text',
+                      'module-sticker-picker__body__text--hint'
+                    )}
+                  >
+                    {i18n('icu:stickers--StickerPicker--Hint')}
+                  </div>
+                ) : null}
+                {featuredStickerElement}
+                {recentStickersElement}
+              </div>
+            );
+          }
+
+          const selectedPack = packs[index - 1];
+          const [
+            ,
+            pendingCount,
+            showPendingText,
+            showEmptyText,
+            hasDownloadError,
+          ] = packDownloadInfo(selectedPack);
+
+          return (
+            <div key={listKey} style={listStyle}>
+              <div className="module-sticker-picker__pack-title">
+                <h3>{selectedPack.title}</h3>
+                <i>{selectedPack.author}</i>
+              </div>
+              {showPendingText ? (
+                <div className="module-sticker-picker__body__text">
+                  {i18n('icu:stickers--StickerPicker--DownloadPending')}
+                </div>
+              ) : null}
+              {hasDownloadError && selectedPack.stickers.length > 0 ? (
+                <div
+                  className={classNames(
+                    'module-sticker-picker__body__text',
+                    'module-sticker-picker__body__text--error'
+                  )}
+                >
+                  {i18n('icu:stickers--StickerPicker--DownloadError')}
+                </div>
+              ) : null}
+              {hasPacks && showEmptyText ? (
+                <div
+                  className={classNames('module-sticker-picker__body__text', {
+                    'module-sticker-picker__body__text--error':
+                      !isRecentsSelected,
+                  })}
+                >
+                  {i18n('icu:stickers--StickerPicker--Empty')}
+                </div>
+              ) : null}
+              <div className="module-sticker-picker__body__grid">
+                {renderStickerGrid(selectedPack.title, selectedPack.stickers)}
+                {showPendingText
+                  ? Array(pendingCount)
+                      .fill(0)
+                      .map((_, i) => (
+                        <div
+                          // eslint-disable-next-line react/no-array-index-key
+                          key={`${listKey}-${i}`}
+                          className="module-sticker-picker__body__cell__placeholder"
+                          role="presentation"
+                        />
+                      ))
+                  : null}
+              </div>
+            </div>
+          );
+        },
+        [
+          recentStickers,
+          packs,
+          showPickerHint,
+          hasPacks,
+          hasRecents,
+          hasTimeStickers,
+          isRecentsSelected,
+          i18n,
+          onPickTimeSticker,
+          packDownloadInfo,
+          renderStickerGrid,
+        ]
+      );
+
+      const onRowsRendered = React.useCallback(
+        ({ startIndex }: { startIndex: number }) => {
+          if (startIndex === 0) {
+            setPacksPage(0);
+          } else if (startIndex > 0 && selectedPackIndex > 0) {
+            // If we're on a new page, we're on a new multiple of PACKS_PAGE_SIZE
+            // (because there are PACKS_PAGE_SIZE stickers per page)
+            //
+            // The indexes have an offset of 1 because of recent stickers at index 0.
+            const newPage = Math.floor((startIndex - 1) / PACKS_PAGE_SIZE);
+            const oldPage = Math.floor(
+              (selectedPackIndex - 1) / PACKS_PAGE_SIZE
+            );
+            const pageDiff = newPage - oldPage;
+
+            if (
+              packsPage !== newPage ||
+              (pageDiff > 0 && !isLastPacksPage(packsPage, packs.length)) ||
+              (pageDiff < 0 && packsPage > 0)
+            ) {
+              setPacksPage(newPage);
+            }
+          }
+
+          setSelectedPackIndex(startIndex);
+        },
+        [
+          packsPage,
+          setPacksPage,
+          selectedPackIndex,
+          setSelectedPackIndex,
+          packs.length,
+        ]
+      );
+
+      const noRowsRenderer = React.useCallback(() => {
+        return (
+          <div className="module-sticker-picker__body__text">
+            {i18n('icu:stickers--StickerPicker--NoPacks')}
+          </div>
+        );
+      }, [i18n]);
 
       return (
         <FocusTrap
@@ -169,54 +475,79 @@ export const StickerPicker = React.memo(
                 <div
                   className="module-sticker-picker__header__packs__slider"
                   style={{
-                    transform: `translateX(-${getPacksPageOffset(
+                    transform: `translateX(${isRTL ? '' : '-'}${getPacksPageOffset(
                       packsPage,
                       packs.length
                     )}px)`,
                   }}
                 >
-                  {hasPacks ? (
-                    <button
-                      aria-pressed={currentTab === 'recents'}
-                      type="button"
-                      onClick={recentsHandler}
-                      className={classNames({
-                        'module-sticker-picker__header__button': true,
-                        'module-sticker-picker__header__button--recents': true,
-                        'module-sticker-picker__header__button--selected':
-                          currentTab === 'recents',
-                      })}
-                      aria-label={i18n('icu:stickers--StickerPicker--Recents')}
-                    />
-                  ) : null}
-                  {packs.map((pack, i) => (
-                    <button
-                      aria-pressed={currentTab === pack.id}
-                      type="button"
-                      key={pack.id}
-                      onClick={packsHandlers[i]}
-                      className={classNames(
-                        'module-sticker-picker__header__button',
-                        {
-                          'module-sticker-picker__header__button--selected':
-                            currentTab === pack.id,
-                          'module-sticker-picker__header__button--error':
-                            pack.status === 'error',
-                        }
-                      )}
-                    >
-                      {pack.cover ? (
-                        <img
-                          className="module-sticker-picker__header__button__image"
-                          src={pack.cover.url}
-                          alt={pack.title}
-                          title={pack.title}
-                        />
-                      ) : (
-                        <div className="module-sticker-picker__header__button__image-placeholder" />
-                      )}
-                    </button>
-                  ))}
+                  <button
+                    aria-pressed={isRecentsSelected}
+                    type="button"
+                    onClick={() => {
+                      listRef.current?.scrollToRow(0);
+                    }}
+                    className={classNames({
+                      'module-sticker-picker__header__button': true,
+                      'module-sticker-picker__header__button--recents': true,
+                      'module-sticker-picker__header__button--selected':
+                        isRecentsSelected,
+                    })}
+                    aria-label={i18n('icu:stickers--StickerPicker--Recents')}
+                  />
+                  {packs.map((pack, i) => {
+                    // Since recent stickers at at row 0,
+                    // we have to offset by 1 to get the pack index
+                    const packIndex = i + 1;
+
+                    return (
+                      <button
+                        aria-pressed={selectedPackIndex === packIndex}
+                        type="button"
+                        key={pack.id}
+                        onClick={() => {
+                          if (listRef.current) {
+                            // scrollToRow has floating point issues so onRowRendered can
+                            // end up returning the wrong rows if the user has fractional
+                            // scaling or app zoom (ask how I know...)
+                            //
+                            // So we add an epsilon value to the computed row position and
+                            // scroll that amount instead. 1 pixel extra is invisible and
+                            // ensures the problem goes away for good
+                            const positionEpsilon = 1.0;
+
+                            const packPosition =
+                              listRef.current.getOffsetForRow({
+                                alignment: 'start',
+                                index: packIndex,
+                              }) + positionEpsilon;
+
+                            listRef.current.scrollToPosition(packPosition);
+                          }
+                        }}
+                        className={classNames(
+                          'module-sticker-picker__header__button',
+                          {
+                            'module-sticker-picker__header__button--selected':
+                              selectedPackIndex === packIndex,
+                            'module-sticker-picker__header__button--error':
+                              pack.status === 'error',
+                          }
+                        )}
+                      >
+                        {pack.cover ? (
+                          <img
+                            className="module-sticker-picker__header__button__image"
+                            src={pack.cover.url}
+                            alt={pack.title}
+                            title={pack.title}
+                          />
+                        ) : (
+                          <div className="module-sticker-picker__header__button__image-placeholder" />
+                        )}
+                      </button>
+                    );
+                  })}
                 </div>
                 {!isUsingKeyboard && packsPage > 0 ? (
                   <button
@@ -264,143 +595,25 @@ export const StickerPicker = React.memo(
                 'module-sticker-picker__body--empty': isEmpty,
               })}
             >
-              {showPickerHint ? (
-                <div
-                  className={classNames(
-                    'module-sticker-picker__body__text',
-                    'module-sticker-picker__body__text--hint',
-                    {
-                      'module-sticker-picker__body__text--pin': showEmptyText,
-                    }
-                  )}
-                >
-                  {i18n('icu:stickers--StickerPicker--Hint')}
-                </div>
-              ) : null}
-              {!hasPacks ? (
-                <div className="module-sticker-picker__body__text">
-                  {i18n('icu:stickers--StickerPicker--NoPacks')}
-                </div>
-              ) : null}
-              {pendingCount > 0 ? (
-                <div className="module-sticker-picker__body__text">
-                  {i18n('icu:stickers--StickerPicker--DownloadPending')}
-                </div>
-              ) : null}
-              {downloadError ? (
-                <div
-                  className={classNames(
-                    'module-sticker-picker__body__text',
-                    'module-sticker-picker__body__text--error'
-                  )}
-                >
-                  {stickers.length > 0
-                    ? i18n('icu:stickers--StickerPicker--DownloadError')
-                    : i18n('icu:stickers--StickerPicker--Empty')}
-                </div>
-              ) : null}
-              {hasPacks && showEmptyText ? (
-                <div
-                  className={classNames('module-sticker-picker__body__text', {
-                    'module-sticker-picker__body__text--error': !isRecents,
-                  })}
-                >
-                  {isRecents
-                    ? i18n('icu:stickers--StickerPicker--NoRecents')
-                    : i18n('icu:stickers--StickerPicker--Empty')}
-                </div>
-              ) : null}
-              {!isEmpty ? (
-                <div className="module-sticker-picker__body__content">
-                  {isRecents && onPickTimeSticker && (
-                    <div className="module-sticker-picker__recents">
-                      <strong className="module-sticker-picker__recents__title">
-                        {i18n('icu:stickers__StickerPicker__featured')}
-                      </strong>
-                      <div className="module-sticker-picker__body__grid">
-                        <button
-                          type="button"
-                          className="module-sticker-picker__body__cell module-sticker-picker__time--digital"
-                          onClick={() => onPickTimeSticker('digital')}
-                        >
-                          {getDateTimeFormatter({
-                            hour: 'numeric',
-                            minute: 'numeric',
-                          })
-                            .formatToParts(Date.now())
-                            .filter(x => x.type !== 'dayPeriod')
-                            .reduce((acc, { value }) => `${acc}${value}`, '')}
-                        </button>
-
-                        <button
-                          aria-label={i18n(
-                            'icu:stickers__StickerPicker__analog-time'
-                          )}
-                          className="module-sticker-picker__body__cell module-sticker-picker__time--analog"
-                          onClick={() => onPickTimeSticker('analog')}
-                          type="button"
-                        >
-                          <span
-                            className="module-sticker-picker__time--analog__hour"
-                            style={{
-                              transform: `rotate(${analogTime.hour}deg)`,
-                            }}
-                          />
-                          <span
-                            className="module-sticker-picker__time--analog__minute"
-                            style={{
-                              transform: `rotate(${analogTime.minute}deg)`,
-                            }}
-                          />
-                        </button>
-                      </div>
-                      {stickers.length > 0 && (
-                        <strong className="module-sticker-picker__recents__title">
-                          {i18n('icu:stickers__StickerPicker__recent')}
-                        </strong>
-                      )}
-                    </div>
-                  )}
-                  <div
-                    className={classNames('module-sticker-picker__body__grid', {
-                      'module-sticker-picker__body__content--under-text':
-                        showText,
-                      'module-sticker-picker__body__content--under-long-text':
-                        showLongText,
-                    })}
-                  >
-                    {stickers.map(({ packId, id, url }, index: number) => {
-                      const maybeFocusRef = index === 0 ? focusRef : undefined;
-
-                      return (
-                        <button
-                          type="button"
-                          ref={maybeFocusRef}
-                          key={`${packId}-${id}`}
-                          className="module-sticker-picker__body__cell"
-                          onClick={() => onPickSticker(packId, id, url)}
-                        >
-                          <img
-                            className="module-sticker-picker__body__cell__image"
-                            src={url}
-                            alt={packTitle}
-                          />
-                        </button>
-                      );
-                    })}
-                    {Array(pendingCount)
-                      .fill(0)
-                      .map((_, i) => (
-                        <div
-                          // eslint-disable-next-line react/no-array-index-key
-                          key={i}
-                          className="module-sticker-picker__body__cell__placeholder"
-                          role="presentation"
-                        />
-                      ))}
-                  </div>
-                </div>
-              ) : null}
+              <div className="module-sticker-picker__body__content">
+                <List
+                  width={316}
+                  height={344}
+                  ref={listRef}
+                  style={{
+                    direction: isRTL ? 'rtl' : 'ltr',
+                  }}
+                  scrollToAlignment="start"
+                  noRowsRenderer={noRowsRenderer}
+                  // Even if there are no recent stickers,
+                  // there is always a row offset of 1
+                  rowCount={isEmpty ? 0 : packs.length + 1}
+                  rowHeight={rowHeight}
+                  rowRenderer={rowRenderer}
+                  overscanRowCount={0}
+                  onRowsRendered={onRowsRendered}
+                />
+              </div>
             </div>
           </div>
         </FocusTrap>


### PR DESCRIPTION
This new sticker picker allows users to scroll through their whole list of stickers, without having to click a single button.

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/) (so did @spazzylemons)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This PR allows users to scroll through all the stickers on the same menu, without having to tediously look for the relevant sticker pack using the cumbersome buttons/pages at the top.

I used virtualization for efficiently rendering the stickers, so it is a non-trivial change: I had to move elements rendering into a rowRenderer, and find a way to calculate the heights of each row exactly (using rowHeight).

(Note: the scrollbar height issue in the video has since been fixed)

[scrollable picker.webm](https://github.com/user-attachments/assets/45f7d333-ecc3-4f05-89b8-e54f15ff6a5d)


#### Performance

Performance is just about the same as before, except initial loading is slightly slower. Scrolling through a large list incurs high CPU usage. I did consider using placeholders while scrolling, which makes it faster, but makes the real stickers load much slower when scrolling stops, so I decided it was not worth it.

In practice, on slow CPUs it works fine, and on a more modern computer it works great. Heap allocation is about the same as before as well. I've compared those things using Chromium's profiler (and I happen to have a slow laptop so I can tell).

This is outside the scope of this PR but I think in general performance would be much improved if tinier/compressed 68x68 sticker thumbnails were loaded rather than the full-quality original files as it is currently being done.

#### Design considerations

I made the sticker pack titles a bit bigger (`<h3>`) than what seems typical for other elements in the app--my thought process was that users may scroll through their stickers quickly, so bigger text means easier to read and more quickly.

AFAICT accessibility is not affected and should remain the same as it used to. Things are labelled correctly. I did change the alt text of individual stickers to include the emoji they're meant to represent (before that, it was just the sticker pack title). I thought that this was more appropriate so a screen reader can say what emoji the sticker is about.

- Recents don't show up if there are no recents stickers or no packs, so some messages were simplified
- Sticker packs can't be "empty" anymore. If there are no sticker packs at all, then the picker will just return a "no packs" message instead of an "empty" message. (Note that in practice this message won't really be seen--if there are no packs then the app sends the user to installing default stickers instead of opening the picker, but that can be bypassed with CTRL+SHIFT+G)

#### Testing

I did a lot of manual testing. I tested that scrolling behaves as expected, stickers send as expected, and that the sticker picker in the media editor works as expected. The featured time stickers in the media editor's sticker picker are OK. The picker updates correctly when a sticker is added/downloaded. Keyboard navigation works. RTL works (in fact there is a bug in the original sticker picker that I fixed here). Dark theme/light theme works. Accessibility labels/screen readers seem to be OK but I don't have experience with them. Lastly I made sure rare/legacy text/error messages display correctly.

#### Credit

@spazzylemons helped me fix a bug I had, so they're co-authored.