### PR TITLE
Prevent hidden shortcuts while Lightbox is open

### DIFF
--- a/ts/components/Lightbox.dom.tsx
+++ b/ts/components/Lightbox.dom.tsx
@@ -97,6 +97,15 @@ const THUMBNAIL_WIDTH = 44;
 const THUMBNAIL_PADDING = 8;
 const THUMBNAIL_FULL_WIDTH = THUMBNAIL_WIDTH + THUMBNAIL_PADDING;
 
+export function _shouldBlockInteractionBehindLightbox(
+  target: EventTarget | null,
+  container: HTMLElement | null
+): boolean {
+  return (
+    target instanceof Node && container != null && !container.contains(target)
+  );
+}
+
 export function Lightbox({
   children,
   closeLightbox,
@@ -300,8 +309,25 @@ export function Lightbox({
 
         default:
       }
+
+      if (
+        _shouldBlockInteractionBehindLightbox(
+          event.target,
+          containerRef.current
+        )
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
     },
     [closeLightbox, onNext, onPrevious, handleSave]
+  );
+
+  const onLightboxKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+    },
+    []
   );
 
   const onClose = (event: ReactMouseEvent<HTMLElement>) => {
@@ -725,6 +751,7 @@ export function Lightbox({
 
               closeLightbox();
             }}
+            onKeyDown={onLightboxKeyDown}
             ref={containerRef}
             role="presentation"
           >

--- a/ts/hooks/useKeyboardShortcuts.dom.tsx
+++ b/ts/hooks/useKeyboardShortcuts.dom.tsx
@@ -8,6 +8,7 @@ import * as KeyboardLayout from '../services/keyboardLayout.dom.ts';
 import { getHasPanelOpen } from '../state/selectors/nav.std.ts';
 import { isShowingAnyModal } from '../state/selectors/globalModals.std.ts';
 import { getIsInFullScreenCall } from '../state/selectors/isInFullScreenCall.std.ts';
+import { shouldShowLightbox } from '../state/selectors/lightbox.std.ts';
 
 const { get } = lodash;
 
@@ -92,12 +93,17 @@ function useHasCalling(): boolean {
   return useSelector(getIsInFullScreenCall);
 }
 
+function useHasLightbox(): boolean {
+  return useSelector(shouldShowLightbox);
+}
+
 function useHasAnyOverlay(): boolean {
   const panels = useHasPanels();
   const globalModal = useHasGlobalModal();
   const calling = useHasCalling();
+  const lightbox = useHasLightbox();
 
-  return panels || globalModal || calling;
+  return panels || globalModal || calling || lightbox;
 }
 
 export function isKeyboardActivation(event: KeyboardEvent): boolean {

--- a/ts/services/addGlobalKeyboardShortcuts.preload.ts
+++ b/ts/services/addGlobalKeyboardShortcuts.preload.ts
@@ -11,6 +11,7 @@ import { getQuotedMessageSelector } from '../state/selectors/composer.preload.ts
 import { removeLinkPreview } from './LinkPreview.preload.ts';
 import { ForwardMessagesModalType } from '../components/ForwardMessagesModal.dom.tsx';
 import { getSelectedConversationId } from '../state/selectors/nav.std.ts';
+import { shouldShowLightbox } from '../state/selectors/lightbox.std.ts';
 import { strictAssert } from '../util/assert.std.ts';
 
 const log = createLogger('addGlobalKeyboardShortcuts');
@@ -32,6 +33,10 @@ export function addGlobalKeyboardShortcuts(): void {
     );
 
     const key = KeyboardLayout.lookup(event);
+
+    if (shouldShowLightbox(state)) {
+      return;
+    }
 
     // NAVIGATION
 

--- a/ts/test-electron/components/Lightbox_test.dom.ts
+++ b/ts/test-electron/components/Lightbox_test.dom.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+
+import { _shouldBlockInteractionBehindLightbox } from '../../components/Lightbox.dom.tsx';
+
+describe('<Lightbox>', () => {
+  describe('_shouldBlockInteractionBehindLightbox', () => {
+    let container: HTMLDivElement;
+    let child: HTMLButtonElement;
+    let outside: HTMLTextAreaElement;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      child = document.createElement('button');
+      outside = document.createElement('textarea');
+
+      container.appendChild(child);
+      document.body.append(container, outside);
+    });
+
+    afterEach(() => {
+      container.remove();
+      outside.remove();
+    });
+
+    it('blocks key events from elements behind the lightbox', () => {
+      assert.isTrue(_shouldBlockInteractionBehindLightbox(outside, container));
+    });
+
+    it('allows key events from elements inside the lightbox', () => {
+      assert.isFalse(_shouldBlockInteractionBehindLightbox(child, container));
+    });
+
+    it('allows key events before the lightbox container is ready', () => {
+      assert.isFalse(_shouldBlockInteractionBehindLightbox(outside, null));
+    });
+  });
+});

--- a/ts/test-mock/messaging/lightbox_test.node.ts
+++ b/ts/test-mock/messaging/lightbox_test.node.ts
@@ -17,6 +17,7 @@ import {
   getTimelineMessageWithText,
   sendMessageWithAttachments,
   sendTextMessage,
+  waitForEnabledComposer,
 } from '../helpers.node.ts';
 import * as durations from '../../util/durations/index.std.ts';
 import { strictAssert } from '../../util/assert.std.ts';
@@ -181,5 +182,81 @@ describe('lightbox', function (this: Mocha.Suite) {
       // oxlint-disable-next-line no-await-in-loop
       await expectLightboxImage(attachment);
     }
+  });
+
+  it('does not let composer shortcuts focus the hidden composer', async () => {
+    const page = await app.getWindow();
+
+    await page.getByTestId(pinned.device.aci).click();
+
+    const fixturesDir = path.join(__dirname, '..', '..', '..', 'fixtures');
+    const imageCat = path.join(fixturesDir, 'cat-screenshot.png');
+
+    await sendMessageWithAttachments(page, pinned, 'Message with image', [
+      imageCat,
+    ]);
+
+    const Message = getTimelineMessageWithText(page, 'Message with image');
+    const FirstImage = Message.locator('.module-image').nth(0);
+
+    await FirstImage.click();
+
+    const Lightbox = page.locator('.Lightbox');
+    await expect(Lightbox).toBeVisible();
+
+    const composer = await waitForEnabledComposer(page);
+    const commandOrCtrl = await page.evaluate(() =>
+      Reflect.get(globalThis, 'platform') === 'darwin' ? 'Meta' : 'Control'
+    );
+    await page.keyboard.press(`${commandOrCtrl}+Shift+T`);
+    await page.keyboard.type('This should not send from behind Lightbox');
+    await page.keyboard.press('Enter');
+
+    const isComposerFocused = await composer.evaluate(el => {
+      const { activeElement } = el.ownerDocument;
+      return el === activeElement || el.contains(activeElement);
+    });
+
+    assert.isFalse(isComposerFocused);
+    await expect(
+      getTimelineMessageWithText(
+        page,
+        'This should not send from behind Lightbox'
+      )
+    ).not.toBeVisible();
+    await expect(Lightbox).toBeVisible();
+  });
+
+  it('does not let lightbox focus trigger shortcuts behind it', async () => {
+    const page = await app.getWindow();
+
+    await page.getByTestId(pinned.device.aci).click();
+
+    const fixturesDir = path.join(__dirname, '..', '..', '..', 'fixtures');
+    const imageCat = path.join(fixturesDir, 'cat-screenshot.png');
+
+    await sendMessageWithAttachments(page, pinned, 'Message with image', [
+      imageCat,
+    ]);
+
+    const Message = getTimelineMessageWithText(page, 'Message with image');
+    const FirstImage = Message.locator('.module-image').nth(0);
+
+    await FirstImage.click();
+
+    const Lightbox = page.locator('.Lightbox');
+    await expect(Lightbox).toBeVisible();
+
+    await Lightbox.locator('.Lightbox__button--close').focus();
+
+    const commandOrCtrl = await page.evaluate(() =>
+      Reflect.get(globalThis, 'platform') === 'darwin' ? 'Meta' : 'Control'
+    );
+    await page.keyboard.press(`${commandOrCtrl}+Shift+J`);
+
+    await expect(
+      page.getByRole('dialog', { name: 'Add an Emoji, Sticker, or GIF' })
+    ).not.toBeVisible();
+    await expect(Lightbox).toBeVisible();
   });
 });


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7896

This stops Lightbox from letting keyboard shortcuts interact with hidden conversation UI behind it

It blocks app-level shortcut handlers while Lightbox is visible, while keeping Lightbox shortcuts like Escape, previous/next, and save working

Tests:
- Added Electron coverage for behind-Lightbox key targets
- Added mock coverage for hidden composer send prevention and the fun picker shortcut
- Ran `pnpm run ready` on macOS 26.5
