### PR TITLE
Fix context menu text being different based on where right click occurred for emojis

### DIFF
--- a/app/spell_check.ts
+++ b/app/spell_check.ts
@@ -97,7 +97,10 @@ export const setup = (
     const isMisspelled = Boolean(params.misspelledWord);
     const isLink = Boolean(params.linkURL);
     const isImage =
-      params.mediaType === 'image' && params.hasImageContents && params.srcURL;
+      params.mediaType === 'image' &&
+      params.hasImageContents &&
+      params.srcURL &&
+      !editFlags.canCopy;
     const showMenu =
       params.isEditable || editFlags.canCopy || isLink || isImage;
 

--- a/app/spell_check.ts
+++ b/app/spell_check.ts
@@ -100,7 +100,8 @@ export const setup = (
       params.mediaType === 'image' &&
       params.hasImageContents &&
       params.srcURL &&
-      !editFlags.canCopy;
+      !editFlags.canCopy; // emoji should not be treated as an image
+
     const showMenu =
       params.isEditable || editFlags.canCopy || isLink || isImage;
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
Fixes #7058 

The fix was to update the logic for `isImage` flag for the context menu. Currently, `isImage` flag is set to true for emojis, which should not be. Thus I added an extra check to filter out emojis, so `isImage` results in false for emojis. 

- What kind of manual testing did you do?
I used my macOS to test the changes. I sent some messages(with/without emojis) and images to myself for testing.
I tried to cover all combinations of texts, emojis, and images I could think of and ensure the changes behaved as expected. I made sure that `Copy` menu shows up as `Copy`(not `Copy Image`) regardless of where I right-click when it has text and emojis. 

![CleanShot 2024-11-05 at 09 59 52](https://github.com/user-attachments/assets/287dc988-fdef-4769-af82-041d89ce7719)

When I selected the emoji in the editable text input and right-clicked, there was no option for `Paste` because it was perceived as an image. However, I believe that was also a bug. So, I fixed it as part of my changes in this PR.

![CleanShot 2024-11-05 at 10 01 10](https://github.com/user-attachments/assets/d3b72799-d710-43f4-bad1-24076e5d2657)

- Did you write any new tests?
No, I did not

- What operating systems did you test with?
`macOS 10.15.7`

- What other devices did you test with?
No other devices because I believe this bug/fix is not platform-specific.

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
