### PR TITLE
Respect user-entered file extension when saving

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -3044,6 +3044,9 @@ ipc.handle('show-save-dialog', async (_event, { defaultPath }) => {
 
   // On Windows, if you change the path from the default, the extension is
   // removed. We want to make sure the extension is always there.
+  if (extname(selectedFilePath) != '') {
+    return { canceled: false, filePath: selectedFilePath };
+  }
   const defaultExt = extname(defaultPath);
   const finalDirname = dirname(selectedFilePath);
   const finalBasename = basename(selectedFilePath, defaultExt);


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7392. Added a check for no file extension before overriding the file extension
provided in the save dialog. Previously, the Signal desktop client ignored user attempts to
change the file extension when saving an attachment.
