### PR TITLE
Don't show sticker picker when replying to a message

### DIFF
--- a/ts/components/CompositionArea.tsx
+++ b/ts/components/CompositionArea.tsx
@@ -655,35 +655,36 @@ export const CompositionArea = memo(function CompositionArea({
     </>
   ) : null;
 
+  const shouldShowStickers =
+    !quotedMessageProps && !draftEditMessage && withStickers;
   const stickerButtonPlacement = large ? 'top-start' : 'top-end';
-  const stickerButtonFragment =
-    !draftEditMessage && withStickers ? (
-      <div className="CompositionArea__button-cell">
-        <StickerButton
-          i18n={i18n}
-          knownPacks={knownPacks}
-          receivedPacks={receivedPacks}
-          installedPack={installedPack}
-          installedPacks={installedPacks}
-          blessedPacks={blessedPacks}
-          recentStickers={recentStickers}
-          clearInstalledStickerPack={clearInstalledStickerPack}
-          onClickAddPack={() =>
-            pushPanelForConversation({
-              type: PanelType.StickerManager,
-            })
-          }
-          onPickSticker={(packId, stickerId) =>
-            sendStickerMessage(conversationId, { packId, stickerId })
-          }
-          showIntroduction={showIntroduction}
-          clearShowIntroduction={clearShowIntroduction}
-          showPickerHint={showPickerHint}
-          clearShowPickerHint={clearShowPickerHint}
-          position={stickerButtonPlacement}
-        />
-      </div>
-    ) : null;
+  const stickerButtonFragment = shouldShowStickers ? (
+    <div className="CompositionArea__button-cell">
+      <StickerButton
+        i18n={i18n}
+        knownPacks={knownPacks}
+        receivedPacks={receivedPacks}
+        installedPack={installedPack}
+        installedPacks={installedPacks}
+        blessedPacks={blessedPacks}
+        recentStickers={recentStickers}
+        clearInstalledStickerPack={clearInstalledStickerPack}
+        onClickAddPack={() =>
+          pushPanelForConversation({
+            type: PanelType.StickerManager,
+          })
+        }
+        onPickSticker={(packId, stickerId) =>
+          sendStickerMessage(conversationId, { packId, stickerId })
+        }
+        showIntroduction={showIntroduction}
+        clearShowIntroduction={clearShowIntroduction}
+        showPickerHint={showPickerHint}
+        clearShowPickerHint={clearShowPickerHint}
+        position={stickerButtonPlacement}
+      />
+    </div>
+  ) : null;
 
   // Listen for cmd/ctrl-shift-x to toggle large composition mode
   useEffect(() => {


### PR DESCRIPTION
The sticker picker could be opened when the user is about to send an attachment, or a reply, or text, neither of which can be combined with stickers.

I have personally witnessed many users thinking they could reply to a message with a sticker, then be surprised when the sticker they sent does not include the reply. This change makes it clear that you cannot send stickers as a reply to a message, or with text/attachments. Note that this behavior follows what iOS is doing, and I think Android should do the same.

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
