### PR TITLE
fix for window not being shown with wayland in same cases by switching to the 'did-finish-load' event instead of 'ready-to-show'

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -992,7 +992,7 @@ async function createWindow() {
     }
   });
 
-  mainWindow.once('ready-to-show', async () => {
+  mainWindow.webContents.once('did-finish-load', async () => {
     getLogger().info('main window is ready-to-show');
 
     // Ignore sql errors and show the window anyway


### PR DESCRIPTION

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### related issues:
- fixes #6368
- fixes #6740
- https://github.com/signalapp/Signal-Desktop/issues/6966

### Description

on some setups signal is never shown due to electrons `ready-to-show` is not firing.

I've found that people use `did-finish-load` instead due to (probably) this bug (https://github.com/electron/electron/issues/25253#issuecomment-691624779).

After a deep rabbit hole into electron and the chromium source code I could not determine why this event is not fired, but both events should be more or less equal from their timing in our case, so it is a workaround, but can be used permanently.

https://www.electronjs.org/docs/latest/api/browser-window
> ### Using the `ready-to-show` event
> This event is usually emitted after the did-finish-load event, but for pages with many remote resources, it may be emitted before the did-finish-load event.


### setup with which I could reproduce the issue and verify the fix 
- latest `main` (`git checkout v7.35.0-alpha.1`)
- electron v33.1.0
- node v20.18.0
- Sway Desktop (wayland/wlroots-based)
- `ELECTRON_OZONE_PLATFORM_HINT=auto` environment variable


