### PR TITLE
Allow collapsing archive sidebar

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -5771,6 +5771,10 @@ button.module-calling-participants-list__contact {
           }
         }
       }
+
+      .NavSidebar--narrow & {
+        margin-left: 0;
+      }
     }
 
     &__text {
@@ -5785,6 +5789,14 @@ button.module-calling-participants-list__contact {
       @include mixins.dark-theme {
         color: variables.$color-gray-05;
       }
+
+      .NavSidebar--narrow & {
+        @include mixins.sr-only;
+      }
+    }
+
+    .NavSidebar--narrow & {
+      justify-content: center;
     }
   }
 
@@ -5864,6 +5876,10 @@ button.module-calling-participants-list__contact {
   @include mixins.dark-theme {
     color: variables.$color-gray-25;
     background-color: variables.$color-gray-75;
+  }
+
+  .NavSidebar--narrow & {
+    display: none;
   }
 }
 .module-left-pane__no-search-results__unread-header {

--- a/ts/components/leftPane/LeftPaneArchiveHelper.tsx
+++ b/ts/components/leftPane/LeftPaneArchiveHelper.tsx
@@ -207,6 +207,12 @@ export class LeftPaneArchiveHelper extends LeftPaneHelper<LeftPaneArchivePropsTy
     );
   }
 
+  override requiresFullWidth(): boolean {
+    const hasNoConversations =
+      !this.#archivedConversations.length;
+    return hasNoConversations;
+  }
+
   shouldRecomputeRowHeights(old: Readonly<LeftPaneArchivePropsType>): boolean {
     const hasSearchingChanged =
       'conversationResults' in old !== Boolean(this.#searchHelper);


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Allow the archive sidebar to be collapsed on smaller screens i.e. on linux mobile phones.
Before:
![before](https://github.com/user-attachments/assets/69a18414-8e78-40e6-82d9-38837bf34121)
After:
![after](https://github.com/user-attachments/assets/48d5f086-6197-4cfb-94bd-8dfcdaf65594)
