### PR TITLE
#7155 If a Group Link contains a query string, that is now ignored

### DIFF
--- a/ts/groups.ts
+++ b/ts/groups.ts
@@ -394,7 +394,8 @@ export function parseGroupLink(value: string): {
   masterKey: string;
   inviteLinkPassword: string;
 } {
-  const base64 = fromWebSafeBase64(value);
+  const valueWithUrlQueryRemoved = value.split("?")[0];
+  const base64 = fromWebSafeBase64(valueWithUrlQueryRemoved);
   const buffer = Bytes.fromBase64(base64);
 
   const inviteLinkProto = Proto.GroupInviteLink.decode(buffer);


### PR DESCRIPTION
Instagram adds tracking via the query string which caused Signal to be unable to lookup the group. Organizations looking to leave Instagram are posting a link to their Signal group as a 'Link in Bio' on Instagram and due to the URL tracking instagram adds, Signal was unable to lookup the group.  There might be a better place in the code  to remove the query string. Def open to feedback. 

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests)) _linting (pprettier) is failing but I think not where Ive made a change_
- [x] My changes are ready to be shipped to users

### Description

Describe briefly what your pull request changes. Focus on the value provided to users.
_Organizations looking to leave Instagram are posting a link to their Signal group as a 'Link in Bio' on Instagram and due to the URL tracking instagram adds, Signal was unable to lookup the group._ 

Does it address any outstanding issues in this project?
_fixes #7155_ 

Please write a summary of your test approach:
 _Tested on a Mac. You can see Im not in a group, I click on a link in a bio, and then I land in a group._

https://github.com/user-attachments/assets/35ae7c06-bdd3-4ffa-8d1d-5281bfceef9f


