### PR TITLE
Fix search result keyboard navigation

### DIFF
--- a/ts/components/conversationList/MessageSearchResult.dom.tsx
+++ b/ts/components/conversationList/MessageSearchResult.dom.tsx
@@ -88,6 +88,7 @@ export const MessageSearchResult: FunctionComponent<PropsType> = memo(
     getPreferredBadge,
     i18n,
     id,
+    isSelected,
     sentAt,
     showConversation,
     snippet,
@@ -193,7 +194,7 @@ export const MessageSearchResult: FunctionComponent<PropsType> = memo(
         id={id}
         isMe={from.isMe}
         isNoteToSelf={isNoteToSelf}
-        isSelected={false}
+        isSelected={Boolean(isSelected)}
         messageText={messageText}
         onClick={onClickItem}
         phoneNumber={from.phoneNumber}

--- a/ts/components/leftPane/LeftPaneArchiveHelper.dom.tsx
+++ b/ts/components/leftPane/LeftPaneArchiveHelper.dom.tsx
@@ -176,7 +176,7 @@ export class LeftPaneArchiveHelper extends LeftPaneHelper<LeftPaneArchivePropsTy
 
   getConversationAndMessageAtIndex(
     conversationIndex: number
-  ): undefined | { conversationId: string } {
+  ): undefined | { conversationId: string; messageId?: string } {
     const searchHelper = this.#searchHelper;
     const archivedConversations = this.#archivedConversations;
 
@@ -192,8 +192,8 @@ export class LeftPaneArchiveHelper extends LeftPaneHelper<LeftPaneArchivePropsTy
   getConversationAndMessageInDirection(
     toFind: Readonly<ToFindType>,
     selectedConversationId: undefined | string,
-    targetedMessageId: unknown
-  ): undefined | { conversationId: string } {
+    targetedMessageId: undefined | string
+  ): undefined | { conversationId: string; messageId?: string } {
     if (this.#searchHelper) {
       return this.#searchHelper.getConversationAndMessageInDirection(
         toFind,

--- a/ts/components/leftPane/LeftPaneSearchHelper.dom.tsx
+++ b/ts/components/leftPane/LeftPaneSearchHelper.dom.tsx
@@ -3,7 +3,7 @@
 
 import type { ReactNode } from 'react';
 
-import type { ToFindType } from './LeftPaneHelper.dom.tsx';
+import { FindDirection, type ToFindType } from './LeftPaneHelper.dom.tsx';
 import { LeftPaneHelper } from './LeftPaneHelper.dom.tsx';
 import type { LocalizerType } from '../../types/Util.std.ts';
 import type { Row } from '../ConversationList.dom.tsx';
@@ -26,6 +26,11 @@ import { UserText } from '../UserText.dom.tsx';
 //   if, in some extremely tall window, we have some empty space. So we just hard-code a
 //   fairly big number.
 const SEARCH_RESULTS_FAKE_ROW_COUNT = 99;
+
+type ConversationAndMessageType = {
+  conversationId: string;
+  messageId?: string;
+};
 
 type MaybeLoadedSearchResultsType<T> =
   | { isLoading: true }
@@ -394,13 +399,45 @@ export class LeftPaneSearchHelper extends LeftPaneHelper<LeftPaneSearchPropsType
     return undefined;
   }
 
-  // This is currently unimplemented. See DESKTOP-1170.
   getConversationAndMessageInDirection(
-    _toFind: Readonly<ToFindType>,
-    _selectedConversationId: undefined | string,
-    _targetedMessageId: unknown
-  ): undefined | { conversationId: string } {
-    return undefined;
+    toFind: Readonly<ToFindType>,
+    selectedConversationId: undefined | string,
+    targetedMessageId: undefined | string
+  ): undefined | ConversationAndMessageType {
+    if (toFind.unreadOnly) {
+      return undefined;
+    }
+
+    const results = this.#getConversationAndMessageResults();
+    if (!results || !results.length) {
+      return undefined;
+    }
+
+    let selectedIndex = -1;
+    if (targetedMessageId) {
+      selectedIndex = results.findIndex(
+        result => result.messageId === targetedMessageId
+      );
+    }
+    if (selectedIndex < 0 && selectedConversationId) {
+      selectedIndex = results.findIndex(
+        result =>
+          result.messageId == null &&
+          result.conversationId === selectedConversationId
+      );
+    }
+
+    let nextIndex: number;
+    if (selectedIndex < 0) {
+      nextIndex =
+        toFind.direction === FindDirection.Up ? results.length - 1 : 0;
+    } else {
+      const step = toFind.direction === FindDirection.Up ? -1 : 1;
+      nextIndex = (selectedIndex + step + results.length) % results.length;
+    }
+    const result = results[nextIndex];
+    strictAssert(result, 'Missing search result');
+    return result;
   }
 
   override onKeyDown(
@@ -424,6 +461,29 @@ export class LeftPaneSearchHelper extends LeftPaneHelper<LeftPaneSearchPropsType
 
   #isLoading(): boolean {
     return this.#allResults().some(results => results.isLoading);
+  }
+
+  #getConversationAndMessageResults():
+    | undefined
+    | Array<ConversationAndMessageType> {
+    const results: Array<ConversationAndMessageType> = [];
+    for (const list of this.#allResults()) {
+      if (list.isLoading) {
+        return undefined;
+      }
+
+      for (const result of list.results) {
+        results.push(
+          result.type === 'incoming' || result.type === 'outgoing'
+            ? {
+                conversationId: result.conversationId,
+                messageId: result.id,
+              }
+            : { conversationId: result.id }
+        );
+      }
+    }
+    return results;
   }
 
   readonly #onEnterKeyDown = (

--- a/ts/test-node/components/leftPane/LeftPaneSearchHelper_test.dom.ts
+++ b/ts/test-node/components/leftPane/LeftPaneSearchHelper_test.dom.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../components/ConversationList.dom.tsx';
 import { getDefaultConversation } from '../../../test-helpers/getDefaultConversation.std.ts';
 
+import { FindDirection } from '../../../components/leftPane/LeftPaneHelper.dom.tsx';
 import { LeftPaneSearchHelper } from '../../../components/leftPane/LeftPaneSearchHelper.dom.tsx';
 
 const baseSearchHelperArgs = {
@@ -24,10 +25,17 @@ const baseSearchHelperArgs = {
   startSearchCounter: 0,
 };
 describe('LeftPaneSearchHelper', () => {
-  const fakeMessage = () => ({
+  const fakeMessage = (
+    overrideProps: Partial<{
+      id: string;
+      type: string;
+      conversationId: string;
+    }> = {}
+  ) => ({
     id: uuid(),
     type: 'outgoing',
     conversationId: uuid(),
+    ...overrideProps,
   });
 
   describe('getBackAction', () => {
@@ -633,6 +641,222 @@ describe('LeftPaneSearchHelper', () => {
 
       // Verify clear filter row is skipped (index 2 doesn't map to a conversation)
       assert.isUndefined(helper.getConversationAndMessageAtIndex(2));
+    });
+  });
+
+  describe('getConversationAndMessageInDirection', () => {
+    it('returns the next result across conversations, contacts, and messages', () => {
+      const conversations = [getDefaultConversation()] as const;
+      const contacts = [getDefaultConversation()] as const;
+      const messages = [fakeMessage()] as const;
+      const helper = new LeftPaneSearchHelper({
+        ...baseSearchHelperArgs,
+        conversationResults: {
+          isLoading: false,
+          results: [...conversations],
+        },
+        contactResults: { isLoading: false, results: [...contacts] },
+        messageResults: { isLoading: false, results: [...messages] },
+      });
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Down, unreadOnly: false },
+          conversations[0].id,
+          undefined
+        ),
+        { conversationId: contacts[0].id }
+      );
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Down, unreadOnly: false },
+          contacts[0].id,
+          undefined
+        ),
+        {
+          conversationId: messages[0].conversationId,
+          messageId: messages[0].id,
+        }
+      );
+    });
+
+    it('uses the targeted message when moving through message results', () => {
+      const conversationId = uuid();
+      const messages = [
+        fakeMessage({ conversationId }),
+        fakeMessage({ conversationId }),
+      ] as const;
+      const helper = new LeftPaneSearchHelper({
+        ...baseSearchHelperArgs,
+        messageResults: { isLoading: false, results: [...messages] },
+      });
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Down, unreadOnly: false },
+          conversationId,
+          messages[0].id
+        ),
+        {
+          conversationId,
+          messageId: messages[1].id,
+        }
+      );
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Up, unreadOnly: false },
+          conversationId,
+          messages[1].id
+        ),
+        {
+          conversationId,
+          messageId: messages[0].id,
+        }
+      );
+    });
+
+    it('does not treat message results as selected without a targeted message', () => {
+      const conversationId = uuid();
+      const messages = [
+        fakeMessage({ conversationId }),
+        fakeMessage({ conversationId }),
+      ] as const;
+      const helper = new LeftPaneSearchHelper({
+        ...baseSearchHelperArgs,
+        messageResults: { isLoading: false, results: [...messages] },
+      });
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Down, unreadOnly: false },
+          conversationId,
+          undefined
+        ),
+        {
+          conversationId,
+          messageId: messages[0].id,
+        }
+      );
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Up, unreadOnly: false },
+          conversationId,
+          undefined
+        ),
+        {
+          conversationId,
+          messageId: messages[1].id,
+        }
+      );
+    });
+
+    it('wraps when moving past the first or last result', () => {
+      const conversations = [getDefaultConversation()] as const;
+      const messages = [fakeMessage()] as const;
+      const helper = new LeftPaneSearchHelper({
+        ...baseSearchHelperArgs,
+        conversationResults: {
+          isLoading: false,
+          results: [...conversations],
+        },
+        messageResults: { isLoading: false, results: [...messages] },
+      });
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Up, unreadOnly: false },
+          conversations[0].id,
+          undefined
+        ),
+        {
+          conversationId: messages[0].conversationId,
+          messageId: messages[0].id,
+        }
+      );
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Down, unreadOnly: false },
+          messages[0].conversationId,
+          messages[0].id
+        ),
+        { conversationId: conversations[0].id }
+      );
+    });
+
+    it('returns the first or last result if no conversation is selected', () => {
+      const conversations = [getDefaultConversation()] as const;
+      const messages = [fakeMessage()] as const;
+      const helper = new LeftPaneSearchHelper({
+        ...baseSearchHelperArgs,
+        conversationResults: {
+          isLoading: false,
+          results: [...conversations],
+        },
+        messageResults: { isLoading: false, results: [...messages] },
+      });
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Down, unreadOnly: false },
+          undefined,
+          undefined
+        ),
+        { conversationId: conversations[0].id }
+      );
+
+      assert.deepEqual(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Up, unreadOnly: false },
+          undefined,
+          undefined
+        ),
+        {
+          conversationId: messages[0].conversationId,
+          messageId: messages[0].id,
+        }
+      );
+    });
+
+    it('returns undefined while results are loading', () => {
+      const helper = new LeftPaneSearchHelper({
+        ...baseSearchHelperArgs,
+        conversationResults: { isLoading: true },
+        contactResults: {
+          isLoading: false,
+          results: [getDefaultConversation()],
+        },
+        messageResults: { isLoading: false, results: [fakeMessage()] },
+      });
+
+      assert.isUndefined(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Down, unreadOnly: false },
+          undefined,
+          undefined
+        )
+      );
+    });
+
+    it('returns undefined for unread-only navigation', () => {
+      const helper = new LeftPaneSearchHelper({
+        ...baseSearchHelperArgs,
+        conversationResults: {
+          isLoading: false,
+          results: [getDefaultConversation({ markedUnread: true })],
+        },
+      });
+
+      assert.isUndefined(
+        helper.getConversationAndMessageInDirection(
+          { direction: FindDirection.Down, unreadOnly: true },
+          undefined,
+          undefined
+        )
+      );
     });
   });
 });

--- a/ts/test-node/state/selectors/search_test.preload.ts
+++ b/ts/test-node/state/selectors/search_test.preload.ts
@@ -240,6 +240,46 @@ describe('both/state/selectors/search', () => {
       assert.deepEqual(actual, expected);
     });
 
+    it('marks the targeted message as selected', () => {
+      const searchId = 'search-id';
+      const toId = 'to-id';
+
+      const from = getDefaultConversationWithServiceId();
+      const to = getDefaultConversation({ id: toId });
+
+      const state = {
+        ...getEmptyRootState(),
+        conversations: {
+          ...getEmptyConversationState(),
+          conversationLookup: {
+            [from.id]: from,
+            [toId]: to,
+          },
+          conversationsByServiceId: {
+            [from.serviceId]: from,
+          },
+        },
+        search: {
+          ...getEmptySearchState(),
+          targetedMessage: searchId,
+          messageLookup: {
+            [searchId]: {
+              ...getDefaultMessage(searchId),
+              type: 'incoming' as const,
+              sourceServiceId: from.serviceId,
+              conversationId: toId,
+              snippet: 'snippet',
+              body: 'snippet',
+              bodyRanges: [],
+            },
+          },
+        },
+      };
+      const selector = getMessageSearchResultSelector(state);
+
+      assert.strictEqual(selector(searchId)?.isSelected, true);
+    });
+
     it('returns the correct "from" and "to" when sent to me', () => {
       const searchId = 'search-id';
       const myId = 'my-id';


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #5176

Adds next/previous keyboard navigation for loaded search results, including chats, contacts, and message results

This also wires selected state for message search results, so moving to a message result can highlight the matching row. There was an older PR for this in #5234, but it no longer applies cleanly; this keeps the same issue scoped to current main

Tests:
- `pnpm run ready`
- targeted `electron-mocha` for `LeftPaneSearchHelper` and `LeftPaneArchiveHelper`: 50 passing
