### PR TITLE
fixed: Video preview turns black when you attach another video or image into a yet unsent message

### DIFF
--- a/ts/test-node/util/resolveDraftAttachmentOnDisk_test.preload.ts
+++ b/ts/test-node/util/resolveDraftAttachmentOnDisk_test.preload.ts
@@ -84,7 +84,7 @@ describe('resolveDraftAttachmentOnDisk', () => {
     assert.match(result.url ?? '', /^attachment:\/\//);
   });
 
-  it('does not create a URL for a attachment without a screenshot', () => {
+  it('does not create URL for an attachment without screenshot', () => {
     const attachment = createAttachment();
 
     const result = resolveDraftAttachmentOnDisk(attachment);

--- a/ts/test-node/util/resolveDraftAttachmentOnDisk_test.preload.ts
+++ b/ts/test-node/util/resolveDraftAttachmentOnDisk_test.preload.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import assert from 'node:assert/strict';
+import * as MIME from '../../types/MIME.std.ts';
+import { resolveDraftAttachmentOnDisk } from '../../util/resolveDraftAttachmentOnDisk.preload.ts';
+import type { AttachmentDraftType } from '../../types/Attachment.std.ts';
+
+type ReadyDraftAttachment = Extract<AttachmentDraftType, { pending: false }>;
+
+const createAttachment = (
+  overrides: Partial<ReadyDraftAttachment> = {}
+): ReadyDraftAttachment => ({
+  blurHash: 'blurHash',
+  caption: 'caption',
+  clientUuid: 'client-uuid',
+  contentType: MIME.VIDEO_MP4,
+  fileName: 'video.mp4',
+  flags: 1,
+  path: 'video.mp4',
+  size: 1234,
+  width: 1920,
+  height: 1080,
+  version: 2,
+  localKey: 'local-key',
+  pending: false,
+  ...overrides,
+});
+
+describe('resolveDraftAttachmentOnDisk', () => {
+  it('preserves metadata and resolves the nested screenshot', () => {
+    const attachment = createAttachment({
+      screenshot: {
+        contentType: MIME.IMAGE_JPEG,
+        path: 'thumbnail.jpg',
+        width: 320,
+        height: 240,
+      },
+    });
+
+    const result = resolveDraftAttachmentOnDisk(attachment);
+
+    assert.deepEqual(result.pending, false);
+    assert.deepEqual(result, {
+      ...attachment,
+      screenshotPath: undefined,
+      url: result.url,
+    });
+    assert.match(result.url ?? '', /^attachment:\/\//);
+  });
+
+  it('preserves metadata and resolves a legacy screenshotPath', () => {
+    const attachment = createAttachment({
+      screenshotPath: 'legacy-thumbnail.jpg',
+    });
+
+    const result = resolveDraftAttachmentOnDisk(attachment);
+
+    assert.deepEqual(result.pending, false);
+    assert.deepEqual(result, {
+      ...attachment,
+      screenshot: undefined,
+      url: result.url,
+    });
+    assert.doesNotMatch(result.url ?? '', /^attachment:\/\//);
+  });
+
+  it('preserves all draft attachment metadata of an image file', () => {
+    const attachment = createAttachment({
+      contentType: MIME.IMAGE_JPEG,
+      fileName: 'image.jpeg',
+      path: 'image.jpeg',
+    });
+
+    const result = resolveDraftAttachmentOnDisk(attachment);
+
+    assert.deepEqual(result.pending, false);
+    assert.deepEqual(result, {
+      ...attachment,
+      screenshot: undefined,
+      screenshotPath: undefined,
+      url: result.url,
+    });
+    assert.match(result.url ?? '', /^attachment:\/\//);
+  });
+
+  it('does not create a URL for a attachment without a screenshot', () => {
+    const attachment = createAttachment();
+
+    const result = resolveDraftAttachmentOnDisk(attachment);
+
+    assert.deepEqual(result.pending, false);
+    assert.deepEqual(result, {
+      ...attachment,
+      screenshot: undefined,
+      screenshotPath: undefined,
+      url: '',
+    });
+  });
+});

--- a/ts/util/resolveDraftAttachmentOnDisk.preload.ts
+++ b/ts/util/resolveDraftAttachmentOnDisk.preload.ts
@@ -50,6 +50,8 @@ export function resolveDraftAttachmentOnDisk(
     height,
     version,
     localKey,
+    screenshot,
+    screenshotPath,
   } = attachment;
 
   return {
@@ -65,6 +67,8 @@ export function resolveDraftAttachmentOnDisk(
     height,
     version,
     localKey,
+    screenshot,
+    screenshotPath,
     pending: false,
     url,
   };


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This fix ensures that draft attachments retain their nested screenshot data and legacy `screenshotPath` after being restored. Users can therefore continue to see and use draft attachments with their associated screenshots correctly.

#### Testing

- Manually tested adding multiple videos, removing them again, and sending them successfully
- Tested on CachyOS (Arch Linux) with KDE Plasma 6.7.4 and no other devices
- Added unit tests covering:
  - attachments with nested screenshot metadata
  - attachments with legacy `screenshotPath`
  - image attachments without screenshots
  - video attachments without screenshots

Fixes #7222 

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
