### PR TITLE
Add accessible labels to message delivery status indicators

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -9958,6 +9958,26 @@
     "messageformat": "Pinned",
     "description": "label for an pinned message"
   },
+  "icu:MessageMetadata__status--sending": {
+    "messageformat": "Sending",
+    "description": "Accessibility label for the status indicator on your outgoing message while it is being sent"
+  },
+  "icu:MessageMetadata__status--sent": {
+    "messageformat": "Sent",
+    "description": "Accessibility label for the status indicator on your outgoing message once it has been sent"
+  },
+  "icu:MessageMetadata__status--delivered": {
+    "messageformat": "Delivered",
+    "description": "Accessibility label for the status indicator on your outgoing message once it has been delivered"
+  },
+  "icu:MessageMetadata__status--read": {
+    "messageformat": "Read",
+    "description": "Accessibility label for the status indicator on your outgoing message once it has been read"
+  },
+  "icu:MessageMetadata__status--viewed": {
+    "messageformat": "Viewed",
+    "description": "Accessibility label for the status indicator on your outgoing media or voice message once it has been viewed or played"
+  },
   "icu:DraftGifMessageSendModal__Title": {
     "messageformat": "Add a message",
     "description": "Draft GIF Message Send Modal > Title"

--- a/ts/components/conversation/MessageMetadata.dom.tsx
+++ b/ts/components/conversation/MessageMetadata.dom.tsx
@@ -53,6 +53,34 @@ enum ConfirmationType {
   DeleteError = 'DeleteError',
 }
 
+// Accessible label for the otherwise icon-only delivery status indicator, so
+// screen reader users hear "Sent" / "Delivered" / "Read" alongside the
+// timestamp. 'error' and 'partial-sent' are surfaced as visible text elsewhere.
+function getStatusAccessibilityLabel(
+  i18n: LocalizerType,
+  status: MessageStatusType
+): string | undefined {
+  switch (status) {
+    case 'sending':
+      return i18n('icu:MessageMetadata__status--sending');
+    case 'sent':
+      return i18n('icu:MessageMetadata__status--sent');
+    case 'delivered':
+      return i18n('icu:MessageMetadata__status--delivered');
+    case 'read':
+      return i18n('icu:MessageMetadata__status--read');
+    case 'viewed':
+      return i18n('icu:MessageMetadata__status--viewed');
+    case 'paused':
+      return i18n('icu:sendPaused');
+    case 'error':
+    case 'partial-sent':
+      return undefined;
+    default:
+      throw missingCaseError(status);
+  }
+}
+
 export const MessageMetadata = forwardRef<HTMLDivElement, Readonly<PropsType>>(
   function MessageMetadataInner(
     {
@@ -285,6 +313,10 @@ export const MessageMetadata = forwardRef<HTMLDivElement, Readonly<PropsType>>(
         status !== 'error' &&
         status !== 'partial-sent' ? (
           <div
+            role="img"
+            aria-label={
+              status ? getStatusAccessibilityLabel(i18n, status) : undefined
+            }
             className={classNames(
               'module-message__metadata__status-icon',
               `module-message__metadata__status-icon--${status}`


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. (It adds new source strings in `_locales/en/messages.json`; it does not submit translated locales.)
- [X] My commits are in nice logical chunks with good commit messages
- [X] My changes are rebased on the latest `main` branch
- [X] A `pnpm run ready` run passes successfully (verified: prettier, `check:types`, oxlint, intl-linter, and icu-types generation all pass; the display-dependent Electron test step was not run locally)
- [X] My changes are ready to be shipped to users

### Description

The outgoing message delivery-status indicator (sending / sent / delivered / read / viewed / paused) is rendered as an **icon-only `<div>` with no text alternative**. Sighted users can see at a glance whether a message was delivered or read; screen reader users get nothing — the element is unlabeled, so it is not even surfaced to the accessibility tree.

This change adds `role="img"` and an `aria-label` (derived from the existing `status` value via the message's `i18n`) to that indicator. Assistive technologies now announce **"Sent" / "Delivered" / "Read" / "Viewed"** alongside the timestamp, bringing Desktop to parity with how status is already conveyed on Signal mobile. It is an **accessibility-only change with zero visual impact**, and only applies to your own outgoing messages (the indicator is already outgoing-only).

- New strings: `icu:MessageMetadata__status--{sending,sent,delivered,read,viewed}` (the `paused` state reuses the existing `icu:sendPaused`).
- `error` / `partial-sent` are intentionally left unlabeled here because they are already surfaced as visible text elsewhere in the metadata.

**Transparency:** the diff was drafted with AI assistance, then reviewed and manually tested by me on a real device with a screen reader.

#### Test approach

- **Manual testing:** Patched a running Signal Desktop to apply the same `role`/`aria-label` to the status indicator, then navigated my own sent messages with the Orca screen reader. Each message row now reads as *content → timestamp → status* (e.g. "…, 14:32, Read"). Verified the label updates live as a message transitions `sent → delivered → read`, and that `paused` reads as "Send paused".
- **Screen reader / OS:** Orca on Arch Linux (Wayland). Because `aria-label` is consumed by Chromium's accessibility engine, the same label is exposed through NSAccessibility (macOS/VoiceOver) and UI Automation (Windows/NVDA, JAWS, Narrator) with no platform-specific code.
- **Automated tests:** none added; this is a labeling-only change to an existing element.
