### PR TITLE
Require arrow-key selection before completing emoji suggestions

### DIFF
--- a/ts/components/CompositionInput.dom.tsx
+++ b/ts/components/CompositionInput.dom.tsx
@@ -497,8 +497,12 @@ export function CompositionInput(props: Props): ReactElement {
     }
 
     if (emojiCompletion.results.length) {
-      emojiCompletion.completeEmoji();
-      return false;
+      if (emojiCompletion.index === -1) {
+        emojiCompletion.reset();
+      } else {
+        emojiCompletion.completeEmoji();
+        return false;
+      }
     }
 
     if (mentionCompletion.results.length) {
@@ -529,8 +533,12 @@ export function CompositionInput(props: Props): ReactElement {
     }
 
     if (emojiCompletion.results.length) {
-      emojiCompletion.completeEmoji();
-      return false;
+      if (emojiCompletion.index === -1) {
+        emojiCompletion.reset();
+      } else {
+        emojiCompletion.completeEmoji();
+        return false;
+      }
     }
 
     if (mentionCompletion.results.length) {

--- a/ts/quill/emoji/completion.dom.tsx
+++ b/ts/quill/emoji/completion.dom.tsx
@@ -53,7 +53,7 @@ export class EmojiCompletion {
 
   constructor(quill: Quill, options: EmojiCompletionOptions) {
     this.results = [];
-    this.index = 0;
+    this.index = -1;
     this.options = options;
     this.root = document.body.appendChild(document.createElement('div'));
     this.quill = quill;
@@ -115,7 +115,13 @@ export class EmojiCompletion {
   }
 
   changeIndex(by: number): void {
-    this.index = (this.index + by + this.results.length) % this.results.length;
+    if (this.index === -1) {
+      this.index = by > 0 ? 0 : this.results.length - 1;
+    } else {
+      this.index =
+        (this.index + by + this.results.length) % this.results.length;
+    }
+
     this.render();
   }
 
@@ -298,7 +304,7 @@ export class EmojiCompletion {
   reset(): void {
     if (this.results.length) {
       this.results = [];
-      this.index = 0;
+      this.index = -1;
 
       this.render();
     }


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

The completion window no longer selects the first suggestion automatically.
Use the Down Arrow to select the first suggestion or the Up Arrow to select the last one.
Pressing Enter without a selection closes the completion window and sending the message.
Pressing Tab without a selection closes the completion window without sending the message.

I'm not sure whether these changes are desired, but since this was still marked as a bug, I wanted to give it a try.

Fixes #3517 

### Testing

I tried this with `:DD`, and it sent `:DD` without selecting `:ladder:`, as expected.
Selecting `:ladder:` with Down Arrow + Enter also worked as expected.

I did not write any new tests.
I only tested this on CachyOS (Arch Linux) with KDE Plasma 6.7.4.

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
