### PR TITLE
fix: add back button to settings when left tabs are hidden

### DIFF
--- a/ts/components/Preferences.dom.tsx
+++ b/ts/components/Preferences.dom.tsx
@@ -413,6 +413,8 @@ type PropsFunctionType = {
 
   // Localization
   i18n: LocalizerType;
+  
+  onCloseSettings: () => void;
 };
 
 export type PropsType = PropsDataType & PropsFunctionType;
@@ -668,6 +670,7 @@ export function Preferences({
   forceKeyTransparencyCheck,
   keyTransparencySelfHealth,
   weArePrimaryDevice,
+  onCloseSettings,
 }: PropsType): JSX.Element {
   const languageId = useId();
 
@@ -2606,6 +2609,7 @@ export function Preferences({
           requiresFullWidth
           savePreferredLeftPaneWidth={savePreferredLeftPaneWidth}
           renderToastManager={renderToastManager}
+          onBack={navTabsCollapsed ? onCloseSettings : undefined}
         >
           <div className="Preferences__page-selector">
             {maybeUpdateDialog ? (

--- a/ts/state/smart/Preferences.preload.tsx
+++ b/ts/state/smart/Preferences.preload.tsx
@@ -1012,6 +1012,7 @@ export function SmartPreferences(): JSX.Element | null {
   return (
     <AppProvider>
       <Preferences
+        onCloseSettings={() => changeLocation({ tab: NavTab.Chats, details: { conversationId: undefined } })}
         backupKey={backupKey}
         backupKeyHash={backupKeyHash}
         addCustomColor={addCustomColor}


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

 Fixes an issue where users could get stuck in the Settings view when the left navigation tabs are collapsed (e.g.,
  on smaller window sizes). Previously, hiding the tabs removed the ability to navigate out of Settings, and standard
  back shortcuts (Alt+Left, Mouse 4) did not work.

  This change introduces a dedicated "Back" button in the Settings sidebar header that appears whenever the left tabs
  are hidden, allowing users to easily return to the main Chats view.

Close: #7976
