### PR TITLE
Fix #5366: no link preview for message with emoji

### DIFF
--- a/ts/test-node/types/LinkPreview_test.ts
+++ b/ts/test-node/types/LinkPreview_test.ts
@@ -116,6 +116,15 @@ describe('Link previews', () => {
       assert.deepEqual(expected, actual);
     });
 
+    it('returns all links after emojis with spaces in between, if a caretLocation is provided', () => {
+      const text = '😎 https://github.com/signalapp/Signal-Desktop';
+
+      const expected = ['https://github.com/signalapp/Signal-Desktop'];
+
+      const actual = findLinks(text, 45);
+      assert.deepEqual(expected, actual);
+    });
+
     it('includes all links if cursor is not in a link', () => {
       const text =
         'Check out this link: https://github.com/signalapp/Signal-Desktop\nAnd this one too: https://github.com/signalapp/Signal-Android';

--- a/ts/types/LinkPreview.ts
+++ b/ts/types/LinkPreview.ts
@@ -162,7 +162,11 @@ export function findLinks(text: string, caretLocation?: number): Array<string> {
   }
 
   const haveCaretLocation = isNumber(caretLocation);
-  const textLength = text ? text.length : 0;
+
+  // Get text length using [...text].length, instead of just text.length, to use the
+  // right length even if text has emoji.
+  // More info: https://stackoverflow.com/a/54369605/28324
+  const textLength = text ? [...text].length : 0;
 
   const matches = linkify.match(text ? replaceEmojiWithSpaces(text) : '') || [];
   return compact(


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
This PR fixes a bug that prevents link previews from being generated for messages with emojis. See #5366.

I tested this manually, on my Mac running macOS Sonoma 14.7.6 (23H626). I tested it by pasting a URL into a message with an emoji, and verifying that the link preview was generated, unlike before.

I added one new test for `findLinks`.