### PR TITLE
Use a blurhash for blurred story backgrounds

### DIFF
--- a/stylesheets/components/StoryViewer.scss
+++ b/stylesheets/components/StoryViewer.scss
@@ -17,7 +17,6 @@
 
   &__content {
     align-items: center;
-    backdrop-filter: blur(90px);
     background: variables.$color-black-alpha-20;
     display: flex;
     flex-direction: column;

--- a/ts/components/StoryViewer.tsx
+++ b/ts/components/StoryViewer.tsx
@@ -5,8 +5,9 @@ import FocusTrap from 'focus-trap-react';
 import type { UIEvent } from 'react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
+import { BlurhashCanvas } from 'react-blurhash';
 import type { DraftBodyRanges } from '../types/BodyRange';
-import type { LocalizerType } from '../types/Util';
+import { ThemeType, type LocalizerType } from '../types/Util';
 import type { ContextMenuOptionType } from './ContextMenu';
 import type {
   ConversationType,
@@ -41,9 +42,9 @@ import { StoryViewsNRepliesModal } from './StoryViewsNRepliesModal';
 import { Theme } from '../util/theme';
 import { ToastType } from '../types/Toast';
 import { getAvatarColor } from '../types/Colors';
-import { getStoryBackground } from '../util/getStoryBackground';
+import { COLOR_BLACK_ALPHA_90 } from '../util/getStoryBackground';
 import { getStoryDuration } from '../util/getStoryDuration';
-import { isVideoAttachment } from '../types/Attachment';
+import { defaultBlurHash, isVideoAttachment } from '../types/Attachment';
 import { graphemeAndLinkAwareSlice } from '../util/graphemeAndLinkAwareSlice';
 import { useEscapeHandling } from '../hooks/useEscapeHandling';
 import { useRetryStorySend } from '../hooks/useRetryStorySend';
@@ -602,10 +603,21 @@ export function StoryViewer({
         }}
       >
         {alertElement}
-        <div
-          className="StoryViewer__overlay"
-          style={{ background: getStoryBackground(attachment) }}
-        />
+
+        {attachment ? (
+          <BlurhashCanvas
+            className="StoryViewer__overlay"
+            hash={attachment.blurHash || defaultBlurHash(ThemeType.dark)}
+            width={attachment.width}
+            height={attachment.height}
+          />
+        ) : (
+          <div
+            className="StoryViewer__overlay"
+            style={{ background: COLOR_BLACK_ALPHA_90 }}
+          />
+        )}
+
         <div className="StoryViewer__content">
           {canNavigateLeft && (
             <button

--- a/ts/util/getStoryBackground.ts
+++ b/ts/util/getStoryBackground.ts
@@ -3,7 +3,7 @@
 
 import type { AttachmentType, TextAttachmentType } from '../types/Attachment';
 
-const COLOR_BLACK_ALPHA_90 = 'rgba(0, 0, 0, 0.9)';
+export const COLOR_BLACK_ALPHA_90 = 'rgba(0, 0, 0, 0.9)';
 export const COLOR_BLACK_INT = 4278190080;
 export const COLOR_WHITE_INT = 4294704123;
 


### PR DESCRIPTION
### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Stories render very slowly on some devices. I believe this is due to the use of `backdrop-filter: blur(90px)` used in the background, which is CPU intensive. This might affect Linux particularly, because nearly all Windows/macOS users would have GPU acceleration, which likely helps render blur faster: https://community.signalusers.org/t/stories-extremely-slow-on-linux-desktop/60588

I have replaced the current CSS background/blur mechanism with a Blurhash, which renders a lot more efficiently, at least on my laptop (I have no good way to show this objectively). On my end, stories now play at full framerate instead of 4-5 FPS thanks to the Blurhash. This does mean the blur effect looks significantly different, overall looking better for images/videos that don't have a uniform background (though that is subjective)

## Before (CSS blur)
![old-1](https://github.com/user-attachments/assets/69dfbf8f-367f-46bf-b541-280a38412229)
![old-2](https://github.com/user-attachments/assets/99174e63-09a7-4076-b4c0-77bac15fa901)

## After (blurhash)
![new-1](https://github.com/user-attachments/assets/5d3ced07-4792-4fe1-9f32-f1a61213e2c6)
![new-2](https://github.com/user-attachments/assets/96dba749-5b7b-4d71-baa4-c81a9e7c1416)