### PR TITLE
feature: fixie wixied the emoji reactions to be sooper dooper!!1 ✨🎉

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -6980,6 +6980,14 @@
     "messageformat": "For example, :-) will be converted to <emojify>🙂</emojify>",
     "description": "Description for the auto convert emoji setting"
   },
+  "icu:Preferences__multiple-emoji-reactions--title": {
+    "messageformat": "Allow multiple emoji reactions per message",
+    "description": "Title for the multiple emoji reactions setting"
+  },
+  "icu:Preferences__multiple-emoji-reactions--description": {
+  "messageformat": "React with multiple different emojis to the same message",
+  "description": "Description for the multiple emoji reactions setting"
+},
   "icu:Preferences--advanced": {
     "messageformat": "Advanced",
     "description": "Title for advanced settings"

--- a/ts/components/Preferences.tsx
+++ b/ts/components/Preferences.tsx
@@ -134,6 +134,7 @@ export type PropsDataType = {
   hasAudioNotifications?: boolean;
   hasAutoConvertEmoji: boolean;
   hasAutoDownloadUpdate: boolean;
+  hasMultipleEmojiReactions: boolean;
   hasAutoLaunch: boolean | undefined;
   hasCallNotifications: boolean;
   hasCallRingtoneNotification: boolean;
@@ -274,6 +275,7 @@ type PropsFunctionType = {
   // Change handlers
   onAudioNotificationsChange: CheckboxChangeHandlerType;
   onAutoConvertEmojiChange: CheckboxChangeHandlerType;
+  onMultipleEmojiReactionsChange: CheckboxChangeHandlerType;
   onAutoDownloadAttachmentChange: (
     setting: AutoDownloadAttachmentType
   ) => unknown;
@@ -392,6 +394,7 @@ export function Preferences({
   hasAudioNotifications,
   hasAutoConvertEmoji,
   hasAutoDownloadUpdate,
+  hasMultipleEmojiReactions,
   hasAutoLaunch,
   hasCallNotifications,
   hasCallRingtoneNotification,
@@ -434,6 +437,7 @@ export function Preferences({
   notificationContent,
   onAudioNotificationsChange,
   onAutoConvertEmojiChange,
+  onMultipleEmojiReactionsChange,
   onAutoDownloadAttachmentChange,
   onAutoDownloadUpdateChange,
   onAutoLaunchChange,
@@ -1168,6 +1172,14 @@ export function Preferences({
             name="autoConvertEmoji"
             onChange={onAutoConvertEmojiChange}
           />
+          <Checkbox
+            checked={hasMultipleEmojiReactions}
+            description={i18n('icu:Preferences__multiple-emoji-reactions--description')}
+            label={i18n('icu:Preferences__multiple-emoji-reactions--title')}
+            moduleClassName="Preferences__checkbox"
+            name="multipleEmojiReactions"
+            onChange={onMultipleEmojiReactionsChange}
+            />
           <SettingsRow>
             <Control
               left={i18n('icu:Preferences__EmojiSkinToneDefaultSetting__Label')}

--- a/ts/components/conversation/TimelineMessage.tsx
+++ b/ts/components/conversation/TimelineMessage.tsx
@@ -121,6 +121,7 @@ export function TimelineMessage(props: Props): JSX.Element {
     copyMessageText,
     pushPanelForConversation,
     reactToMessage,
+    reactions,
     renderEmojiPicker,
     renderReactionPicker,
     retryDeleteForEveryone,
@@ -336,9 +337,15 @@ export function TimelineMessage(props: Props): JSX.Element {
                   onClose: toggleReactionPicker,
                   onPick: emoji => {
                     toggleReactionPicker(true);
+                    // Check if current user already has this specific emoji reaction
+                    const ourId = window.ConversationController.getOurConversationIdOrThrow();
+                    const alreadyReacted = (reactions || []).some(
+                      reaction => reaction.fromId === ourId && reaction.emoji === emoji
+                    );
+
                     reactToMessage(id, {
                       emoji,
-                      remove: emoji === selectedReaction,
+                      remove: alreadyReacted, // Toggle: remove if already reacted, add if not
                     });
                   },
                   renderEmojiPicker,

--- a/ts/messageModifiers/Reactions.ts
+++ b/ts/messageModifiers/Reactions.ts
@@ -350,7 +350,7 @@ export async function handleReaction(
   );
 
   const newReaction: MessageReactionType = {
-    emoji: reaction.remove ? undefined : reaction.emoji,
+    emoji: reaction.emoji, // Keep emoji for both add and remove to enable proper filtering
     fromId: reaction.fromId,
     targetTimestamp: reaction.targetTimestamp,
     timestamp: reaction.timestamp,
@@ -505,7 +505,7 @@ export async function handleReaction(
         }
 
         reactions = oldReactions.filter(
-          re => !isNewReactionReplacingPrevious(re, reaction)
+          re => !isNewReactionReplacingPrevious(re, newReaction)
         );
         reactions.push(reactionToAdd);
         message.set({ reactions });

--- a/ts/reactions/util.ts
+++ b/ts/reactions/util.ts
@@ -108,9 +108,16 @@ export function isNewReactionReplacingPrevious(
   reaction: MessageReactionType,
   newReaction: MessageReactionType
 ): boolean {
-  // Only replace reactions with the same emoji from the same user
-  // This allows multiple different emoji reactions from the same user
-  return reaction.fromId === newReaction.fromId && reaction.emoji === newReaction.emoji;;
+  const hasMultipleEmojiReactions = window.storage.get('multipleEmojiReactions', false);
+
+  if (hasMultipleEmojiReactions) {
+    // Only replace reactions with the same emoji from the same user
+    // This allows multiple different emoji reactions from the same user
+    return reaction.fromId === newReaction.fromId && reaction.emoji === newReaction.emoji;
+  }
+ 
+  // Default behavior: replace all reactions from the same user
+  return reaction.fromId === newReaction.fromId;
 }
 
 export const markOutgoingReactionFailed = (

--- a/ts/reactions/util.ts
+++ b/ts/reactions/util.ts
@@ -108,7 +108,9 @@ export function isNewReactionReplacingPrevious(
   reaction: MessageReactionType,
   newReaction: MessageReactionType
 ): boolean {
-  return reaction.fromId === newReaction.fromId;
+  // Only replace reactions with the same emoji from the same user
+  // This allows multiple different emoji reactions from the same user
+  return reaction.fromId === newReaction.fromId && reaction.emoji === newReaction.emoji;;
 }
 
 export const markOutgoingReactionFailed = (

--- a/ts/state/selectors/message.ts
+++ b/ts/state/selectors/message.ts
@@ -405,12 +405,33 @@ const getReactionsForMessage = (
   { reactions = [] }: MessageWithUIFieldsType,
   { conversationSelector }: { conversationSelector: GetConversationByIdType }
 ) => {
-  // Just show all reactions with emojis - no grouping by user
-  const reactionsWithEmoji = iterables.filter(
-    reactions,
-    re => re.emoji
-  );
-  const formattedReactions = iterables.map(reactionsWithEmoji, re => {
+  const hasMultipleEmojiReactions = window.storage.get('multipleEmojiReactions', false);
+
+  let reactionsToFormat: Iterable<MessageReactionType>;
+
+  if (hasMultipleEmojiReactions) {
+    // Just show all reactions with emojis - no grouping by user
+    reactionsToFormat = iterables.filter(
+      reactions,
+      re => re.emoji
+    );
+  } else {
+    // Default behavior: group by sender, keeping only the latest reaction
+    const reactionBySender = new Map<string, MessageReactionType>();
+    for (const reaction of reactions) {
+      const existingReaction = reactionBySender.get(reaction.fromId);
+      if (!existingReaction || reaction.timestamp > existingReaction.timestamp) {
+        reactionBySender.set(reaction.fromId, reaction);
+      }
+    }
+    const reactionsWithEmpties = reactionBySender.values();
+    reactionsToFormat = iterables.filter(
+      reactionsWithEmpties,
+      re => re.emoji
+    );
+  }
+
+  const formattedReactions = iterables.map(reactionsToFormat, re => {
     const c = conversationSelector(re.fromId);
 
     type From = NonNullable<PropsData['reactions']>[0]['from'];

--- a/ts/state/selectors/message.ts
+++ b/ts/state/selectors/message.ts
@@ -405,17 +405,9 @@ const getReactionsForMessage = (
   { reactions = [] }: MessageWithUIFieldsType,
   { conversationSelector }: { conversationSelector: GetConversationByIdType }
 ) => {
-  const reactionBySender = new Map<string, MessageReactionType>();
-  for (const reaction of reactions) {
-    const existingReaction = reactionBySender.get(reaction.fromId);
-    if (!existingReaction || reaction.timestamp > existingReaction.timestamp) {
-      reactionBySender.set(reaction.fromId, reaction);
-    }
-  }
-
-  const reactionsWithEmpties = reactionBySender.values();
+  // Just show all reactions with emojis - no grouping by user
   const reactionsWithEmoji = iterables.filter(
-    reactionsWithEmpties,
+    reactions,
     re => re.emoji
   );
   const formattedReactions = iterables.map(reactionsWithEmoji, re => {

--- a/ts/state/smart/Preferences.tsx
+++ b/ts/state/smart/Preferences.tsx
@@ -564,6 +564,10 @@ export function SmartPreferences(): JSX.Element | null {
     'autoConvertEmoji',
     true
   );
+  const [hasMultipleEmojiReactions, onMultipleEmojiReactionsChange] = createItemsAccess(
+    'multipleEmojiReactions',
+    false
+  );
   const [hasAutoDownloadUpdate, onAutoDownloadUpdateChange] = createItemsAccess(
     'auto-download-update',
     true
@@ -754,6 +758,7 @@ export function SmartPreferences(): JSX.Element | null {
         hasAudioNotifications={hasAudioNotifications}
         hasAutoConvertEmoji={hasAutoConvertEmoji}
         hasAutoDownloadUpdate={hasAutoDownloadUpdate}
+        hasMultipleEmojiReactions={hasMultipleEmojiReactions}
         hasAutoLaunch={hasAutoLaunch}
         hasCallNotifications={hasCallNotifications}
         hasCallRingtoneNotification={hasCallRingtoneNotification}
@@ -799,6 +804,7 @@ export function SmartPreferences(): JSX.Element | null {
         notificationContent={notificationContent}
         onAudioNotificationsChange={onAudioNotificationsChange}
         onAutoConvertEmojiChange={onAutoConvertEmojiChange}
+        onMultipleEmojiReactionsChange={onMultipleEmojiReactionsChange}
         onAutoDownloadAttachmentChange={onAutoDownloadAttachmentChange}
         onAutoDownloadUpdateChange={onAutoDownloadUpdateChange}
         onAutoLaunchChange={onAutoLaunchChange}

--- a/ts/types/Storage.d.ts
+++ b/ts/types/Storage.d.ts
@@ -61,6 +61,7 @@ export type StorageAccessType = {
   'auto-download-update': boolean;
   'auto-download-attachment': AutoDownloadAttachmentType;
   autoConvertEmoji: boolean;
+  multipleEmojiReactions: boolean;
   'badge-count-muted-conversations': boolean;
   'blocked-groups': ReadonlyArray<string>;
   'blocked-uuids': ReadonlyArray<ServiceIdString>;


### PR DESCRIPTION


<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Hii~~ ╰(*´︶`*)╯♡

I fixie wixied the emoji reaction fucksy wucksie!!! xpp

```
   ∧__∧
  ( ͡° ͜ʖ ͡°)  < "why only ONE emoji when u can have MANY??"
  (つ　 ﾉ
   しーＪ
```

## NEW!! Config option!! 🎮✨
Added a toggie woggie in Settings > Chats!!  
- **OFF by default** = normal Signal behavior (one emoji per person) 😴
- **Turn it ON** = MULTIPLE EMOJI PARTY MODE!! 🎉🎊

```
Settings > Chats > "Allow multiple emoji reactions per message"
                    ↓
              [✓] Enable the chaos!! ＼(^o^)／
```

## What I changey wangey'd: ✨

### 1. Settings UI - Added the magic switch!! 🔧
```
ts/components/Preferences.tsx     <- checkbox UI!! 
ts/state/smart/Preferences.tsx    <- state management!!
_locales/en/messages.json         <- "Allow multiple emoji reactions per message"
ts/types/Storage.d.ts             <- multipleEmojiReactions: boolean
```
Now there's a pretty checkbox that lets users CHOOSE their destiny!! Default OFF means no breaking existing behavior!! Safety first!! ٩(◕‿◕)۶

### 2. `util.ts` - Made reactions play nice together!! 
```
BEFORE: fromId check only = (╯°□°）╯︵ ┻━┻
AFTER:  fromId + emoji check = ┬─┬ノ( º _ ºノ)
```
The meanie code was like "ONE EMOJI PER PERSON ONLY!!" but I made it check BOTH the person AND the emoji so now diffewent emojis can be fwends!! UwU
BUT WAIT!! Now it checks the setting first!! If the toggle is OFF, it stays a meanie!! If ON, it becomes a softie!! (´｡• ᵕ •｡`)

### 3. `message.ts` - Stopped the Map bully!! 
```
   [Before]              [After with setting ON]
   😀 <- only latest     😀 😢 🎉 <- ALL THE EMOJIS!!
   per user :(          ＼(^o^)／
```
The sewector was using a Map that was being a dictator keeping only the NEWEST reaction per person!! I made it CHECK THE SETTING!! If multipleEmojiReactions is ON, I YEET that Map into the void!! If OFF, the Map stays in charge like before!! Democracy wins!! 🗳️✨ 

### 4. `TimelineMessage.tsx` - Added toggie woggie magic!! ⚡
```
Click emoji already there = BYE BYE emoji! ┌( ಠ_ಠ)┘
Click new emoji = HELLO emoji! ＼(★^∀^★)／
```
Added code to check if u already weacted wiff that emoji using `reactions.some()` - if yes then REMOVE, if no then ADD!! It's like a light switch but for emojis!! xD

### 5. `Reactions.ts` - Fixed the undefined ouchie!! 💔→❤️
```
   _____
  /     \    < "emoji was undefined for removes!!"
 | () () |
  \  >  /
   |||||     *sad reaction noises*
```
The remove reactions had `emoji: reaction.remove ? undefined : reaction.emoji` which made the emoji DISAPPEAR when removing!! That's illegal!! Fixed to always keep the emoji so the filter can find it!! 

*starts twerking* 

## The Magic Formula: 🪄
```
OLD: reaction.fromId === newReaction.fromId 
     ↓ (boring single emoji land)
NEW: reaction.fromId === newReaction.fromId && reaction.emoji === newReaction.emoji
     ↓ (PARTY TIME MULTIPLE EMOJIS!!)
```

## Testing stuffs: ฅ^•ﻌ•^ฅ
- Multiple emojis work!! Can add 😀 AND 👍 AND ❤️!! 
- Clicky same emoji = toggie off!! (´｡• ᵕ •｡`)
- Old single reactions still work for backwards compatibility!! 
- No breaky wakey the reaction sync!! ✨

Can u pwease merge my pwull wequest senpai?!! This will make Signal Desktop kawaii AF!! 

*nuzzles your codebase* UwU

```
   ∧_∧
  ( ･ω･)  < "approve pls"
  ( つ旦O
  と＿)_)
```

P.S. - Now with SETTINGS!! 6 files changed total!! The feature is OFF by default so no breaky existing users!! Opt-in chaos!! (｡♥‿♥｡)

  happy coding noises (◕‿◕)♡

