### PR TITLE
Fix: use fromSeconds when setting universalExpireTimer

### DIFF
--- a/ts/state/smart/Preferences.tsx
+++ b/ts/state/smart/Preferences.tsx
@@ -183,7 +183,7 @@ export function SmartPreferences(): JSX.Element | null {
 
   const universalExpireTimer = universalExpireTimerUtil.getForRedux(items);
   const onUniversalExpireTimerChange = async (newValue: number) => {
-    await universalExpireTimerUtil.set(DurationInSeconds.fromMillis(newValue));
+    await universalExpireTimerUtil.set(DurationInSeconds.fromSeconds(newValue));
 
     // Update account in Storage Service
     const account = window.ConversationController.getOurConversationOrThrow();


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

When setting a "Default timer for new chats", `DurationInSeconds.fromSeconds(newValue)` should be used instead of `fromMillis` as the `newValue` number is in seconds. Otherwise the following bug occurs:

Tested on macOS 10.15.7 (Signal Desktop: 7.59.0):
To recreate this bug, simply:

1. open Settings -> Privacy, 
2. set the "Default timer for new chats" to any set/custom value from the dropdown menu, (e.g. '1 week'), 
3. notice how the default timer is instead set to 0.001 times your selected value (1 week -> 10 minutes, 4 seconds)


This PR fixes this behaviour.