### PR TITLE
Make read status on Note to Self only show if read receipts enabled in settings

### DIFF
--- a/ts/state/selectors/message.ts
+++ b/ts/state/selectors/message.ts
@@ -1777,7 +1777,10 @@ export function getMessagePropStatus(
     ) {
       return sent ? 'partial-sent' : 'error';
     }
-    return sent ? 'viewed' : 'sending';
+    const sentStatus = window.storage.get('read-receipt-setting')
+      ? 'viewed'
+      : 'delivered';
+    return sent ? sentStatus : 'sending';
   }
 
   const highestSuccessfulStatus = getHighestSuccessfulRecipientStatus(

--- a/ts/test-electron/state/selectors/messages_test.ts
+++ b/ts/test-electron/state/selectors/messages_test.ts
@@ -465,7 +465,8 @@ describe('state/selectors/messages', () => {
       );
     });
 
-    it('returns "viewed" if the message is just for you and has been sent', () => {
+    it('returns "viewed" if the message is just for you, has been sent and read receipts are enabled', async () => {
+      await window.storage.put('read-receipt-setting', true);
       const message = createMessage({
         sendStateByConversationId: {
           [ourConversationId]: {
@@ -478,6 +479,23 @@ describe('state/selectors/messages', () => {
       assert.strictEqual(
         getMessagePropStatus(message, ourConversationId),
         'viewed'
+      );
+    });
+
+    it('returns "delivered" if the message is just for you, has been sent and read receipts are disabled', async () => {
+      await window.storage.put('read-receipt-setting', false);
+      const message = createMessage({
+        sendStateByConversationId: {
+          [ourConversationId]: {
+            status: SendStatus.Sent,
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      assert.strictEqual(
+        getMessagePropStatus(message, ourConversationId),
+        'delivered'
       );
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

A pretty minute change to make the desktop client consistent with Android client (didn't have the resources to test iOS at time of writing). Currently, even if read receipts are off, a Note to Self message will show a status icon of read once successfully sent. This change makes Notes to Self messages only show as delivered when read receipts are disabled. 

Along with mirroring the Android Signal client's functionality, this makes more sense to me personally as it could be confusing to users to have read receipts showing up at all after disabling.

Thanks for taking a look, Cheers!