### PR TITLE
Fix stickers when userData path symlinked

### DIFF
--- a/ts/windows/main/attachments.ts
+++ b/ts/windows/main/attachments.ts
@@ -66,7 +66,8 @@ export const copyIntoAttachmentsDirectory = (
     throw new TypeError("'root' must be a path");
   }
 
-  const userDataPath = window.SignalContext.getPath('userData');
+  const naiveUserDataPath = window.SignalContext.getPath('userData');
+  const userDataPath = fse.realpathSync(naiveUserDataPath);
 
   return async (
     sourcePath: string


### PR DESCRIPTION

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
  * failed with an unrelated-looking error, my changes are minimal so just submitting anyway
- [X] My changes are ready to be shipped to users

### Description

The problem comes from `createPathGetter` in `app/attachments.ts` resolving everything using `fs-extra.realpathSync`, but `copyIntoAttachmentsDirectory` in `ts/windows/main/attachments.ts` checking with the plain `userData` path.

`copyIntoAttachmentsDirectory` now resolves the `userData` path with `fs-extra.realpathSync` before determining if the attachment destination is below the `userData` path.

I tested this on one of my affected systems, where ~/.config is a symlink due to having dotfiles in a git repository. It's a rather clean debian testing system. Manual tests were done against the production servers and without setting a `storageProfile` in the config - since that changes something in how the paths are resolved, hiding this issue :upside_down_face:

Fixes #7169